### PR TITLE
ci: revert build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,8 @@ jobs:
           git-config-email: github-actions[bot]@users.noreply.github.com
 
       - name: Post gh pages link under Checks
-        if: github.ref != 'refs/heads/main' && always()
-        uses: actions/github-script@v5
+        if: failure()
+        uses: actions/github-script@v6
         with:
           script: |
             github.rest.repos.createCommitStatus({
@@ -59,8 +59,8 @@ jobs:
               sha: '${{ github.event.pull_request.head.sha }}',
               state: '${{ job.status }}',
               context: 'Test results',
-              ...(context.job.status !== 'success' && { description: 'Backstop html report' }),
-              ...(context.job.status !== 'success' && { target_url: 'https://itwin.github.io/iTwinUI/${{ github.event.number }}/html_report/' }),
+               description: 'Backstop html report',
+              target_url: 'https://itwin.github.io/iTwinUI/${{ github.event.number }}/html_report/'
             })
 
   deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
               sha: '${{ github.event.pull_request.head.sha }}',
               state: '${{ job.status }}',
               context: 'Test results',
-               description: 'Backstop html report',
+              description: 'Backstop html report',
               target_url: 'https://itwin.github.io/iTwinUI/${{ github.event.number }}/html_report/'
             })
 

--- a/src/alert/alert.scss
+++ b/src/alert/alert.scss
@@ -12,7 +12,7 @@
   align-items: center;
   @include themed {
     border: 1px solid t(iui-color-background-5);
-    color: rgba(81, 36, 170, 0.37);
+    color: t(iui-text-color);
     background-color: t(iui-color-background-1);
   }
 

--- a/src/alert/alert.scss
+++ b/src/alert/alert.scss
@@ -12,7 +12,7 @@
   align-items: center;
   @include themed {
     border: 1px solid t(iui-color-background-5);
-    color: t(iui-text-color);
+    color: rgba(81, 36, 170, 0.37);
     background-color: t(iui-color-background-1);
   }
 


### PR DESCRIPTION
Just revert the script to previous code.
If my guess is right, we would have only issue when failed tests are rerun and we have deploy step marked as red.
But if this fixes our current deployed pages issues, I think it is fine for now.