### PR TITLE
fix(Wizard): allow placing tooltip inside wizard wrapper

### DIFF
--- a/src/wizard/wizard.scss
+++ b/src/wizard/wizard.scss
@@ -86,7 +86,7 @@
     }
 
     .iui-wizard-track-content::before,
-    &:not(:last-child) .iui-wizard-track-content::after {
+    &:not(:last-of-type) .iui-wizard-track-content::after {
       @include themed {
         background-color: t(iui-color-background-5);
       }
@@ -112,8 +112,8 @@
     }
   }
 
-  &:first-child .iui-wizard-track-content::before,
-  &:last-child .iui-wizard-track-content::after {
+  &:first-of-type .iui-wizard-track-content::before,
+  &:last-of-type .iui-wizard-track-content::after {
     background-color: transparent;
   }
 }

--- a/src/wizard/workflow.scss
+++ b/src/wizard/workflow.scss
@@ -23,8 +23,8 @@
       }
     }
 
-    &:first-child .iui-wizard-circle,
-    &:last-child .iui-wizard-circle {
+    &:first-of-type .iui-wizard-circle,
+    &:last-of-type .iui-wizard-circle {
       border-radius: $iui-sm;
       @include themed {
         background-color: t(iui-color-background-1);


### PR DESCRIPTION
Changed `:last-child` selectors to `:last-of-type` because tooltips are normally placed after last step in the DOM.

Before (with `:last-child`):
![image](https://user-images.githubusercontent.com/9084735/130270386-01fa5475-e185-41a3-8622-5a11c43a2282.png)

After (with `:last-of-type`):
![image](https://user-images.githubusercontent.com/9084735/130271177-855520c8-5c1f-4faa-853e-1ff7f38b0005.png)
