### PR TITLE
Use css variable for badge color

### DIFF
--- a/backstop/tests/badge.html
+++ b/backstop/tests/badge.html
@@ -34,67 +34,67 @@
 
     <span
       class="iui-badge"
-      style="background-color: #6AB9EC;"
+      style="--badge-color: #6AB9EC;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #B1C854;"
+      style="--badge-color: #B1C854;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #F7706C;"
+      style="--badge-color: #F7706C;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #4585A5;"
+      style="--badge-color: #4585A5;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #FFC335;"
+      style="--badge-color: #FFC335;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #F7963E;"
+      style="--badge-color: #F7963E;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #73C7C1;"
+      style="--badge-color: #73C7C1;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #85A9CF;"
+      style="--badge-color: #85A9CF;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #A3779F;"
+      style="--badge-color: #A3779F;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #C8C2B4;"
+      style="--badge-color: #C8C2B4;"
     >
       Label
     </span>
     <span
       class="iui-badge"
-      style="background-color: #A47854;"
+      style="--badge-color: #A47854;"
     >
       Label
     </span>
@@ -104,7 +104,7 @@
 
     <span
       class="iui-badge"
-      style="background-color: #6AB9EC;"
+      style="--badge-color: #6AB9EC;"
       title="A long label that becomes truncated"
     >
       A long label that becomes truncated

--- a/src/badge/badge.scss
+++ b/src/badge/badge.scss
@@ -10,6 +10,7 @@
   padding: 0 $iui-xs;
   margin: round($iui-baseline * 0.5) 0;
   border-radius: $iui-border-radius;
+  background-color: var(--badge-color);
   text-transform: uppercase;
   user-select: none;
   max-width: 20ch;


### PR DESCRIPTION
Forcing inline background-color style increases specificity, so I've changed the approach to use a new inline css variable instead (`--badge-color`).

Passing an inline background-color is still possible but this allows extra flexibility.