### PR TITLE
fix(Popover): Hiding popover when parent element is not visible

### DIFF
--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -7,7 +7,7 @@
 @mixin iui-popover {
   &.tippy-box {
     &[data-reference-hidden] {
-      visibility: visible;
+      visibility: hidden;
       pointer-events: auto;
     }
 


### PR DESCRIPTION
Dumb mistake that popover is not hidden when its parent/reference element is not visible anymore, e.g. scrolled.