### PR TITLE
ci: Fix link in pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,6 @@ jobs:
               pull_number: ${{ github.event.number }}
             });
             if (!/^(.+)(?:(([^)s]+)))?: (.+)/.test(title)) {
-              console.error('PR title should follow the conventional commits spec (https://www.conventionalcommits.org).');
+              console.error('PR title should follow the conventional commits spec: https://www.conventionalcommits.org');
               process.exit(1);
             }


### PR DESCRIPTION
Previously, the link included the parentheses and period:
![image](https://user-images.githubusercontent.com/9084735/129955342-4e42b5ae-eb3d-4c37-a879-fc42bb10e2b8.png)