### PR TITLE
Remove svg selector from tabs

### DIFF
--- a/src/tabs/tabs.scss
+++ b/src/tabs/tabs.scss
@@ -31,8 +31,7 @@
         color: t(iui-color-foreground-primary);
       }
 
-      .iui-tab-icon,
-      > svg {
+      .iui-tab-icon {
         @include themed {
           fill: t(iui-icons-color-primary);
         }
@@ -45,8 +44,7 @@
         color: t(iui-text-color-muted);
       }
 
-      .iui-tab-icon,
-      > svg {
+      .iui-tab-icon {
         @include themed {
           fill: t(iui-icons-color-actionable-disabled);
         }
@@ -63,8 +61,7 @@
     }
   }
 
-  .iui-tab-icon,
-  .iui-tab > svg { // svg selector should be removed in the future
+  .iui-tab-icon {
     width: $iui-icons-default;
     height: $iui-icons-default;
     @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
After https://github.com/iTwin/iTwinUI-react/pull/181, there is no need for the `svg` selector, as we are forcing users to use our component (which applies the class automatically).