### PR TITLE
Declare $fallback before using it

### DIFF
--- a/src/style/theme.scss
+++ b/src/style/theme.scss
@@ -418,6 +418,7 @@ $fallbackvars: getfallbackvars();
   }
 }
 
+$fallback: null;
 
 //  Adds a CSS variable with a fallback value.
 //


### PR DESCRIPTION
Tackles this deprecation warning:

> DEPRECATION WARNING: As of Dart Sass 2.0.0, !global assignments won't be able to declare new variables. Consider adding `$fallback: null` at the root of the stylesheet.
> 
> 616 │   $fallback: true !global;
> 

![image](https://user-images.githubusercontent.com/9084735/119203891-24174c00-ba62-11eb-92c2-de491c8e7aab.png)
