### PR TITLE
fix(DatePicker): Make element inline

### DIFF
--- a/src/date-picker/date-picker.scss
+++ b/src/date-picker/date-picker.scss
@@ -11,7 +11,7 @@ $iui-date-picker-today-circle-size: 32px;
 @mixin iui-date-picker {
   @include iui-surface;
   user-select: none;
-  display: grid;
+  display: inline-grid;
   grid-template-columns: 1fr auto;
 
   .iui-time-picker {


### PR DESCRIPTION
As I removed explicit width from DatePicker and we have `fit-content` in all our css, I didnt notice that this will happen...

![image](https://user-images.githubusercontent.com/81580355/160374834-ebedcede-2aeb-40fd-bbf5-1b38d3cbf660.png)

Switched to `inline-grid` to fix this.