### PR TITLE
fix(Label): Change display style according to modifier

### DIFF
--- a/src/inputs/classes.scss
+++ b/src/inputs/classes.scss
@@ -38,10 +38,6 @@
 
 .iui-input-label {
   @include iui-input-label;
-
-  &.iui-inline {
-    @include iui-input-label-inline;
-  }
 }
 
 .iui-input {

--- a/src/inputs/labeled-inputs.scss
+++ b/src/inputs/labeled-inputs.scss
@@ -164,7 +164,8 @@
 
   &.iui-required {
     &::after {
-      content: ' *';
+      content: '*';
+      margin-left: $iui-xs;
       @include themed {
         color: t(iui-color-foreground-negative);
       }
@@ -192,10 +193,17 @@
 }
 
 /// Independent label outside the grid.
+/// Supports .iui-inline modifier to place it inline.
 @mixin iui-input-label {
   @include iui-input-label-styling;
   @include iui-input-label-cursor;
-  display: inline-block;
+  display: block;
+
+  &.iui-inline {
+    @include iui-input-label-inline;
+    display: inline-flex;
+    align-items: center;
+  }
 }
 
 /// Message shown below input


### PR DESCRIPTION
Improvements to `iui-input-label`:
- Set default `display` to `block`, because it was placing inline elements next to it.
  - Before (span in pink, should have been in next line):
    ![](https://user-images.githubusercontent.com/9084735/141806014-0ddac842-603b-41b5-b93c-c32e69b24db4.png)
- Changed to `display: inline-flex` when iui-inline is set, and fixed alignment.
  - Before:
    ![image](https://user-images.githubusercontent.com/9084735/141825884-70e2c16d-6213-4037-bd20-0099d233173f.png)
- Added left margin to the required asterisk pseudo-element.
  - Without margin, space is not respected in inline display:
    ![image](https://user-images.githubusercontent.com/9084735/141826102-b1fcedfc-5481-46cf-892e-61a4252f2998.png)