### PR TITLE
chore(button-group): Reduce specificity of negative margin

### DIFF
--- a/src/button/button-group.scss
+++ b/src/button/button-group.scss
@@ -84,8 +84,8 @@
     }
 
     // Use negative margin to make adjacent borders overlap
-    &:not(:last-child) {
-      margin-right: -1px;
+    + * {
+      margin-left: -1px;
     }
 
     // Add slight border between disabled items

--- a/src/table/paginator.scss
+++ b/src/table/paginator.scss
@@ -66,15 +66,13 @@
   @include iui-button-group;
   margin: 0 $iui-s;
 
-  > * {
-    &:not(:last-child) {
-      margin-right: 0; // unset negative margin from button-group
-    }
+  > * + * {
+    margin-left: 0; // unset negative margin from button-group
+  }
 
-    button.iui-active::after {
-      top: auto;
-      bottom: $iui-xxs;
-    }
+  button.iui-active::after {
+    top: auto;
+    bottom: $iui-xxs;
   }
 }
 


### PR DESCRIPTION
Now using owl selector (* + *) instead of last-child to lower specificity. Flipped from margin-right to margin-left.