### PR TITLE
chore: Updated node-fetch to non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "glob-parent": "^5.1.2",
     "jpeg-js": "^0.4.3",
     "set-value": "^4.1.0",
-    "ansi-regex": "^5.0.1"
+    "ansi-regex": "^5.0.1",
+    "node-fetch": "^2.6.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,10 +3212,10 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-fetch@2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
-  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+node-fetch@2.6.5, node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36186912/150740778-b8ef3281-b42e-4a5e-95f1-da0f6d07f5c1.png)
https://github.com/iTwin/iTwinUI/security/dependabot/yarn.lock/node-fetch/open