### PR TITLE
fix(ColorPicker): Add `forced-colors` support.

### DIFF
--- a/src/color-picker/color-picker.scss
+++ b/src/color-picker/color-picker.scss
@@ -49,6 +49,7 @@ $iui-hover-box-shadow: 0 0 1px $iui-xxs + 1 rgba(var(--iui-color-foreground-body
   margin-right: $iui-xs;
   position: relative;
   background-color: var(--iui-color-swatch-background);
+  forced-color-adjust: none;
   @include iui-transparent-background;
   @supports (gap: $iui-s) {
     margin-bottom: 0;
@@ -172,6 +173,7 @@ $iui-hover-box-shadow: 0 0 1px $iui-xxs + 1 rgba(var(--iui-color-foreground-body
   cursor: crosshair;
   width: 100%;
   height: $iui-baseline * 19;
+  forced-color-adjust: none;
   background-image: linear-gradient(0deg, rgb(0, 0, 0), transparent),
     linear-gradient(90deg, rgb(255, 255, 255), var(--iui-color-field-hue));
 
@@ -183,6 +185,7 @@ $iui-hover-box-shadow: 0 0 1px $iui-xxs + 1 rgba(var(--iui-color-foreground-body
 @mixin iui-hue-slider {
   .iui-slider-rail {
     height: $iui-s;
+    forced-color-adjust: none;
     @include themed {
       background: linear-gradient(
         to right,
@@ -205,6 +208,7 @@ $iui-hover-box-shadow: 0 0 1px $iui-xxs + 1 rgba(var(--iui-color-foreground-body
 @mixin iui-opacity-slider {
   .iui-slider-rail {
     height: $iui-s;
+    forced-color-adjust: none;
     @include iui-transparent-background($size: $iui-s);
 
     &::before {


### PR DESCRIPTION
- Add `forced-color-adjust: none;` on color swatches, color field, and slider rails.

Before:
![Screen Shot 2022-04-01 at 5 16 15 PM](https://user-images.githubusercontent.com/849817/161342311-ddc504b3-c124-4d18-94e5-6099b337fed6.png)

After:
![Screen Shot 2022-04-01 at 5 16 30 PM](https://user-images.githubusercontent.com/849817/161342337-ba85504f-d4b8-470f-8b2a-f448c984f4f6.png)