### PR TITLE
fix(Tree): Fix tree focus

### DIFF
--- a/src/tree/tree.scss
+++ b/src/tree/tree.scss
@@ -91,7 +91,7 @@ $iui-expander-button-width: ($iui-icons-default) + ($iui-expander-inline-padding
   }
 
   &:focus:not(:focus-visible) {
-    outline-offset: -2px;
+    outline: none;
   }
 
   &:hover {
@@ -108,10 +108,13 @@ $iui-expander-button-width: ($iui-icons-default) + ($iui-expander-inline-padding
   }
 
   &.iui-active {
-    @include themed {
-      background-color: rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-5));
-      outline: $iui-active-outline;
-      outline-offset: -1px;
+    &,
+    &:focus:not(:focus-visible) {
+      @include themed {
+        background-color: rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-5));
+        outline: $iui-active-outline;
+        outline-offset: -1px;
+      }
     }
 
     &:focus {

--- a/src/tree/tree.scss
+++ b/src/tree/tree.scss
@@ -83,16 +83,7 @@ $iui-expander-button-width: ($iui-icons-default) + ($iui-expander-inline-padding
     }
   }
 
-  &:focus {
-    @include themed {
-      outline: 1px solid t(iui-color-foreground-primary);
-    }
-    outline-offset: -1px;
-  }
-
-  &:focus:not(:focus-visible) {
-    outline: none;
-  }
+  @include iui-focus;
 
   &:hover {
     @include themed {
@@ -108,19 +99,13 @@ $iui-expander-button-width: ($iui-icons-default) + ($iui-expander-inline-padding
   }
 
   &.iui-active {
-    &,
-    &:focus:not(:focus-visible) {
-      @include themed {
-        background-color: rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-5));
-        outline: $iui-active-outline;
-        outline-offset: -1px;
-      }
+    @include themed {
+      background-color: rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-5));
+      outline: $iui-active-outline;
+      outline-offset: -1px;
     }
 
-    &:focus {
-      outline-width: $iui-xxs;
-      outline-offset: -2px;
-    }
+    @include iui-focus($offset: -2px, $thickness: $iui-xxs);
   }
 
   &.iui-disabled {


### PR DESCRIPTION
Fixed focus on tree nodes, removed focus outline that showed when selecting and unselecting tree nodes.

Before:
![treeFocus](https://user-images.githubusercontent.com/88331924/151203055-8314e046-3c8d-4e7e-b9f5-d5381fca173c.gif)

After:
![treeFocusAfter](https://user-images.githubusercontent.com/88331924/151203070-a7c9f1fd-aa35-463d-aa39-6d12e842d4d1.gif)
