### PR TITLE
fix(Menu): Apply text color on menu root

### DIFF
--- a/src/menu/menu.scss
+++ b/src/menu/menu.scss
@@ -10,6 +10,7 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
   box-shadow: $iui-elevation-2;
   @include themed {
     background-color: t(iui-color-background-1);
+    color: t(iui-text-color);
   }
 }
 
@@ -46,9 +47,6 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
   cursor: pointer;
   box-sizing: border-box;
   line-height: normal;
-  @include themed {
-    color: t(iui-text-color);
-  }
 
   + #{&} {
     margin-top: -1px;


### PR DESCRIPTION
Moved text color from iui-menu-item into iui-menu so that it can be inherited by iui-menu-content as well.

Fixes #368