### PR TITLE
fix(Checkbox): loading checkmark is now styled correctly

### DIFF
--- a/src/inputs/checkbox-radio.scss
+++ b/src/inputs/checkbox-radio.scss
@@ -43,7 +43,7 @@
       background-color: t(iui-color-background-1);
     }
 
-    svg {
+    svg:not(.iui-radial) {
       width: $iui-sm;
       height: $iui-sm;
 


### PR DESCRIPTION
#232 broke loading checkboxes:
![image](https://user-images.githubusercontent.com/9084735/131687384-e7923def-3b3f-4b14-acdc-40a022ffcc00.png)

After fix:
![image](https://user-images.githubusercontent.com/9084735/131687505-d2586a59-e7a8-4849-96d4-77b5e3a80ecf.png)
