### PR TITLE
fix(NotificationMarker): Remove top-level `&` to fix error

### DIFF
--- a/src/notification-marker/classes.scss
+++ b/src/notification-marker/classes.scss
@@ -3,7 +3,7 @@
 @import './index';
 
 @each $status in primary, positive, warning, negative, accessory {
-  &.iui-notification-#{$status} {
+  .iui-notification-#{$status} {
     @include iui-notification-marker($status: $status);
   }
 }


### PR DESCRIPTION
`&` is not needed. Closes #336 