### PR TITLE
Fix chevron selector in header

### DIFF
--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -31,7 +31,7 @@
     flex: 2 1 33%;
     @include iui-header-buttons;
 
-    > .iui-chevron {
+    .iui-chevron {
       @include iui-icons-small;
       flex-shrink: 0;
       margin: 0 $iui-xs;


### PR DESCRIPTION
`>` is unnecessary and prevents us from wrapping elements around it. See https://github.com/iTwin/iTwinUI-react/pull/45#discussion_r631998227 (also see #55) 