### PR TITLE
fix(Table): Zebra row selector change

### DIFF
--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -135,7 +135,7 @@
     background-color: t(iui-color-background-1);
   }
 
-  &.iui-zebra-striping > .iui-row:nth-child(even):not(.iui-selected) {
+  &.iui-zebra-striping .iui-row:nth-child(even):not(.iui-selected) {
     @include themed {
       background-color: rgba(t(iui-color-foreground-body-rgb), 0.02);
     }


### PR DESCRIPTION
After adding VirtualScroll https://github.com/iTwin/iTwinUI-react/pull/236, some styles broke as noticed in https://github.com/iTwin/iTwinUI-react/pull/236#discussion_r793049030
After checking the selectors, I think only Zebra rows were looking for direct children.
Changed this one which should fix the issue.