### PR TITLE
fix(transition-group): Handle exit animation correctly

### DIFF
--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -142,23 +142,27 @@
 /// Classes for react-transition-group
 /// Used for expand/collapse transitions. Needs height/width to be set in JS.
 @mixin iui-transition-group {
+  $transition-rule: opacity $iui-speed-fast ease-out, width $iui-speed-fast ease-out, height $iui-speed-fast ease-out;
+
   &.iui-enter {
     opacity: 0;
   }
 
-  &.iui-exit,
   &.iui-enter-active {
+    opacity: 1;
+    @media (prefers-reduced-motion: no-preference) {
+      transition: $transition-rule;
+    }
+  }
+
+  &.iui-exit {
     opacity: 1;
   }
 
   &.iui-exit-active {
     opacity: 0;
-  }
-
-  &.iui-enter-active,
-  &.iui-exit-active {
     @media (prefers-reduced-motion: no-preference) {
-      transition: opacity $iui-speed-fast ease-out, width $iui-speed-fast ease-out, height $iui-speed-fast ease-out;
+      transition: $transition-rule;
     }
   }
 }


### PR DESCRIPTION
Previously, `opacity: 1` was lower in the cascade than `opacity: 0`, so exit animation would not work correctly.