### PR TITLE
feat(Table): Add scroll snapping

### DIFF
--- a/backstop/tests/table.html
+++ b/backstop/tests/table.html
@@ -2150,7 +2150,8 @@
     <hr />
 
     <h2>Additional options</h2>
-    <p class="iui-text-small iui-text-muted">Sticky header, zebra striping, pagination, & editable cells.</p><br />
+    <p class="iui-text-small iui-text-muted">Sticky header, zebra striping, pagination, editable cells, & scroll
+      snapping.</p><br />
     <section id="demo-extras">
 
       <div
@@ -2203,7 +2204,7 @@
           </div>
         </div>
 
-        <div class="iui-table-body">
+        <div class="iui-table-body iui-scroll-snapping">
           <div class="iui-row">
             <div
               class="iui-cell iui-main-column"
@@ -2657,7 +2658,7 @@
           </div>
         </div>
 
-        <div class="iui-table-body">
+        <div class="iui-table-body iui-scroll-snapping">
           <div class="iui-row">
             <div
               class="iui-cell iui-main-column"
@@ -2922,7 +2923,7 @@
           </div>
         </div>
 
-        <div class="iui-table-body">
+        <div class="iui-table-body iui-scroll-snapping">
           <div class="iui-row">
             <div
               class="iui-cell iui-main-column"

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -160,7 +160,7 @@
   }
 }
 
-/// Adds the ability to toggle vertical scroll snapping by setting `.iui-scroll-snapping` as a modifier or at root level if used outside a class.
+/// Adds the ability to toggle vertical scroll snapping by setting `.iui-scroll-snapping` as a modifier (if used inside a class) or at root level.
 /// @arg $selector - selector to apply `scroll-snap-align: start` on. Defaults to '> *'
 @mixin iui-scroll-snapping($selector: '> *') {
   #{if(&, '&.iui-scroll-snapping', '.iui-scroll-snapping')} {

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -166,3 +166,9 @@
     }
   }
 }
+
+@mixin iui-scroll-snapping {
+  .iui-scroll-snapping {
+    scroll-snap-type: y mandatory;
+  }
+}

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -159,7 +159,7 @@
     }
   }
 }
-
+/// Mixin allows scroll snapping to a specific class if .iui-scroll-snapping is applied to the parent
 @mixin iui-scroll-snapping($selector: '> *') {
   .iui-scroll-snapping {
     scroll-snap-type: y mandatory;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -159,7 +159,8 @@
     }
   }
 }
-/// Mixin allows scroll snapping to a specific class if .iui-scroll-snapping is applied to the parent
+/// Adds the ability to toggle vertical scroll snapping using .iui-scroll-snapping class.
+/// @arg $selector - selector to apply `scroll-snap-align: start` on. Defaults to '> *'
 @mixin iui-scroll-snapping($selector: '> *') {
   .iui-scroll-snapping {
     scroll-snap-type: y mandatory;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -167,8 +167,12 @@
   }
 }
 
-@mixin iui-scroll-snapping {
+@mixin iui-scroll-snapping($selector: '> *') {
   .iui-scroll-snapping {
     scroll-snap-type: y mandatory;
+
+    #{$selector} {
+      scroll-snap-align: start;
+    }
   }
 }

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -159,10 +159,11 @@
     }
   }
 }
-/// Adds the ability to toggle vertical scroll snapping using .iui-scroll-snapping class.
+
+/// Adds the ability to toggle vertical scroll snapping by setting `.iui-scroll-snapping` as a modifier or at root level if used outside a class.
 /// @arg $selector - selector to apply `scroll-snap-align: start` on. Defaults to '> *'
 @mixin iui-scroll-snapping($selector: '> *') {
-  .iui-scroll-snapping {
+  #{if(&, '&.iui-scroll-snapping', '.iui-scroll-snapping')} {
     scroll-snap-type: y mandatory;
 
     #{$selector} {

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -126,6 +126,7 @@
   overflow-x: hidden;
   overflow-y: scroll;
   overflow-y: overlay;
+  scroll-snap-type: y mandatory;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -137,6 +138,7 @@
   .iui-row {
     display: flex;
     border: solid 1px transparent;
+    scroll-snap-align: start;
     @media (prefers-reduced-motion: no-preference) {
       transition: border $iui-speed-fast ease-out;
     }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,7 +20,6 @@
   }
 
   @include iui-table-cell-icon;
-  @include iui-scroll-snapping('.iui-row');
 }
 
 @mixin iui-table-header {
@@ -130,6 +129,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  @include iui-scroll-snapping('.iui-row');
   @include themed {
     background-color: t(iui-color-background-1);
   }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,6 +20,8 @@
   }
 
   @include iui-table-cell-icon;
+
+  /// Mixin allows scroll snapping to individual table rows if .iui-scroll-snapping is applied to the table
   @include iui-scroll-snapping('.iui-row');
 }
 

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,8 +20,6 @@
   }
 
   @include iui-table-cell-icon;
-
-  /// Mixin allows scroll snapping to individual table rows if .iui-scroll-snapping is applied to the table
   @include iui-scroll-snapping('.iui-row');
 }
 

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,6 +20,7 @@
   }
 
   @include iui-table-cell-icon;
+  @include iui-scroll-snapping;
 }
 
 @mixin iui-table-header {
@@ -133,17 +134,10 @@
     background-color: t(iui-color-background-1);
   }
 
-  &.iui-scroll-snapping {
-    scroll-snap-type: y mandatory;
-
-    .iui-row {
-      scroll-snap-align: start;
-    }
-  }
-
   .iui-row {
     display: flex;
     border: solid 1px transparent;
+    scroll-snap-align: start;
     @media (prefers-reduced-motion: no-preference) {
       transition: border $iui-speed-fast ease-out;
     }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,7 +20,7 @@
   }
 
   @include iui-table-cell-icon;
-  @include iui-scroll-snapping;
+  @include iui-scroll-snapping($selector: '.iui-row');
 }
 
 @mixin iui-table-header {
@@ -137,7 +137,6 @@
   .iui-row {
     display: flex;
     border: solid 1px transparent;
-    scroll-snap-align: start;
     @media (prefers-reduced-motion: no-preference) {
       transition: border $iui-speed-fast ease-out;
     }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -126,19 +126,24 @@
   overflow-x: hidden;
   overflow-y: scroll;
   overflow-y: overlay;
-  scroll-snap-type: y mandatory;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-
   @include themed {
     background-color: t(iui-color-background-1);
+  }
+
+  &.iui-scroll-snapping {
+    scroll-snap-type: y mandatory;
+
+    .iui-row {
+      scroll-snap-align: start;
+    }
   }
 
   .iui-row {
     display: flex;
     border: solid 1px transparent;
-    scroll-snap-align: start;
     @media (prefers-reduced-motion: no-preference) {
       transition: border $iui-speed-fast ease-out;
     }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -20,7 +20,7 @@
   }
 
   @include iui-table-cell-icon;
-  @include iui-scroll-snapping($selector: '.iui-row');
+  @include iui-scroll-snapping('.iui-row');
 }
 
 @mixin iui-table-header {


### PR DESCRIPTION
Adds `iui-scroll-snapping` mixin to `.iui-table-body` to enable Y-axis scroll snapping. Closes #378.