### PR TITLE
Add `focus-visible` to checkbox

### DIFF
--- a/src/inputs/checkbox-radio.scss
+++ b/src/inputs/checkbox-radio.scss
@@ -106,10 +106,23 @@
   }
 
   // Adds focus to enabled checkbox & radio
-  input:enabled:focus ~ .iui-checkbox-checkmark,
-  input:enabled:focus ~ .iui-radio-dot {
-    @include themed {
-      box-shadow: t(iui-focus-box-shadow);
+  input:enabled {
+    &:focus,
+    &:focus-visible {
+      ~ .iui-checkbox-checkmark,
+      ~ .iui-radio-dot {
+        outline: 0;
+        @include themed {
+          box-shadow: t(iui-focus-box-shadow);
+        }
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      ~ .iui-checkbox-checkmark,
+      ~ .iui-radio-dot {
+        box-shadow: none;
+      }
     }
   }
 

--- a/src/inputs/checkbox-radio.scss
+++ b/src/inputs/checkbox-radio.scss
@@ -107,11 +107,9 @@
 
   // Adds focus to enabled checkbox & radio
   input:enabled {
-    &:focus,
-    &:focus-visible {
+    &:focus {
       ~ .iui-checkbox-checkmark,
       ~ .iui-radio-dot {
-        outline: 0;
         @include themed {
           box-shadow: t(iui-focus-box-shadow);
         }


### PR DESCRIPTION
Added :focus-visible selector to prevent adding focus ring for mouse clicks. Rule will be ignored for unsupported browsers (IE, Safari).

_Could not use `iui-focus` mixin because styles are not set on the focused element (hidden input)._