### PR TITLE
Bump jpeg-js to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "hosted-git-info": ">=3.0.8",
     "jimp": ">=0.16.1",
     "trim-newlines": "^3.0.1",
-    "glob-parent": "^5.1.2"
+    "glob-parent": "^5.1.2",
+    "jpeg-js": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "jimp": ">=0.16.1",
     "trim-newlines": "^3.0.1",
     "glob-parent": "^5.1.2",
-    "jpeg-js": "^0.4.0"
+    "jpeg-js": "^0.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,15 +2935,10 @@ jimp@0.2.27, jimp@>=0.16.1:
     "@jimp/types" "^0.16.1"
     regenerator-runtime "^0.13.3"
 
-jpeg-js@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
-  integrity sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=
-
-jpeg-js@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.2.tgz#8b345b1ae4abde64c2da2fe67ea216a114ac279d"
-  integrity sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw==
+jpeg-js@0.2.0, jpeg-js@0.4.2, jpeg-js@^0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
+  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
 js-base64@^2.1.8:
   version "2.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,7 +2935,7 @@ jimp@0.2.27, jimp@>=0.16.1:
     "@jimp/types" "^0.16.1"
     regenerator-runtime "^0.13.3"
 
-jpeg-js@0.2.0, jpeg-js@0.4.2, jpeg-js@^0.4.0:
+jpeg-js@0.2.0, jpeg-js@0.4.2, jpeg-js@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-w7q9-p3jq-fmhm