### PR TITLE
fix(SideNavigation): remove fixed width from submenu

### DIFF
--- a/backstop/tests/side-navigation.html
+++ b/backstop/tests/side-navigation.html
@@ -355,117 +355,122 @@
           </button>
         </div>
 
-        <div class="iui-side-navigation-submenu">
-          <div class="iui-side-navigation-submenu-header">
-            <div class="iui-side-navigation-submenu-header-label">
-              <button class="iui-button iui-borderless">
-                <svg-chevron-left
-                  class="iui-icon"
-                  aria-hidden="true"
-                ></svg-chevron-left>
-              </button>
-              <span>Documents with a long label to test for truncation</span>
+        <div
+          class="iui-side-navigation-submenu"
+          style="width: 384px;"
+        >
+          <div class="iui-side-navigation-submenu-content">
+            <div class="iui-side-navigation-submenu-header">
+              <div class="iui-side-navigation-submenu-header-label">
+                <button class="iui-button iui-borderless">
+                  <svg-chevron-left
+                    class="iui-icon"
+                    aria-hidden="true"
+                  ></svg-chevron-left>
+                </button>
+                <span>Documents with a long label to test for truncation</span>
+              </div>
+              <div class="iui-side-navigation-submenu-header-actions">
+                <button class="iui-button iui-borderless">
+                  <svg-settings
+                    class="iui-icon"
+                    aria-hidden="true"
+                  ></svg-settings>
+                </button>
+              </div>
             </div>
-            <div class="iui-side-navigation-submenu-header-actions">
-              <button class="iui-button iui-borderless">
-                <svg-settings
-                  class="iui-icon"
-                  aria-hidden="true"
-                ></svg-settings>
-              </button>
-            </div>
-          </div>
 
-          <div class="iui-text-leading">Frequently viewed</div>
-          <ul>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-          </ul>
-          <div class="iui-text-leading">All documents</div>
-          <ul>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Lorem ipsum</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Dolor sit amet</a></li>
-            <li><a
-                href="#"
-                class="iui-anchor"
-              >Consectetur adipiscing elit</a></li>
-          </ul>
+            <div class="iui-text-leading">Frequently viewed</div>
+            <ul>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+            </ul>
+            <div class="iui-text-leading">All documents</div>
+            <ul>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Lorem ipsum</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Dolor sit amet</a></li>
+              <li><a
+                  href="#"
+                  class="iui-anchor"
+                >Consectetur adipiscing elit</a></li>
+            </ul>
+          </div>
         </div>
       </div>
 

--- a/src/side-navigation/side-navigation.scss
+++ b/src/side-navigation/side-navigation.scss
@@ -174,11 +174,9 @@
 
 @mixin iui-side-navigation-submenu {
   min-width: $iui-3xl * 2;
-  width: $iui-3xl * 4;
   max-width: 50vw;
   height: 100%;
   box-sizing: border-box;
-  padding: 0 $iui-sm $iui-baseline;
   overflow-x: hidden;
   overflow-y: auto;
   overflow-y: overlay;
@@ -189,6 +187,10 @@
   }
 
   @include iui-transition-group;
+
+  &-content {
+    padding: 0 $iui-sm $iui-baseline;
+  }
 
   &-header {
     height: $iui-baseline * 5;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -140,7 +140,7 @@
 }
 
 /// Classes for react-transition-group
-/// Used for expand/collapse transitions. Needs height to be set in JS.
+/// Used for expand/collapse transitions. Needs height/width to be set in JS.
 @mixin iui-transition-group {
   &.iui-enter,
   &.iui-exit-active {


### PR DESCRIPTION
Removed `width` from sidenav submenu, as it's a bit too much in most cases. The width will now respond to content.

Moved padding into a new div called `-submenu-content`. This will make animations smoother, as setting `width: 0` still includes the padding if present.