### PR TITLE
chore(Styles): Add text selection mixin

### DIFF
--- a/src/alert/alert.scss
+++ b/src/alert/alert.scss
@@ -79,11 +79,7 @@
   }
 
   #{$rootSelector}-message {
-    &::selection {
-      @include themed {
-        background-color: rgba(t(iui-color-foreground-#{$statusColor}-rgb), t(iui-opacity-4));
-      }
-    }
+    @include iui-text-selection($statusColor);
   }
 
   #{$rootSelector}-link {

--- a/src/inputs/labeled-inputs.scss
+++ b/src/inputs/labeled-inputs.scss
@@ -300,11 +300,7 @@
 /// @arg iconSelector - selector to apply status fill on. Defaults to .iui-input-icon
 /// @arg textSelector - selector to apply text color on. Defaults to .iui-message
 @mixin iui-input-status($status, $iconSelector: '.iui-input-icon', $textSelector: '.iui-message') {
-  *::selection {
-    @include themed {
-      background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-4));
-    }
-  }
+  @include iui-text-selection($status);
 
   #{$iconSelector} {
     @include themed {

--- a/src/progress-indicator/linear.scss
+++ b/src/progress-indicator/linear.scss
@@ -71,11 +71,7 @@
       }
 
       > span {
-        &::selection {
-          @include themed {
-            background-color: rgba(t(iui-color-foreground-positive-rgb), t(iui-opacity-4));
-          }
-        }
+        @include iui-text-selection(positive);
       }
     }
   }
@@ -101,11 +97,7 @@
       }
 
       > span {
-        &::selection {
-          @include themed {
-            background-color: rgba(t(iui-color-foreground-negative-rgb), t(iui-opacity-4));
-          }
-        }
+        @include iui-text-selection(negative);
       }
     }
   }

--- a/src/style/global.scss
+++ b/src/style/global.scss
@@ -26,11 +26,7 @@
 [class*='iui-'],
 [class*='iui-'] * {
   // Text highlight
-  ::selection {
-    @include themed {
-      background-color: rgba(t(iui-color-foreground-primary-rgb), t(iui-opacity-4));
-    }
-  }
+  @include iui-text-selection;
 
   // Scrollbar
   @include iui-scrollbar;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -63,6 +63,15 @@
   }
 }
 
+@mixin iui-text-selection($status: primary) {
+  &::selection,
+  *::selection {
+    @include themed {
+      background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-5));
+    }
+  }
+}
+
 @mixin iui-scrollbar {
   @include themed {
     scrollbar-color: rgba(t(iui-color-foreground-body-rgb), t(iui-opacity-4)) transparent;

--- a/src/style/mixins.scss
+++ b/src/style/mixins.scss
@@ -67,7 +67,7 @@
   &::selection,
   *::selection {
     @include themed {
-      background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-5));
+      background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-4));
     }
   }
 }

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -391,11 +391,7 @@
       box-shadow: inset $iui-xxs 0 0 0 t(iui-icons-color-#{$status});
     }
 
-    *::selection {
-      @include themed {
-        background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-4));
-      }
-    }
+    @include iui-text-selection($status);
   }
 
   .iui-cell-end-icon svg {
@@ -410,11 +406,7 @@
     background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-6));
   }
 
-  &::selection {
-    @include themed {
-      background-color: rgba(t(iui-color-foreground-#{$status}-rgb), t(iui-opacity-4));
-    }
-  }
+  @include iui-text-selection($status);
 }
 
 @mixin iui-table-cell-icon {

--- a/src/toast-notification/categories.scss
+++ b/src/toast-notification/categories.scss
@@ -10,11 +10,7 @@
   }
 
   > .iui-message {
-    &::selection {
-      @include themed {
-        background-color: rgba(t(iui-color-foreground-#{$category}-rgb), t(iui-opacity-4));
-      }
-    }
+    @include iui-text-selection($category);
   }
 
   > .iui-status-area {


### PR DESCRIPTION
These components use `::selection`:
- Alert
- Labeled inputs
- Progress indicator
- Table
- Toast notification

This PR adds `@mixin iui-text-selection;` so the opacity is always in sync across components.