### PR TITLE
Update badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <div align="center">
   
   [![itwinui-css on npm](https://img.shields.io/npm/v/@itwin/itwinui-css)](https://www.npmjs.com/package/@itwin/itwinui-css)
-  ![Build status](https://github.com/iTwin/iTwinUI/actions/workflows/build.yml/badge.svg?branch=main)
-  [![Dependencies Status](https://status.david-dm.org/gh/itwin/iTwinUI.svg)](https://david-dm.org/itwin/iTwinUI)
+  [![Build status](https://github.com/iTwin/iTwinUI/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/iTwin/iTwinUI/actions/workflows/build.yml?query=branch%3Amain)
+  [![Dependencies Status](https://img.shields.io/badge/dependencies-none-brightgreen)](https://www.npmjs.com/package/@itwin/itwinui-css?activeTab=dependencies)
 
 </div>
 


### PR DESCRIPTION
Replaced david-dm badge with shields.io because it's more reliable, and added link to npm dependencies tab.
Also added link to github build badge.