### PR TITLE
ci: Allow publishing to npm manually

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  publish:
+    name: Build and publish output to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node 16.X
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          registry-url: https://registry.npmjs.org/
+
+      - run: yarn install
+      - run: yarn build
+
+      - run: npm publish --access public
+        working-directory: "./lib"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,21 +26,7 @@ jobs:
     if: needs.release-please.outputs.release-created
 
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node 16.X
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          registry-url: https://registry.npmjs.org/
-
-      - run: yarn install
-      - run: yarn build
-
-      - run: npm publish --access public
-        working-directory: './lib'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+      - uses: ./.github/workflows/publish-npm.yml
 
   fix-title:
     name: Edit release title


### PR DESCRIPTION

Moved npm publish into separate file so that it's possible to trigger it manually using `workflow_dispatch`.

Also now reusing that workflow in release-please through the `workflow_call` trigger.