### PR TITLE
ci: Exclude main branch when creating check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           git-config-email: github-actions[bot]@users.noreply.github.com
 
       - name: Post gh pages link under Checks
-        if: always()
+        if: github.ref != 'refs/heads/main'
         uses: actions/github-script@v5
         with:
           script: |


### PR DESCRIPTION
This should fix the failing build in main branch.