### PR TITLE
fix(Button): Add `font-family: inherit`

### DIFF
--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -9,6 +9,7 @@ $iui-button-padding-large: $iui-xs * 6;
 
 @mixin iui-button {
   @include iui-reset;
+  font-family: inherit;
   display: inline-flex;
   align-items: center;
   vertical-align: middle;


### PR DESCRIPTION
Added manual inherit rule because buttons also don't inherit fonts by default, same as inputs. Closes #341 