### PR TITLE
Add nav and aria attributes to header breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.14.0]
+
+`2021-05-XX`
+
+### Fixes
+
+- **Added nav and aria attributes to header breadcrumbs.**
+
 ## [0.13.1]
 
 `2021-05-12`

--- a/backstop/tests/header.html
+++ b/backstop/tests/header.html
@@ -114,76 +114,79 @@
 
           <div class="iui-divider"></div>
 
-          <!-- Project Button -->
-          <button
-            class="iui-button iui-borderless iui-large iui-header-button"
-            type="button"
-            aria-label="Project picker"
-            aria-expanded="false"
-            id="test-button-1"
-          >
-            <div class="iui-icon iui-header-button-icon demo-picture"></div>
-            <span class="iui-label">
-              <div>Project Alpha</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
+          <nav aria-label="breadcrumbs">
+            <!-- Project Button -->
+            <button
+              class="iui-button iui-borderless iui-large iui-header-button"
+              type="button"
+              aria-label="Project picker"
+              aria-expanded="false"
+              id="test-button-1"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <div class="iui-icon iui-header-button-icon demo-picture"></div>
+              <span class="iui-label">
+                <div>Project Alpha</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
 
-          <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
-          <svg
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            class="iui-chevron"
-          >
-            <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
-          </svg>
+            <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
+            <svg
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              class="iui-chevron"
+            >
+              <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
+            </svg>
 
-          <!-- IModel Button -->
-          <button
-            class="iui-button iui-borderless iui-active iui-large iui-header-button"
-            type="button"
-            aria-label="Model picker"
-            aria-expanded="false"
-          >
-            <!-- Use model.svg from @itwin/itwinui-icons package. -->
-            <svg
-              aria-hidden="true"
-              viewBox="0 0 16 16"
-              class="iui-icon iui-header-button-icon"
+            <!-- IModel Button -->
+            <button
+              class="iui-button iui-borderless iui-active iui-large iui-header-button"
+              type="button"
+              aria-label="Model picker"
+              aria-expanded="false"
+              aria-current="location"
             >
-              <path
-                d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
-                opacity=".33"
-              />
-              <path
-                d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
-              />
-            </svg>
-            <span class="iui-label">
-              <div>Model Beta</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
-            >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <!-- Use model.svg from @itwin/itwinui-icons package. -->
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+                class="iui-icon iui-header-button-icon"
+              >
+                <path
+                  d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
+                  opacity=".33"
+                />
+                <path
+                  d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
+                />
+              </svg>
+              <span class="iui-label">
+                <div>Model Beta</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+          </nav>
         </div>
 
         <div class="iui-center">
@@ -296,57 +299,60 @@
           <div class="iui-divider"></div>
 
           <!-- Project Button -->
-          <button
-            class="iui-button iui-borderless iui-header-button iui-large"
-            type="button"
-            aria-label="Project picker"
-            aria-expanded="false"
-          >
-            <span class="iui-label">
-              <div class="iui-name">Project Alpha</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+          <nav aria-label="breadcrumbs">
+            <button
+              class="iui-button iui-borderless iui-header-button iui-large"
+              type="button"
+              aria-label="Project picker"
+              aria-expanded="false"
+            >
+              <span class="iui-label">
+                <div class="iui-name">Project Alpha</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+
+            <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
             <svg
               viewBox="0 0 16 16"
               aria-hidden="true"
-              class="iui-icon"
+              class="iui-chevron"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
+              <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
             </svg>
-          </button>
 
-          <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
-          <svg
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            class="iui-chevron"
-          >
-            <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
-          </svg>
-
-          <!-- IModel Button -->
-          <button
-            class="iui-button iui-borderless iui-active iui-large iui-header-button"
-            type="button"
-            aria-label="Model picker"
-            aria-expanded="false"
-          >
-            <span class="iui-label">
-              <div class="iui-name">Model Beta</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
+            <!-- IModel Button -->
+            <button
+              class="iui-button iui-borderless iui-active iui-large iui-header-button"
+              type="button"
+              aria-label="Model picker"
+              aria-expanded="false"
+              aria-current="location"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <span class="iui-label">
+                <div class="iui-name">Model Beta</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+          </nav>
         </div>
 
         <div class="iui-right">
@@ -455,75 +461,78 @@
           <div class="iui-divider"></div>
 
           <!-- Project Button -->
-          <button
-            class="iui-button iui-borderless iui-header-button iui-large"
-            type="button"
-            aria-label="Project picker"
-            aria-expanded="false"
-            id="test-button-3"
-          >
-            <div class="iui-icon iui-header-button-icon demo-picture"></div>
-            <span class="iui-label">
-              <div>Project Alpha</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
+          <nav aria-label="breadcrumbs">
+            <button
+              class="iui-button iui-borderless iui-header-button iui-large"
+              type="button"
+              aria-label="Project picker"
+              aria-expanded="false"
+              id="test-button-3"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <div class="iui-icon iui-header-button-icon demo-picture"></div>
+              <span class="iui-label">
+                <div>Project Alpha</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
 
-          <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
-          <svg
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            class="iui-chevron"
-          >
-            <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
-          </svg>
+            <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
+            <svg
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              class="iui-chevron"
+            >
+              <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
+            </svg>
 
-          <!-- IModel Button -->
-          <button
-            class="iui-button iui-borderless iui-active iui-large iui-header-button"
-            type="button"
-            aria-label="Model picker"
-            aria-expanded="false"
-          >
-            <!-- Use model.svg from @itwin/itwinui-icons package. -->
-            <svg
-              class="iui-icon iui-header-button-icon"
-              aria-hidden="true"
-              viewBox="0 0 16 16"
+            <!-- IModel Button -->
+            <button
+              class="iui-button iui-borderless iui-active iui-large iui-header-button"
+              type="button"
+              aria-label="Model picker"
+              aria-expanded="false"
+              aria-current="location"
             >
-              <path
-                d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
-                opacity=".33"
-              />
-              <path
-                d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
-              />
-            </svg>
-            <span class="iui-label">
-              <div>Model Beta</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
-            >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <!-- Use model.svg from @itwin/itwinui-icons package. -->
+              <svg
+                class="iui-icon iui-header-button-icon"
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
+                  opacity=".33"
+                />
+                <path
+                  d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
+                />
+              </svg>
+              <span class="iui-label">
+                <div>Model Beta</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+          </nav>
         </div>
 
         <div class="iui-right">
@@ -629,57 +638,60 @@
           <div class="iui-divider"></div>
 
           <!-- Project Button -->
-          <button
-            class="iui-button iui-borderless iui-large iui-header-button"
-            type="button"
-            aria-label="Project picker"
-            aria-expanded="false"
-          >
-            <span class="iui-label">
-              <div class="iui-name">Project Alpha</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+          <nav aria-label="breadcrumbs">
+            <button
+              class="iui-button iui-borderless iui-large iui-header-button"
+              type="button"
+              aria-label="Project picker"
+              aria-expanded="false"
+            >
+              <span class="iui-label">
+                <div class="iui-name">Project Alpha</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+
+            <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
             <svg
               viewBox="0 0 16 16"
               aria-hidden="true"
-              class="iui-icon"
+              class="iui-chevron"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
+              <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
             </svg>
-          </button>
 
-          <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
-          <svg
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            class="iui-chevron"
-          >
-            <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
-          </svg>
-
-          <!-- IModel Button -->
-          <button
-            class="iui-button iui-borderless iui-active iui-large iui-header-button"
-            type="button"
-            aria-label="Model picker"
-            aria-expanded="false"
-          >
-            <span class="iui-label">
-              <div class="iui-name">Model Beta</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
+            <!-- IModel Button -->
+            <button
+              class="iui-button iui-borderless iui-active iui-large iui-header-button"
+              type="button"
+              aria-label="Model picker"
+              aria-expanded="false"
+              aria-current="location"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <span class="iui-label">
+                <div class="iui-name">Model Beta</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+          </nav>
         </div>
 
         <div class="iui-right">
@@ -798,75 +810,78 @@
           <div class="iui-divider"></div>
 
           <!-- Project Button -->
-          <button
-            class="iui-button iui-borderless iui-header-button iui-large"
-            type="button"
-            aria-label="Project picker"
-            aria-expanded="false"
-          >
+          <nav aria-label="breadcrumbs">
+            <button
+              class="iui-button iui-borderless iui-header-button iui-large"
+              type="button"
+              aria-label="Project picker"
+              aria-expanded="false"
+            >
 
-            <div class="iui-icon iui-header-button-icon demo-picture"></div>
-            <span class="iui-label">
-              <div>Project Alpha</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <div class="iui-icon iui-header-button-icon demo-picture"></div>
+              <span class="iui-label">
+                <div>Project Alpha</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+
+            <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
             <svg
               viewBox="0 0 16 16"
               aria-hidden="true"
-              class="iui-icon"
+              class="iui-chevron"
             >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
+              <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
             </svg>
-          </button>
 
-          <!-- Use chevron-right.svg from @itwin/itwinui-icons package. -->
-          <svg
-            viewBox="0 0 16 16"
-            aria-hidden="true"
-            class="iui-chevron"
-          >
-            <path d="m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z" />
-          </svg>
-
-          <!-- IModel Button -->
-          <button
-            class="iui-button iui-borderless iui-active iui-header-button iui-large"
-            type="button"
-            aria-label="Model picker"
-            aria-expanded="false"
-          >
-            <!-- Use model.svg from @itwin/itwinui-icons package. -->
-            <svg
-              class="iui-icon iui-header-button-icon"
-              aria-hidden="true"
-              viewBox="0 0 16 16"
+            <!-- IModel Button -->
+            <button
+              class="iui-button iui-borderless iui-active iui-header-button iui-large"
+              type="button"
+              aria-label="Model picker"
+              aria-expanded="false"
+              aria-current="location"
             >
-              <path
-                d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
-                opacity=".33"
-              />
-              <path
-                d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
-              />
-            </svg>
-            <span class="iui-label">
-              <div>Model Beta</div>
-              <div class="iui-description">0x0123456789</div>
-            </span>
-            <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
-            <svg
-              viewBox="0 0 16 16"
-              aria-hidden="true"
-              class="iui-icon"
-            >
-              <path
-                d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
-              />
-            </svg>
-          </button>
+              <!-- Use model.svg from @itwin/itwinui-icons package. -->
+              <svg
+                class="iui-icon iui-header-button-icon"
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="m14 11.126-6-2.954v-6.811l-.5-.246-.5.246v6.811l-6 2.954v.559l.565.278 5.935-2.922 5.935 2.922.565-.278z"
+                  opacity=".33"
+                />
+                <path
+                  d="m7.5 0-7.5 3.69232v8.61536l7.5 3.69232 7.5-3.69232v-8.61536zm5.93549 4.03674-5.93549 2.92226-5.93549-2.92232 5.93549-2.92206zm-12.43549 7.64862v-6.81121l6 2.95349v6.81158zm13 0-6 2.95386v-6.81164l6-2.9535z"
+                />
+              </svg>
+              <span class="iui-label">
+                <div>Model Beta</div>
+                <div class="iui-description">0x0123456789</div>
+              </span>
+              <!-- Use caret-down-small.svg from @itwin/itwinui-icons package. -->
+              <svg
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                class="iui-icon"
+              >
+                <path
+                  d="m4.8067 6h6.3953a.27961.27961 0 0 1 .24043.44321l-3.1736 3.45707a.33969.33969 0 0 1 -.48085 0l-3.2217-3.45707a.26909.26909 0 0 1 .24042-.44321z"
+                />
+              </svg>
+            </button>
+          </nav>
         </div>
 
         <div class="iui-right">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-css",
-  "version": "0.14.0",
+  "version": "0.13.1",
   "author": "Bentley Systems",
   "license": "MIT",
   "main": "src/index.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-css",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "author": "Bentley Systems",
   "license": "MIT",
   "main": "src/index.scss",

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -31,6 +31,10 @@
     flex: 2 1 33%;
     @include iui-header-buttons;
 
+    > nav {
+      display: contents;
+    }
+
     .iui-chevron {
       @include iui-icons-small;
       flex-shrink: 0;

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -32,7 +32,9 @@
     @include iui-header-buttons;
 
     > nav {
-      display: contents;
+      display: flex;
+      align-items: center;
+      height: 100%;
     }
 
     .iui-chevron {


### PR DESCRIPTION
Based off of this guide: https://www.aditus.io/patterns/breadcrumbs/

Had to add a few rules to `nav` to preserve layout of children.