### PR TITLE
fix(Tree): Fix spacing for tree node icon

### DIFF
--- a/src/tree/tree.scss
+++ b/src/tree/tree.scss
@@ -54,11 +54,11 @@ $iui-expander-button-width: ($iui-icons-default) + ($iui-expander-inline-padding
 
     &-icon {
       @include iui-icons-default;
-      padding: 0 $iui-expander-inline-padding;
+      margin: 0 $iui-expander-inline-padding;
       flex-shrink: 0;
 
       &:first-child {
-        margin-left: $iui-expander-button-width;
+        margin-left: $iui-expander-button-width + $iui-expander-inline-padding;
       }
     }
 


### PR DESCRIPTION
Closes #567 

I needed to increase margin left to child icon, after switching from padding to margin for the icon itself.