### PR TITLE
Update fallback fonts in iui-font-family mixin

### DIFF
--- a/src/style/typography.scss
+++ b/src/style/typography.scss
@@ -5,10 +5,11 @@
 
 /// Constants ------------------------------------------------------------------
 
-$iui-sans: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+$iui-sans-fallback: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+$iui-sans: 'Open Sans';
 $iui-monospace: ui-monospace, Menlo, 'Segoe UI Mono', Consolas, 'Roboto Mono', 'Courier New', monospace;
 
-$iui-font-family: $iui-sans;
+$iui-font-family: $iui-sans, $iui-sans-fallback;
 
 $iui-font-size: 14px;
 $iui-font-size-small: 12px;
@@ -36,7 +37,7 @@ $iui-font-loaded-class: null !default;
 
 @mixin iui-font-family {
   @if $iui-font-loaded-class {
-    font-family: sans-serif;
+    font-family: $iui-sans-fallback;
 
     &.#{ $iui-font-loaded-class } {
       font-family: $iui-font-family;


### PR DESCRIPTION
Declared new fallback variable to use system fonts in the iui-font-family mixin, in response to https://github.com/iTwin/iTwinUI-react/issues/182#issuecomment-892181370