### PR TITLE
fix(SkipToContent): Fix Overlapping Visibility Bug

### DIFF
--- a/src/skip-to-content/skip-to-content.scss
+++ b/src/skip-to-content/skip-to-content.scss
@@ -15,8 +15,9 @@
   position: fixed;
   text-align: center;
   left: 50%;
-  opacity: 0;
   top: $iui-baseline * 2;
+  opacity: 0;
+  z-index: 99;
   transform: translateX(-50%) translateY(-170%);
   transition: background-color $iui-speed-fast ease-in-out;
   @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
The problem looks like this: 
![image](https://user-images.githubusercontent.com/37936169/161634623-04328153-18ad-476b-b5db-7a53d32679cc.png)
The result of the fix:
![image](https://user-images.githubusercontent.com/37936169/161634680-52c654d3-69cc-47f1-9f94-d8c719f74d69.png)

I added a z-index of 99 - higher than most things but lower than the modals, overlays, and toasts (and tooltips). The alternative was 998 but I thought this followed the pattern better.

**There might be other changes I want to make to this component.