### PR TITLE
fix(Menu): Add missing class name for button dropdowns

### DIFF
--- a/backstop/tests/menu.html
+++ b/backstop/tests/menu.html
@@ -1102,7 +1102,7 @@
       </ul>
       <br />
 
-      <button class="iui-button iui-dropdown">
+      <button class="iui-button iui-default iui-dropdown">
         <svg-placeholder
           class="iui-button-icon"
           aria-hidden="true"
@@ -1201,7 +1201,7 @@
       </ul>
       <br />
 
-      <button class="iui-button iui-large iui-dropdown">
+      <button class="iui-button iui-default iui-large iui-dropdown">
         <svg-placeholder
           class="iui-button-icon"
           aria-hidden="true"


### PR DESCRIPTION
2 of the dropdown buttons within `menu.html` were missing the `.iui-default` class.
![Screen Shot 2022-01-11 at 11 44 17 PM](https://user-images.githubusercontent.com/849817/149065235-d1d4aca8-da7c-47fc-a864-9b0f49e53c6c.png)