### PR TITLE
fix(ButtonGroup): Disable exit animation to prevent flicker

### DIFF
--- a/src/button/button-group.scss
+++ b/src/button/button-group.scss
@@ -29,6 +29,13 @@
         z-index: -1;
       }
 
+      transition-duration: 0ms; // disable exit animation to avoid border flicker
+
+      &:hover,
+      &:focus {
+        transition-duration: $iui-speed-fast; // re-enable enter animation
+      }
+
       // Adds stripe above active button
       &.iui-active {
         &::after {

--- a/src/table/paginator.scss
+++ b/src/table/paginator.scss
@@ -50,11 +50,6 @@
           }
         }
 
-        > .iui-button {
-          // Animation looks odd when switching pages
-          transition: none;
-        }
-
         > .iui-ellipsis {
           display: flex;
           justify-content: center;


### PR DESCRIPTION
Reset base transition-duration to disable _exit_ animation on hover/focus to prevent border flicker when moving between buttons. Added back transition-duration for hover/focus to enable _enter_ animation.

Before:
![before](https://user-images.githubusercontent.com/9084735/146811916-c6923b70-5dac-4b50-b91c-ad908f5af023.gif)

After (slowed down):
![after](https://user-images.githubusercontent.com/9084735/146811942-44bcc038-8907-4c69-b4a5-cb413c6dd1c1.gif)

