### PR TITLE
Fix column resizer activation

### DIFF
--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -59,8 +59,8 @@
       transform: translateX(50%);
       touch-action: none;
       cursor: ew-resize;
-      z-index: 100;
-      display: none;
+      z-index: 1;
+      opacity: 0;
 
       > .iui-resizer-bar {
         height: 100%;
@@ -81,7 +81,7 @@
     }
 
     &:hover > .iui-resizer {
-      display: block;
+      opacity: 1;
     }
 
     &:hover,


### PR DESCRIPTION
Changed `display: none`/`block` to use `opacity: 0`/`1`. This makes the resizer always be present in the DOM tree, allowing activating it when moving mouse from right to left.
![resizer](https://user-images.githubusercontent.com/9084735/122265712-0beeed00-cea7-11eb-99d6-ae2ea9a14002.gif)

After this, I was able to set z-index to 1 (the resizer needs to be on top of the next column which comes later in the tree).
Can't remove it completely because then it won't be activable when moving from right side:
![resizer2](https://user-images.githubusercontent.com/9084735/122266348-b5ce7980-cea7-11eb-8642-d5ca7daa670b.gif)
