### PR TITLE
Disable Pages deploy for forked workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Host test results on gh pages
         continue-on-error: true
-        if: github.ref != 'refs/heads/main'
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.ref != 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages


### PR DESCRIPTION
`continue-on-error` still marks the job as failed, so the step should be skipped for PRs coming from forks