### PR TITLE
Rename expandable block content

### DIFF
--- a/backstop/tests/expandable-block.html
+++ b/backstop/tests/expandable-block.html
@@ -47,7 +47,7 @@
           Expandable block title
         </div>
       </div>
-      <div class="iui-content">
+      <div class="iui-expandable-content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -78,7 +78,7 @@
           Expandable block title
         </div>
       </div>
-      <div class="iui-content">
+      <div class="iui-expandable-content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -116,7 +116,7 @@
           Collapsed block caption
         </div>
       </div>
-      <div class="iui-content">
+      <div class="iui-expandable-content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -153,7 +153,7 @@
           Expanded block caption
         </div>
       </div>
-      <div class="iui-content">
+      <div class="iui-expandable-content">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea

--- a/src/expandable-block/block.scss
+++ b/src/expandable-block/block.scss
@@ -80,7 +80,7 @@
     margin-top: $iui-baseline;
   }
 
-  .iui-content {
+  .iui-expandable-content {
     transform: scaleY(0);
     transform-origin: top;
     transition: transform $iui-speed-fast ease-in-out;
@@ -145,7 +145,7 @@
       }
     }
 
-    > .iui-content {
+    > .iui-expandable-content {
       transform: scaleY(1);
       opacity: 1;
       height: auto;


### PR DESCRIPTION
The `.iui-content` class name is too generic and has led to multiple problems already, so I've changed it to `iui-expandable-content`.