### PR TITLE
Add missing header imports in barrel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.13.1]
+
+`2021-05-12`
+
+### Fixes
+
+- **Added missing header imports in barrel.**
+
 ## [0.13.0]
 
 `2021-05-12`
@@ -175,6 +183,7 @@
 
 - **Global style resets have 0 specificity now.**
 
+[0.13.1]: https://github.com/iTwin/iTwinUI/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/iTwin/iTwinUI/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/iTwin/iTwinUI/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/iTwin/iTwinUI/compare/v0.10.0...v0.11.0

--- a/src/classes.scss
+++ b/src/classes.scss
@@ -12,6 +12,7 @@
 @import './table/classes';
 @import './file-upload/classes';
 @import './footer/classes';
+@import './header/classes';
 @import './icon/classes';
 @import './inputs/classes';
 @import './keyboard/classes';

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,6 +11,7 @@
 @import './table/index';
 @import './file-upload/index';
 @import './footer/index';
+@import './header/index';
 @import './icon/index';
 @import './inputs/index';
 @import './keyboard/index';


### PR DESCRIPTION
Added header import in global index.scss and classes.scss. This will also make sure it gets included in all.css