### PR TITLE
ci: Fix index.html getting removed on failed builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Host test results on gh pages
         continue-on-error: true
-        if: failure()
+        if: github.ref != 'refs/heads/main' && failure()
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages

--- a/backstop/tests/alert.html
+++ b/backstop/tests/alert.html
@@ -84,7 +84,7 @@
         class="iui-icon"
         aria-hidden="true"
       ></svg-info-circular>
-      <span class="iui-message">TEST Informational message. <a href="#">Learn more</a></span>
+      <span class="iui-message">Informational message. <a href="#">Learn more</a></span>
       <button
         aria-label="Close"
         type="button"

--- a/backstop/tests/alert.html
+++ b/backstop/tests/alert.html
@@ -84,7 +84,7 @@
         class="iui-icon"
         aria-hidden="true"
       ></svg-info-circular>
-      <span class="iui-message">Informational message. <a href="#">Learn more</a></span>
+      <span class="iui-message">TEST Informational message. <a href="#">Learn more</a></span>
       <button
         aria-label="Close"
         type="button"


### PR DESCRIPTION
Disabled `Host test results on gh pages` to prevent hosting test results for failed builds on main branch (because build should never fail for legit reasons on main branch).

The problem was happening because `github.event.number` is undefined on main branch and it was putting the test results in the root folder. If we really want to host the test results for main branch, we could change target folder.