### PR TITLE
fix(ButtonGroup): Add back position: relative to fix z-index issue

### DIFF
--- a/src/button/button-group.scss
+++ b/src/button/button-group.scss
@@ -13,6 +13,8 @@
     display: flex;
 
     #{$childSelector} {
+      position: relative;
+
       &:hover {
         z-index: 1;
       }


### PR DESCRIPTION
Added `position: relative` to child selector to fix the issue in storybook (#418 didn't fix it). Previously it was set on hover/focus/disabled states but now it's always set regardless, and it seems to fix the issue in Chrome 96