### PR TITLE
chore: fix reusing workflow syntax

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,13 +21,9 @@ jobs:
 
   publish:
     name: Publish npm package
-    runs-on: ubuntu-latest
     needs: release-please
     if: needs.release-please.outputs.release-created
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/workflows/publish-npm.yml
+    uses: ./.github/workflows/publish-npm.yml
 
   fix-title:
     name: Edit release title


### PR DESCRIPTION
According to [this doc](https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow), calling workflow should be done directly within the job, not steps.

So hopefully, this fixes
https://github.com/iTwin/iTwinUI/runs/5716829567?check_suite_focus=true