### PR TITLE
fix(ColorSwatch): Fix absolute positioning when used in button

### DIFF
--- a/src/color-picker/color-picker.scss
+++ b/src/color-picker/color-picker.scss
@@ -58,6 +58,8 @@ $iui-hover-box-shadow: 0 0 1px $iui-xxs + 1 rgba(var(--iui-color-foreground-body
   &::after {
     content: '';
     position: absolute;
+    left: 0;
+    top: 0;
     width: inherit;
     height: inherit;
     border-radius: inherit;


### PR DESCRIPTION
Not sure how it was working in color-palette before, without any positioning specified.

Before:
![image](https://user-images.githubusercontent.com/9084735/155228007-774ed859-02da-49eb-ad6e-cd2015622a4b.png)

After:
![image](https://user-images.githubusercontent.com/9084735/155228031-4054786f-1bf3-4212-a3d6-d1c8f4d0ccfe.png)
