### PR TITLE
ci: Add workflow for release automation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-pr-title:
+    name: PR title follows conventional commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const pr = await github.repos.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.number }}
+            });
+            console.log(pr);

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const pr = await github.repos.pulls.get({
+            const pr = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: ${{ github.event.number }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,9 +13,11 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const pr = await github.pulls.get({
+            const { data: { title } } = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: ${{ github.event.number }}
             });
-            console.log(pr);
+            if (!/^(.+)(?:(([^)s]+)))?: (.+)/.test(title)) {
+              process.exit(1);
+            }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, reopened, edited, synchronize]
     branches: [main]
 
 jobs:
@@ -19,5 +20,6 @@ jobs:
               pull_number: ${{ github.event.number }}
             });
             if (!/^(.+)(?:(([^)s]+)))?: (.+)/.test(title)) {
+              console.error('PR title should follow conventional commit spec (https://www.conventionalcommits.org)');
               process.exit(1);
             }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PR
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-pr-title:
-    name: PR title follows conventional commit
+    name: Title follows conventional commit
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title
@@ -20,6 +20,6 @@ jobs:
               pull_number: ${{ github.event.number }}
             });
             if (!/^(.+)(?:(([^)s]+)))?: (.+)/.test(title)) {
-              console.error('PR title should follow conventional commit spec (https://www.conventionalcommits.org)');
+              console.error('PR title should follow the conventional commits spec (https://www.conventionalcommits.org).');
               process.exit(1);
             }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-pr-title:
-    name: Title follows conventional commit
+    name: Title follows conventional commits
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,25 @@ jobs:
         working-directory: './lib'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+
+  fix-title:
+    name: Edit release title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release title to match tag name
+        uses: actions/github-script@v4
+        with:
+          script: |
+            const { data: release } = await github.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: ${{ github.ref }}
+            });
+            if (release.name !== release.tag_name) {
+              await github.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                id: release.id,
+                name: release.tag_name
+              });
+            }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,17 +1,16 @@
- name:
- 
- on:
-   push:
-     branches:
-       - main
- 
- jobs:
-   release-please:
-     name: Create release PR
-     runs-on: ubuntu-latest
-     steps:
-       - uses: GoogleCloudPlatform/release-please-action@v2
-         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
-           release-type: node
-           package-name: release-please-action
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release-please:
+    name: Create release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: release-please-action

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,17 @@
+ name:
+ 
+ on:
+   push:
+     branches:
+       - main
+ 
+ jobs:
+   release-please:
+     name: Create release PR
+     runs-on: ubuntu-latest
+     steps:
+       - uses: GoogleCloudPlatform/release-please-action@v2
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           release-type: node
+           package-name: release-please-action

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,6 @@ To enable us to quickly review and accept your pull requests, always create one 
   - `.js` file has scenarios covering these cases.
   - All existing and new tests should pass.
 
-After verifying that your changes are ready, you can [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that the name of your pull request follows the [Conventional Commits spec](https://www.conventionalcommits.org/), and that you have a proper description with screenshots and a [closing keyword]*https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
+After verifying that your changes are ready, you can [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that the name of your pull request follows the [Conventional Commits spec](https://www.conventionalcommits.org/), and that you have a proper description with screenshots and a [closing keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
 
 If your pull request changes an existing component, we ask that the description distinctly lists all visual changes that have occurred. These notes are used by the Visual Design team to update specifications and images within documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,22 +118,6 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
     ```
   - More information about options can be found in [BackstopJS GitHub](https://github.com/garris/BackstopJS#advanced-scenarios).
 
-### Changelog
-
-The `CHANGELOG.md` file must be updated for any new components or changes that you add. At the top of the file, create an "unreleased" section with a placeholder date (if not already present).
-
-<details>
-<summary>Example</summary>
-
-```
-## Unreleased
-
-`Date`
-
-### What's new
-```
-</details>
-
 ---
 
 ## Committing your work
@@ -149,8 +133,7 @@ To enable us to quickly review and accept your pull requests, always create one 
   - `.html` file has all possible states of the component.
   - `.js` file has scenarios covering these cases.
   - All existing and new tests should pass.
-- Updated changelog.
 
-After verifying that your changes are ready, you can [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that an issue is linked to the pull request and that you have a proper description with screenshots.
+After verifying that your changes are ready, you can [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that the name of your pull request follows the [Conventional Commits spec](https://www.conventionalcommits.org/), and that you have a proper description with screenshots and a [closing keyword]*https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
 
 If your pull request changes an existing component, we ask that the description distinctly lists all visual changes that have occurred. These notes are used by the Visual Design team to update specifications and images within documentation.


### PR DESCRIPTION
Added two new workflows:
- `release-please.yml`: uses the [release-please](https://github.com/googleapis/release-please) action to automatically create a release PR and update changelog.
- `pr.yml`: uses a custom script to ensure that PR title follows the conventional commits spec.

Updated:
- `publish.yml`: the release-please action includes the package name in release title, so I'm removing it.
- `CONTRIBUTING.md`: removed details about changelog.