### PR TITLE
chore: Pass auth token on auto release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,9 @@ name: Publish to npm
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      NPMJS_PUBLISH_ITWIN:
+        required: true
 
 jobs:
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,8 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release-created
     uses: ./.github/workflows/publish-npm.yml
+    secrets:
+      NPMJS_PUBLISH_ITWIN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
 
   fix-title:
     name: Edit release title


### PR DESCRIPTION
So our auto release is failing and the guess is that it needs auth token to be passed explicitly to the reused workflow.