### PR TITLE
Increase specificity of sidenav-button selectors

### DIFF
--- a/src/side-navigation/side-navigation.scss
+++ b/src/side-navigation/side-navigation.scss
@@ -80,7 +80,7 @@
 
     &,
     &:enabled:hover,
-    &:disabled,
+    &[disabled],
     &:focus-visible {
       @include themed {
         border-color: t(iui-color-background-5);

--- a/src/side-navigation/side-navigation.scss
+++ b/src/side-navigation/side-navigation.scss
@@ -76,7 +76,7 @@
     height: $iui-baseline * 5;
 
     &,
-    &:hover {
+    &:enabled:hover {
       @include themed {
         border-color: t(iui-color-background-5);
       }

--- a/src/side-navigation/side-navigation.scss
+++ b/src/side-navigation/side-navigation.scss
@@ -36,7 +36,7 @@
         border-bottom: none;
       }
     }
-    
+
     > .iui-bottom {
       justify-content: flex-end;
 
@@ -73,7 +73,10 @@
     border-right: none;
     overflow: hidden;
     justify-content: flex-start;
-    height: $iui-baseline * 5;
+    
+    &:not(.iui-expand) {
+      height: $iui-baseline * 5;
+    }
 
     &,
     &:enabled:hover {
@@ -82,11 +85,11 @@
       }
     }
 
-    > .iui-icon {
+    > .iui-icon:not(.iui-user-icon) {
       width: $iui-icons-large;
       height: $iui-icons-large;
       flex-shrink: 0;
-      
+
       + .iui-label {
         margin-left: $iui-icons-large;
         white-space: nowrap;
@@ -111,7 +114,7 @@
         }
       }
     }
-  
+
     &[disabled] {
       @include themed {
         background-color: t(iui-color-background-2);
@@ -135,19 +138,19 @@
       box-shadow: inset 0 0 $iui-xs
         rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-3));
     }
-  }
 
-  .iui-sidenav-button.iui-expand {
-    height: $iui-line-height;
-    justify-content: center;
-    border: none;
-    @include themed {
-      border-bottom: 1px solid t(iui-color-background-5);
-    }
+    &.iui-expand {
+      height: $iui-line-height;
+      justify-content: center;
+      border: none;
+      @include themed {
+        border-bottom: 1px solid t(iui-color-background-5);
+      }
 
-    > .iui-icon {
-      @include iui-icons-small;
-      transition: transform $iui-speed ease-out;
+      > .iui-icon {
+        @include iui-icons-small;
+        transition: transform $iui-speed ease-out;
+      }
     }
   }
 }

--- a/src/side-navigation/side-navigation.scss
+++ b/src/side-navigation/side-navigation.scss
@@ -79,7 +79,9 @@
     }
 
     &,
-    &:enabled:hover {
+    &:enabled:hover,
+    &:disabled,
+    &:focus-visible {
       @include themed {
         border-color: t(iui-color-background-5);
       }


### PR DESCRIPTION
Sidenav buttons should have a specificity higher than that of default button so that the order of imports won't matter (to fix #125). This PR increases the specificity by adding redundant selectors in a few places.