### PR TITLE
fix(Tabs): vertical tabs shouldn't wrap

### DIFF
--- a/src/tabs/tabs.scss
+++ b/src/tabs/tabs.scss
@@ -137,7 +137,7 @@
     li,
     .iui-tab {
       width: 100%;
-      whites-space: nowrap;
+      white-space: nowrap;
     }
 
     ~ .iui-tabs-content {

--- a/src/tabs/tabs.scss
+++ b/src/tabs/tabs.scss
@@ -137,6 +137,7 @@
     li,
     .iui-tab {
       width: 100%;
+      whites-space: nowrap;
     }
 
     ~ .iui-tabs-content {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9084735/130486161-6535e8a1-7c68-497d-a51d-3c5b72490b89.png)

After applying `white-space: nowrap`:
![image](https://user-images.githubusercontent.com/9084735/130486227-7d972dc7-cbc7-4273-af41-1bb29e84bde4.png)