### PR TITLE
fix(Slider): Add min-height

### DIFF
--- a/src/slider/slider.scss
+++ b/src/slider/slider.scss
@@ -9,6 +9,7 @@ $tick-height: $iui-baseline; // 11px
 
 @mixin iui-slider-component-container {
   display: flex;
+  min-height: $iui-baseline * 2;
 
   .iui-slider-min,
   .iui-slider-max {


### PR DESCRIPTION
If no min / max label or icon are present the slider would get a height of 0. Added `min-height` to force a height.
![Screen Shot 2021-10-14 at 11 40 57 AM](https://user-images.githubusercontent.com/849817/137351264-2658968b-7e8f-481f-9cf5-33065239a4ac.png)