### PR TITLE
fix(Button): Show default outline as fallback

### DIFF
--- a/src/button/button.scss
+++ b/src/button/button.scss
@@ -20,7 +20,6 @@ $iui-button-padding-large: $iui-xs * 6;
   box-sizing: border-box;
   border-radius: $iui-border-radius;
   line-height: $iui-line-height;
-  outline: none;
   box-shadow: none;
   font-size: $iui-font-size;
   font-weight: $iui-font-weight-normal;


### PR DESCRIPTION
There was a huge accessibility oversight in #166 as it completely breaks focus styles in older versions of Safari and IE. `outline: none` should almost never be used except inside `:focus-visible` sometimes. I've removed it so that the default focus outline is shown in older browsers which dont support `@supports selector`.