### PR TITLE
ci: fix typo in release title workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
+            console.log(await github.repos.getLatestRelease({ ...context.repo }));
             const { data: { title } } = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -23,4 +24,3 @@ jobs:
               console.error('PR title should follow the conventional commits spec: https://www.conventionalcommits.org');
               process.exit(1);
             }
-            console.log(await github.repos.getLatestRelease({ ...context.repo });

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,3 +23,4 @@ jobs:
               console.error('PR title should follow the conventional commits spec: https://www.conventionalcommits.org');
               process.exit(1);
             }
+            console.log(await github.repos.getLatestRelease({ ...context.repo });

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            const { data: release } = await github.repos.getLatestRelease({ ...context.repo });
-            console.log(release.tag_name, release.name);
             const { data: { title } } = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,8 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            console.log(await github.repos.getLatestRelease({ ...context.repo }));
+            const { data: release } = await github.repos.getLatestRelease({ ...context.repo });
+            console.log(release.tag_name, release.name);
             const { data: { title } } = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,7 +61,7 @@ jobs:
               await github.repos.updateRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                id: release.id,
+                release_id: release.id,
                 name: release.tag_name
               });
             }


### PR DESCRIPTION
Correct param is `release_id` not `id`.

Refs: https://github.com/iTwin/iTwinUI/actions/runs/1151405731 and https://octokit.github.io/rest.js/v18#repos-update-release