### PR TITLE
feat(MenuItem): Add `iui-focused` class to emulate focus styling

### DIFF
--- a/src/menu/menu.scss
+++ b/src/menu/menu.scss
@@ -92,7 +92,8 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
     }
   }
 
-  &:focus {
+  &:focus,
+  &.iui-focused {
     @include themed {
       outline: $iui-active-outline;
       outline-offset: -1px;
@@ -130,7 +131,8 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
       }
     }
 
-    &:focus {
+    &:focus,
+    &.iui-focused {
       outline-width: $iui-xxs;
       outline-offset: -2px;
     }


### PR DESCRIPTION
`iui-focused` class can now be applied on menu item to emulate focus styling when it is not possible to *actually* set focus on the item.

Will be used in typeahead/combobox component. Notice how input is focused but menu item has emulated focus:
![typeahead2](https://user-images.githubusercontent.com/9084735/134957204-b9edc037-93d2-4700-86fa-e29b7d41ec0d.gif)

