### PR TITLE
fix: Added Popover helper class

### DIFF
--- a/src/classes.scss
+++ b/src/classes.scss
@@ -25,6 +25,7 @@
 @import './modal/classes';
 @import './non-ideal-state/classes';
 @import './notification-marker/classes';
+@import './popover/classes';
 @import './progress-indicator/classes';
 @import './side-navigation/classes';
 @import './slider/classes';

--- a/src/index.scss
+++ b/src/index.scss
@@ -23,6 +23,7 @@
 @import './modal/index';
 @import './non-ideal-state/index';
 @import './notification-marker/index';
+@import './popover/index';
 @import './progress-indicator/index';
 @import './side-navigation/index';
 @import './slider/index';

--- a/src/popover/classes.scss
+++ b/src/popover/classes.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+
+// tippy.js helper class to hide Popover when it is scrolled out of view
+.iui-popover[data-popper-reference-hidden] {
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/src/popover/index.scss
+++ b/src/popover/index.scss
@@ -1,7 +1,3 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 // See LICENSE.md in the project root for license terms and full copyright notice.
-@import './index';
-
-.iui-popover {
-  @include iui-popover;
-}
+@import './popover';

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -3,7 +3,7 @@
 
 // tippy.js helper class to hide Popover when it is scrolled out of view
 @mixin iui-popover {
-  &[data-popper-reference-hidden] {
+  &[data-reference-hidden] {
     visibility: hidden;
     pointer-events: none;
   }

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -1,0 +1,10 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+
+// tippy.js helper class to hide Popover when it is scrolled out of view
+@mixin iui-popover {
+  &[data-popper-reference-hidden] {
+    visibility: hidden;
+    pointer-events: none;
+  }
+}

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -12,11 +12,11 @@
   // Resets tippy.js default stylings that interfere with our own
   /* stylelint-disable-next-line selector-class-pattern */
   &.tippy-box {
-    all: initial;
+    all: revert;
   }
 
   /* stylelint-disable-next-line selector-class-pattern */
   .tippy-content {
-    all: initial;
+    all: revert;
   }
 }

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -12,11 +12,11 @@
   // Resets tippy.js default stylings that interfere with our own
   /* stylelint-disable-next-line selector-class-pattern */
   &.tippy-box {
-    all: revert;
+    all: initial;
   }
 
   /* stylelint-disable-next-line selector-class-pattern */
   .tippy-content {
-    all: revert;
+    all: initial;
   }
 }

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -1,10 +1,22 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 // See LICENSE.md in the project root for license terms and full copyright notice.
+@import '../style/index';
 
 // tippy.js helper class to hide Popover when it is scrolled out of view
 @mixin iui-popover {
   &[data-reference-hidden] {
     visibility: hidden;
     pointer-events: none;
+  }
+
+  // Resets tippy.js default stylings that interfere with our own
+  /* stylelint-disable-next-line selector-class-pattern */
+  &.tippy-box {
+    all: revert;
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  .tippy-content {
+    all: revert;
   }
 }


### PR DESCRIPTION
It is meant to be used only in React as it helps to easily hide tooltips, menus and other these kind of components when they are out of view.

This should help to fix https://github.com/iTwin/iTwinUI-react/issues/529