### PR TITLE
Add scrollbar-width: thin for firefox

### DIFF
--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -72,6 +72,7 @@
   @include themed {
     scrollbar-color: rgba(t(iui-color-foreground-body-rgb), t(iui-opacity-4))
       transparent;
+    scrollbar-width: thin;
   }
 
   &::-webkit-scrollbar {


### PR DESCRIPTION
Setting `scrollbar-width: thin` provides the added benefit of removing those nasty scrollbar arrows (which are currently masked by the `transparent` scrollbar track)

Before:
![image](https://user-images.githubusercontent.com/9084735/115451327-0c427300-a1eb-11eb-95c5-fd9ff1e88051.png)

After:
![image](https://user-images.githubusercontent.com/9084735/115451339-0fd5fa00-a1eb-11eb-8828-0aaa0017c385.png)
