### PR TITLE
Add svg selector to tab icons for backwards compatibility

### DIFF
--- a/src/tabs/tabs.scss
+++ b/src/tabs/tabs.scss
@@ -28,7 +28,8 @@
         color: t(iui-color-foreground-primary);
       }
 
-      .iui-tab-icon {
+      .iui-tab-icon,
+      > svg {
         @include themed {
           fill: t(iui-icons-color-primary);
         }
@@ -41,7 +42,8 @@
         color: t(iui-text-color-muted);
       }
 
-      .iui-tab-icon {
+      .iui-tab-icon,
+      > svg {
         @include themed {
           fill: t(iui-icons-color-actionable-disabled);
         }
@@ -58,7 +60,8 @@
     }
   }
 
-  .iui-tab-icon {
+  .iui-tab-icon,
+  .iui-tab > svg { // svg selector should be removed in the future
     width: $iui-icons-default;
     height: $iui-icons-default;
     transition: fill $iui-speed-fast ease-out;
@@ -93,7 +96,8 @@
         color: t(iui-color-foreground-positive);
       }
 
-      .iui-tab-icon {
+      .iui-tab-icon,
+      > svg {
         @include themed {
           fill: t(iui-icons-color-positive);
         }


### PR DESCRIPTION
Previously (after #10), the user could just pass an svg to pill tabs without needing to provide size or class. After #156, this behavior was changed.

To avoid breaking user apps, I've added back the svg selector with a deprecation note.