### PR TITLE
Ignore html files from github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+
+*.html -linguist-detectable


### PR DESCRIPTION
Ignoring all html files using [github linguist](https://github.com/github/linguist/blob/master/docs/overrides.md) syntax to reclassify this repo as SCSS