### PR TITLE
feat(Table): Added transition rules to row

### DIFF
--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -142,6 +142,8 @@
       border-bottom-color: t(iui-color-background-4);
     }
 
+    @include iui-transition-group;
+
     > .iui-slot > .iui-more-options {
       visibility: hidden;
     }
@@ -190,8 +192,6 @@
         }
       }
     }
-
-    @include iui-transition-group;
 
     &.iui-expanded-content {
       overflow: hidden;

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -191,9 +191,10 @@
       }
     }
 
+    @include iui-transition-group;
+
     &.iui-expanded-content {
       overflow: hidden;
-      @include iui-transition-group;
     }
 
     // #region Selection


### PR DESCRIPTION
Moved out transition rules from expanded content to row, so we could animate subrows expansion too.

![subrows3](https://user-images.githubusercontent.com/81580355/131644389-9f8d4d0a-10c4-4d3b-9b07-adb420f7d7e9.gif)
