### PR TITLE
fix(ButtonGroup): Use flex instead of position to set z-index

### DIFF
--- a/src/button/button-group.scss
+++ b/src/button/button-group.scss
@@ -10,16 +10,22 @@
   $childSelector: 'input, button'; // target nested inputs and buttons
 
   > * {
+    display: flex;
+
     #{$childSelector} {
-      &:hover,
-      &:focus,
-      &:focus-within {
-        position: relative;
+      &:hover {
         z-index: 1;
       }
 
+      &:focus {
+        z-index: 2;
+
+        &:where(:not(:focus-visible):not(:hover)) {
+          z-index: revert;
+        }
+      }
+
       &:disabled {
-        position: relative;
         z-index: -1;
       }
 

--- a/src/table/paginator.scss
+++ b/src/table/paginator.scss
@@ -40,7 +40,6 @@
 
       > * {
         margin-right: 0; // unset negative margin from button-group
-        display: flex; // for vertically aligning svgs
 
         > .iui-button,
         > .iui-ellipsis {


### PR DESCRIPTION
Changed z-index approach to rely on `display: flex` instead of `position: relative` to fix this weird bug:
![zindex](https://user-images.githubusercontent.com/9084735/146606519-e87aeda1-4e0f-48c6-b603-fc7de2157cc1.gif)

Also changed logic a little to give focus priority over hover, and added correct focus-visible behavior.
