### PR TITLE
Increase specificity of default user icon

### DIFF
--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -35,7 +35,7 @@ $iui-button-padding-large: $iui-xs * 6;
     background-color $iui-speed-fast ease-out,
     border-color $iui-speed-fast ease-out;
 
-  > .iui-icon {
+  > svg.iui-icon {
     width: $iui-icons-default;
     height: $iui-icons-default;
     transition: fill $iui-speed-fast ease-out;

--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -35,7 +35,7 @@ $iui-button-padding-large: $iui-xs * 6;
     background-color $iui-speed-fast ease-out,
     border-color $iui-speed-fast ease-out;
 
-  > iui-icon {
+  > .iui-icon {
     width: $iui-icons-default;
     height: $iui-icons-default;
     transition: fill $iui-speed-fast ease-out;

--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -35,7 +35,7 @@ $iui-button-padding-large: $iui-xs * 6;
     background-color $iui-speed-fast ease-out,
     border-color $iui-speed-fast ease-out;
 
-  > svg.iui-icon {
+  > iui-icon {
     width: $iui-icons-default;
     height: $iui-icons-default;
     transition: fill $iui-speed-fast ease-out;

--- a/src/user-icon/classes.scss
+++ b/src/user-icon/classes.scss
@@ -4,7 +4,6 @@
 
 .iui-user-icon {
   @include iui-user-icon;
-  @include iui-user-icon-size;
 
   &#{&} {
     @include iui-user-icon-size;

--- a/src/user-icon/classes.scss
+++ b/src/user-icon/classes.scss
@@ -6,6 +6,10 @@
   @include iui-user-icon;
   @include iui-user-icon-size;
 
+  &#{&} {
+    @include iui-user-icon-size;
+  }
+
   &.iui-small {
     @include iui-user-icon-size($size: $iui-icons-large, $font-size: $iui-font-size-small);
   }


### PR DESCRIPTION
Repeating the class name slightly increases the specificity (which got reduced after we removed `.iui-medium` in #34).

This is important because the `.iui-icon` class (which is applied to children of `IconButton` in react) overrides the default dimensions of user icon. We can see this happen in https://github.com/iTwin/iTwinUI-react/pull/45 where we need to put a `UserIcon` inside `IconButton` and it messes up the size.