### PR TITLE
feat(labeled-inputs): Add css variable for inline padding

### DIFF
--- a/src/inputs/labeled-inputs.scss
+++ b/src/inputs/labeled-inputs.scss
@@ -23,7 +23,8 @@
   &.iui-inline-icon {
     > .iui-input,
     > .iui-textarea {
-      padding-right: $iui-icons-default + $iui-l;
+      padding-right: ($iui-icons-default + $iui-l);
+      padding-right: var(--inline-icon-width, ($iui-icons-default + $iui-l));
 
       &:last-child {
         padding-right: $iui-sm;


### PR DESCRIPTION
Added `--inline-icon-width` variable to be set in JS (see https://github.com/iTwin/iTwinUI-react/pull/403). Allows putting any arbitrary content as the inline icon, instead of limiting to 40px icon buttons. Falls back to 40px if not specified.

Before:
![image](https://user-images.githubusercontent.com/9084735/138950746-d000d56f-198b-4cb4-a219-992e096faf64.png)
![image](https://user-images.githubusercontent.com/9084735/138950730-9c82e586-e81d-459b-ad4b-d6dc71c6c056.png)

After:
![image](https://user-images.githubusercontent.com/9084735/138950817-a468472a-cf0d-4de8-a5e1-29e236d9464b.png)
![image](https://user-images.githubusercontent.com/9084735/138950827-00976dd0-6367-4f5d-ad4b-59c540714fb1.png)

![image](https://user-images.githubusercontent.com/9084735/138956503-88cb716f-115b-41ba-939f-831aa994f070.png)
