### PR TITLE
fix(Wizard): focus is now applied on step, not circle

### DIFF
--- a/backstop/scenarios/wizard.js
+++ b/backstop/scenarios/wizard.js
@@ -24,9 +24,7 @@ module.exports = [
 
   // Focus states
   scenario('State long focus on complete', {
-    actions: [
-      focus('#demo-long .iui-clickable:first-child .iui-wizard-circle'),
-    ],
+    actions: [focus('#demo-long .iui-clickable:first-child')],
     selectors: ['#demo-long'],
     viewports: [{ width: 800, height: 600 }],
   }),

--- a/backstop/tests/wizard.html
+++ b/backstop/tests/wizard.html
@@ -39,24 +39,22 @@
 
       <div class="iui-wizard">
         <ol aria-label="Progress">
-          <li class="iui-wizard-step iui-clickable">
+          <li
+            class="iui-wizard-step iui-clickable"
+            tabindex="0"
+          >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-                tabindex="0"
-              >1</span>
+              <span class="iui-wizard-circle">1</span>
             </div>
             <div class="iui-wizard-step-name">First step</div>
           </li>
 
-          <li class="iui-wizard-step iui-clickable">
+          <li
+            class="iui-wizard-step iui-clickable"
+            tabindex="0"
+          >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-                tabindex="0"
-              >2</span>
+              <span class="iui-wizard-circle">2</span>
             </div>
             <div class="iui-wizard-step-name">Completed step</div>
           </li>
@@ -76,20 +74,14 @@
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >4</span>
+              <span class="iui-wizard-circle">4</span>
             </div>
             <div class="iui-wizard-step-name">Next step</div>
           </li>
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >5</span>
+              <span class="iui-wizard-circle">5</span>
             </div>
             <div class="iui-wizard-step-name">Last step</div>
           </li>
@@ -105,23 +97,21 @@
 
       <div class="iui-wizard iui-long">
         <ol aria-label="Progress">
-          <li class="iui-wizard-step iui-clickable">
+          <li
+            class="iui-wizard-step iui-clickable"
+            tabindex="0"
+          >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-                tabindex="0"
-              >1</span>
+              <span class="iui-wizard-circle">1</span>
             </div>
           </li>
 
-          <li class="iui-wizard-step iui-clickable">
+          <li
+            class="iui-wizard-step iui-clickable"
+            tabindex="0"
+          >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-                tabindex="0"
-              >2</span>
+              <span class="iui-wizard-circle">2</span>
             </div>
           </li>
 
@@ -139,37 +129,25 @@
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >4</span>
+              <span class="iui-wizard-circle">4</span>
             </div>
           </li>
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >5</span>
+              <span class="iui-wizard-circle">5</span>
             </div>
           </li>
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >6</span>
+              <span class="iui-wizard-circle">6</span>
             </div>
           </li>
 
           <li class="iui-wizard-step">
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="false"
-              >7</span>
+              <span class="iui-wizard-circle">7</span>
             </div>
           </li>
         </ol>

--- a/backstop/tests/wizard.html
+++ b/backstop/tests/wizard.html
@@ -61,13 +61,10 @@
 
           <li
             class="iui-wizard-step iui-current"
-            aria-current="true"
+            aria-current="step"
           >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="true"
-              >3</span>
+              <span class="iui-wizard-circle">3</span>
             </div>
             <div class="iui-wizard-step-name">Current step</div>
           </li>
@@ -117,13 +114,10 @@
 
           <li
             class="iui-wizard-step iui-current"
-            aria-current="true"
+            aria-current="step"
           >
             <div class="iui-wizard-track-content">
-              <span
-                class="iui-wizard-circle"
-                aria-selected="true"
-              >3</span>
+              <span class="iui-wizard-circle">3</span>
             </div>
           </li>
 

--- a/src/wizard/wizard.scss
+++ b/src/wizard/wizard.scss
@@ -47,7 +47,7 @@
   // Current step
   &.iui-current {
     font-weight: $iui-font-weight-semibold;
-    
+
     .iui-wizard-step-name {
       @include themed {
         color: t(iui-color-foreground-positive);
@@ -96,7 +96,6 @@
   // Clickable steps
   &.iui-clickable {
     .iui-wizard-circle {
-      @include iui-focus(iui-focus-positive-box-shadow);
       cursor: pointer;
       @media (prefers-reduced-motion: no-preference) {
         transition: background-color $iui-speed-fast ease-out;
@@ -108,6 +107,21 @@
           border: 1px solid t(iui-color-background-positive);
           background-color: t(iui-color-background-positive);
         }
+      }
+    }
+
+    &:focus {
+      .iui-wizard-circle {
+        outline: 0;
+        @include themed {
+          box-shadow: t(iui-focus-positive-box-shadow);
+        }
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      .iui-wizard-circle {
+        box-shadow: none;
       }
     }
   }

--- a/src/wizard/wizard.scss
+++ b/src/wizard/wizard.scss
@@ -111,6 +111,8 @@
     }
 
     &:focus {
+      outline: 0;
+
       .iui-wizard-circle {
         outline: 0;
         @include themed {


### PR DESCRIPTION
Moved focus selectors and tabindex from iui-wizard-circle into iui-wizard-step.
Kept styling on circle.
Removed aria-selected attribute from html.