### PR TITLE
Fix blurry text on tile hover

### DIFF
--- a/src/tile/tile.scss
+++ b/src/tile/tile.scss
@@ -97,10 +97,11 @@
     > .iui-picture {
       width: 100%;
       height: 100%;
-      transition: transform $iui-speed ease;
+      transition: width $iui-speed ease, height $iui-speed ease;
       position: absolute;
-      top: 0;
-      left: 0;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
 
       @at-root {
         div#{&} {
@@ -269,7 +270,8 @@
     }
 
     .iui-picture {
-      transform: translateZ(0) scale(1.1);
+      width: calc(100% + #{$iui-xl});
+      height: calc(100% + #{$iui-xl});
     }
   }
 
@@ -291,7 +293,8 @@
     }
 
     .iui-picture {
-      transform: translateZ(0) scale(1.1);
+      width: calc(100% + #{$iui-xl});
+      height: calc(100% + #{$iui-xl});
     }
   }
 


### PR DESCRIPTION
Replaces `transform: scale (1.1)` with `width: calc(100% + #{$iui-xl});` to fix the blur issue in #44.  This change ensures that the thumbnail's width & height are always a whole number.  When the thumbnail expands to a non-whole number it introduces [sub-pixelation](https://stackoverflow.com/a/27420953) which seems to be creating the blur effect on Windows.

Thumbnail width in our demo = **288px**
Old method of using 1.1 scale = **316.8px** & blurry
New method of using 100% + iui-xl = **320px** & not blurry