### PR TITLE
Use span instead of anchor for current location within breadcrumb

### DIFF
--- a/backstop/tests/breadcrumbs.html
+++ b/backstop/tests/breadcrumbs.html
@@ -135,11 +135,7 @@
               </svg>
             </li>
             <li class="iui-breadcrumbs-item iui-current">
-              <a
-                class="iui-anchor"
-                href="#"
-                aria-current='page'
-              >You are here</a>
+              <span aria-current='page'>You are here</span>
             </li>
           </ol>
         </nav>

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -6,69 +6,73 @@
 @mixin iui-breadcrumbs {
   @include iui-reset;
   @include iui-font-family;
-
-  &,
-  .iui-breadcrumbs-list,
-  .iui-breadcrumbs-item,
-  .iui-breadcrumbs-separator {
-    display: flex;
-    align-items: center;
-  }
+  display: flex;
+  align-items: center;
+}
   
-  .iui-breadcrumbs-list {
-    @include iui-reset;
-    list-style-type: none;
-    user-select: none;
+@mixin iui-breadcrumbs-list {
+  @include iui-reset;
+  display: flex;
+  align-items: center;
+  list-style-type: none;
+  user-select: none;
+}
+
+@mixin iui-breadcrumbs-item {
+  display: flex;
+  align-items: center;
+
+  > .iui-anchor {
+    display: inline-block;
   }
 
-  .iui-breadcrumbs-item {
-    > .iui-anchor {
-      display: inline-block;
+  > .iui-anchor,
+  .iui-ellipsis {
+    margin: 0 $iui-sm;
+  }
+
+  > .iui-button {
+    margin: 0 $iui-xs;
+  }
+
+  > .iui-anchor,
+  > .iui-button > .iui-label {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: $iui-3xl * 2;
+  }
+
+  &:not(.iui-current) > .iui-button {
+    @include themed {
+      color: t(iui-color-foreground-primary);
     }
 
-    > .iui-anchor,
-    .iui-ellipsis {
-      margin: 0 $iui-sm;
-    }
-
-    > .iui-button {
-      margin: 0 $iui-xs;
-    }
-
-    > .iui-anchor,
-    > .iui-button > .iui-label {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      max-width: $iui-3xl * 2;
-    }
-
-    &:not(.iui-current) > .iui-button {
+    &:hover {
       @include themed {
-        color: t(iui-color-foreground-primary);
-      }
-
-      &:hover {
-        @include themed {
-          color: t(iui-color-foreground-primary-overlay);
-        }
-      }
-    }
-
-    &.iui-current > span {
-      margin-left: $iui-sm;
-      user-select: all;
-    }
-
-    &:last-child {
-      > .iui-anchor,
-      > .iui-button {
-        margin-right: 0;
+        color: t(iui-color-foreground-primary-overlay);
       }
     }
   }
 
-  .iui-breadcrumbs-separator > svg {
+  &.iui-current > span {
+    margin-left: $iui-sm;
+    user-select: all;
+  }
+
+  &:last-child {
+    > .iui-anchor,
+    > .iui-button {
+      margin-right: 0;
+    }
+  }
+}
+
+@mixin iui-breadcrumbs-separator {
+  display: flex;
+  align-items: center;
+
+  svg {
     @include iui-icons-small;
   }
 }

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -58,7 +58,8 @@
 
   &:last-child {
     > .iui-anchor,
-    > .iui-button {
+    > .iui-button,
+    > span {
       margin-right: 0;
     }
   }

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -55,12 +55,9 @@
       }
     }
 
-    &.iui-current {
-      > .iui-anchor {
-        @include themed {
-          color: t(iui-text-color);
-        }
-      }
+    &.iui-current > span {
+      margin-left: $iui-sm;
+      user-select: all;
     }
 
     &:last-child {

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -27,6 +27,7 @@
   }
 
   > .iui-anchor,
+  > span,
   .iui-ellipsis {
     margin: 0 $iui-sm;
   }
@@ -53,11 +54,6 @@
         color: t(iui-color-foreground-primary-overlay);
       }
     }
-  }
-
-  &.iui-current > span {
-    margin-left: $iui-sm;
-    user-select: all;
   }
 
   &:last-child {

--- a/src/breadcrumbs/classes.scss
+++ b/src/breadcrumbs/classes.scss
@@ -5,3 +5,15 @@
 .iui-breadcrumbs {
   @include iui-breadcrumbs;
 }
+
+.iui-breadcrumbs-list {
+  @include iui-breadcrumbs-list;
+}
+
+.iui-breadcrumbs-item {
+  @include iui-breadcrumbs-item;
+}
+
+.iui-breadcrumbs-separator {
+  @include iui-breadcrumbs-separator;
+}


### PR DESCRIPTION
![Screen Shot 2021-07-22 at 11 32 16 AM](https://user-images.githubusercontent.com/849817/126666410-d4a1ebf7-cafe-49bb-a6b2-1b2f02ac08af.png)

- Last breadcrumb is no longer an anchor link, is instead a span.
- Reduced specificity across the board.