### PR TITLE
fix(ButtonGroup): Add max width/height for overflow calculations

### DIFF
--- a/src/button/button-group.scss
+++ b/src/button/button-group.scss
@@ -10,8 +10,11 @@
   align-items: center;
   isolation: isolate;
 
-  @if $orientation != 'horizontal' {
+  @if $orientation == 'horizontal' {
+    max-width: 100%;
+  } @else {
     flex-direction: column;
+    max-height: 100%;
   }
 
   $childZindexSelector: '.iui-input-container, .iui-button, .iui-input:where(:not(.iui-input-container .iui-input))';


### PR DESCRIPTION
Previously (before vertical), we were adding `width: 100%` as an inline style when overflow was used. Apparently we can use `max-width`/`max-height` instead of `width`/`height` so it makes sense to just add it to the base CSS.

This will help towards https://github.com/iTwin/iTwinUI-react/pull/579
