### PR TITLE
ci: Update `actions/setup-node` to use built-in caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,19 +16,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node 12.X
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
-
-      - run: yarn audit:ci
+      - run: yarn audit
 
       - run: yarn lint
       - run: yarn lint:copyright ${{ github.workspace }}/*/**.{scss,html,js,ts}
@@ -78,15 +72,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node 12.X
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
       - run: yarn build


### PR DESCRIPTION
Caching is now supported in [`actions/setup-node`](https://github.com/actions/setup-node/releases/tag/v2.2.0) so I've replaced `actions/cache`.

Also changed `yarn audit:ci` to `yarn audit`.