### PR TITLE
fix(Radio): Remove redudant wrapper styles

### DIFF
--- a/src/inputs/radio.scss
+++ b/src/inputs/radio.scss
@@ -3,10 +3,6 @@
 @import '../style/index';
 
 @mixin iui-radio {
-  &-wrapper {
-    @include iui-inputs-checkbox-radio;
-  }
-
   @include iui-checkbox;
 
   border-radius: 50%;


### PR DESCRIPTION
The `iui-checkbox` mixin already includes the wrapper smixin so it doesn't need to be included again.