### PR TITLE
Continue pipeline even if Pages deploy fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           path: '${{ github.workspace }}/backstop/results/'
 
       - name: Host test results on gh pages
+        continue-on-error: true
         if: github.ref != 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:


### PR DESCRIPTION
Needed for external PRs to be able to be merged