### PR TITLE
ci: Add checkout to release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
     if: needs.release-please.outputs.release-created
 
     steps:
+      - uses: actions/checkout@v2
       - uses: ./.github/workflows/publish-npm.yml
 
   fix-title:


### PR DESCRIPTION
The recent auto-publishing to npm failed: https://github.com/iTwin/iTwinUI/runs/5644297298?check_suite_focus=true

The error message suggesting adding checkout, so my hope is that this will be enough to fix it.