### PR TITLE
Remove iui-font-family from all components

### DIFF
--- a/backstop/assets/demo.css
+++ b/backstop/assets/demo.css
@@ -1,4 +1,3 @@
-body,
 h1,
 h2,
 h3,
@@ -15,6 +14,7 @@ p {
 }
 
 body {
+  margin: 0;
   padding: 24px;
 }
 

--- a/src/alert/alert.scss
+++ b/src/alert/alert.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-alert {
   @include iui-reset;
-  @include iui-font-family;
   border-radius: $iui-border-radius;
   box-sizing: border-box;
   display: flex;

--- a/src/badge/badge.scss
+++ b/src/badge/badge.scss
@@ -12,7 +12,6 @@ $iui-badge-text-color: rgba($iui-color-foreground-body--light, $iui-opacity-3--l
 
 @mixin iui-badge {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-block;
   font-size: $iui-font-size-small;
   padding: 0 $iui-xs * 1.5;

--- a/src/blockquote/blockquote.scss
+++ b/src/blockquote/blockquote.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-blockquote {
   @include iui-reset;
-  @include iui-font-family;
   display: block;
   position: relative;
   padding: $iui-baseline $iui-m;

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-breadcrumbs {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   align-items: center;
 }

--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -9,7 +9,6 @@ $iui-button-padding-large: $iui-xs * 6;
 
 @mixin iui-button {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-flex;
   align-items: center;
   vertical-align: middle;

--- a/src/code/code.scss
+++ b/src/code/code.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-code {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-block;
   font-family: $iui-monospace;
   font-size: $iui-font-size-small;

--- a/src/code/codeblock.scss
+++ b/src/code/codeblock.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-codeblock {
   @include iui-reset;
-  @include iui-font-family;
   margin: round($iui-baseline/2) 0;
 
   > .iui-title-bar {

--- a/src/expandable-block/block.scss
+++ b/src/expandable-block/block.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-expandable-block {
   @include iui-reset;
-  @include iui-font-family;
   box-sizing: border-box;
   @include themed {
     background-color: t(iui-color-background-1);

--- a/src/fieldset/fieldset.scss
+++ b/src/fieldset/fieldset.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-fieldset {
   @include iui-reset;
-  @include iui-font-family;
   padding: $iui-baseline $iui-sm;
   border-radius: $iui-border-radius;
   @include themed {

--- a/src/file-upload/file-upload.scss
+++ b/src/file-upload/file-upload.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-file-upload {
   @include iui-reset;
-  @include iui-font-family;
   font-size: $iui-font-size;
   font-weight: $iui-font-weight-normal;
   position: relative;

--- a/src/footer/footer.scss
+++ b/src/footer/footer.scss
@@ -5,7 +5,6 @@
 @mixin iui-legal-footer {
   @include iui-reset;
 
-  @include iui-font-family;
   text-align: center;
   width: 100%;
   padding: $iui-baseline 0;

--- a/src/header/header.scss
+++ b/src/header/header.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-page-header {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   justify-content: space-between;
   width: 100%;

--- a/src/inputs/checkbox-radio.scss
+++ b/src/inputs/checkbox-radio.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-inputs-checkbox-radio {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   align-items: center;
   font-size: $iui-font-size;

--- a/src/inputs/input.scss
+++ b/src/inputs/input.scss
@@ -5,6 +5,7 @@
 @mixin iui-input {
   @include iui-reset;
   width: 100%;
+  font-family: inherit;
   font-size: $iui-font-size;
   font-weight: $iui-font-weight-normal;
   line-height: $iui-line-height;

--- a/src/inputs/input.scss
+++ b/src/inputs/input.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-input {
   @include iui-reset;
-  @include iui-font-family;
   width: 100%;
   font-size: $iui-font-size;
   font-weight: $iui-font-weight-normal;

--- a/src/inputs/labeled-inputs.scss
+++ b/src/inputs/labeled-inputs.scss
@@ -4,7 +4,6 @@
 @import '../icon/index';
 
 @mixin iui-input-container {
-  @include iui-font-family;
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;

--- a/src/inputs/radio-tile.scss
+++ b/src/inputs/radio-tile.scss
@@ -4,7 +4,6 @@
 @import '../icon/index';
 
 @mixin iui-radio-tile {
-  @include iui-font-family;
   display: inline-flex;
   width: fit-content;
   user-select: none;

--- a/src/inputs/select.scss
+++ b/src/inputs/select.scss
@@ -7,7 +7,6 @@ $iui-after-border: 5px solid;
 
 @mixin iui-select {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   flex-direction: column;
   position: relative;

--- a/src/location-marker/location-marker.scss
+++ b/src/location-marker/location-marker.scss
@@ -7,7 +7,6 @@
 @mixin iui-location-marker {
   @include iui-reset;
 
-  @include iui-font-family;
   display: inline-block;
   user-select: none;
   position: relative;

--- a/src/menu/menu.scss
+++ b/src/menu/menu.scss
@@ -7,7 +7,6 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
 
 @mixin iui-dropdown {
   @include iui-reset;
-  @include iui-font-family;
   box-shadow: $iui-elevation-2;
   @include themed {
     background-color: t(iui-color-background-1);

--- a/src/modal/modal.scss
+++ b/src/modal/modal.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-modal {
   @include iui-reset;
-  @include iui-font-family;
   z-index: 999;
   position: fixed;
   top: 0;

--- a/src/non-ideal-state/non-ideal-state.scss
+++ b/src/non-ideal-state/non-ideal-state.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-non-ideal-state {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/progress-indicator/linear.scss
+++ b/src/progress-indicator/linear.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-progress-indicator-linear($height: 4px) {
   @include iui-reset;
-  @include iui-font-family;
   text-align: left;
   display: block;
 

--- a/src/progress-indicator/radial.scss
+++ b/src/progress-indicator/radial.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-progress-indicator-radial-ie {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-block;
   position: relative;
   box-sizing: border-box;

--- a/src/slider/slider.scss
+++ b/src/slider/slider.scss
@@ -12,7 +12,6 @@ $tick-height: $iui-baseline; // 11px
 
   .iui-slider-min,
   .iui-slider-max {
-    @include iui-font-family;
     user-select: all;
     margin-top: $iui-xxs;
 

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -12,9 +12,10 @@
   line-height: $iui-line-height;
 
   @include iui-scrollbar;
+  @include iui-font-family;
 
-  &.iui-set-fonts {
-    @include iui-font-family;
+  &.iui-no-webfonts {
+    font-family: $iui-sans-fallback;
   }
 }
 

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -11,8 +11,11 @@
   font-size: $iui-font-size;
   line-height: $iui-line-height;
 
-  @include iui-font-family;
   @include iui-scrollbar;
+
+  &.iui-set-fonts {
+    @include iui-font-family;
+  }
 }
 
 .iui-anchor {

--- a/src/table/paginator.scss
+++ b/src/table/paginator.scss
@@ -7,7 +7,6 @@
 
 @mixin iui-paginator {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   flex: 1;
   justify-content: space-around;

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-table {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   flex-direction: column;
 

--- a/src/tabs/tabs.scss
+++ b/src/tabs/tabs.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-tabs {
   @include iui-reset;
-  @include iui-font-family;
   position: relative;
   display: flex;
   align-items: center;
@@ -13,7 +12,6 @@
 
   .iui-tab {
     @include iui-reset;
-    @include iui-font-family;
     position: relative;
     display: flex;
     align-items: center;

--- a/src/tag/tag.scss
+++ b/src/tag/tag.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-tag {
   @include iui-reset;
-  @include iui-font-family;
   @include iui-focus;
   user-select: all;
   text-transform: lowercase;

--- a/src/tile/tile.scss
+++ b/src/tile/tile.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-tile {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-flex;
   flex-direction: column;
   width: $iui-3xl * 3;
@@ -229,7 +228,6 @@
     white-space: nowrap;
 
     > .iui-button {
-      @include iui-font-family;
       font-size: $iui-font-size;
       flex: 1;
       height: auto;

--- a/src/time-picker/time-picker.scss
+++ b/src/time-picker/time-picker.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-time-picker {
   @include iui-reset;
-  @include iui-font-family;
   user-select: none;
   text-align: center;
   height: $iui-baseline * 26;

--- a/src/toast-notification/toast.scss
+++ b/src/toast-notification/toast.scss
@@ -5,7 +5,6 @@
 
 @mixin iui-toast {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-flex;
   align-items: center;
   box-sizing: border-box;

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-toggle-switch {
   @include iui-reset;
-  @include iui-font-family;
   display: flex;
   align-items: center;
   font-size: $iui-font-size;

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -4,7 +4,6 @@
 
 @mixin iui-tooltip {
   @include iui-reset;
-  @include iui-font-family;
   display: block;
   text-align: center;
   border-radius: $iui-border-radius;

--- a/src/user-icon/user-icon.scss
+++ b/src/user-icon/user-icon.scss
@@ -6,7 +6,6 @@
 
 @mixin iui-user-icon {
   @include iui-reset;
-  @include iui-font-family;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/src/wizard/wizard.scss
+++ b/src/wizard/wizard.scss
@@ -4,8 +4,7 @@
 
 @mixin iui-wizards {
   @include iui-reset;
-  @include iui-font-family;
-
+  
   > .iui-wizards-wrapper {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
### Changes

1. Removed iui-font-family from all components. Had to add `font-family: inherit` to inputs because it doesn't automatically use fonts from body.

2. Added `.iui-no-webfonts` modifier on `.iui-body` to only load fallback fonts.

### Rationale

These two changes combined will give the user more control over when the Open Sans webfont is set and what to show while it's loading.

### Tests

Removed font-family from body in demo.css to be able to test without fonts. Working fine in my testing.