### PR TITLE
Don't set button icon size on user-icon

### DIFF
--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -35,7 +35,7 @@ $iui-button-padding-large: $iui-xs * 6;
     background-color $iui-speed-fast ease-out,
     border-color $iui-speed-fast ease-out;
 
-  > .iui-icon {
+  > .iui-icon:not(.iui-user-icon) {
     width: $iui-icons-default;
     height: $iui-icons-default;
     transition: fill $iui-speed-fast ease-out;


### PR DESCRIPTION
Apparently, #57 was not enough because even though the specificity is higher now, the order of imports could still cause problems. So I've changed the selector to only apply icon size when it's not a user-icon.