### PR TITLE
ci: Fix gh-pages link using `always()` in if condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           git-config-email: github-actions[bot]@users.noreply.github.com
 
       - name: Post gh pages link under Checks
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && always()
         uses: actions/github-script@v5
         with:
           script: |

--- a/backstop/tests/alert.html
+++ b/backstop/tests/alert.html
@@ -63,9 +63,7 @@
         class="iui-alert-icon"
         aria-hidden="true"
       ></svg-info-circular>
-      <span class="iui-alert-message">
-        THIS SHOULD FAIL
-        This is a sticky alert.
+      <span class="iui-alert-message">This is a sticky alert.
         <a
           class="iui-alert-link"
           href="#"

--- a/backstop/tests/alert.html
+++ b/backstop/tests/alert.html
@@ -63,7 +63,9 @@
         class="iui-alert-icon"
         aria-hidden="true"
       ></svg-info-circular>
-      <span class="iui-alert-message">This is a sticky alert.
+      <span class="iui-alert-message">
+        THIS SHOULD FAIL
+        This is a sticky alert.
         <a
           class="iui-alert-link"
           href="#"


### PR DESCRIPTION
Using `always()` allows the step to be called when there is a failure in a preceeding step. This will fix the gh-pages link not getting posted after #497.