### PR TITLE
fix(Toast): Increase z-index

### DIFF
--- a/src/toast-notification/classes.scss
+++ b/src/toast-notification/classes.scss
@@ -17,7 +17,7 @@
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  z-index: 1070;
+  z-index: 50000;
 
   @media screen and (max-width: 400px) {
     width: calc(100vw - 36px);

--- a/src/toast-notification/classes.scss
+++ b/src/toast-notification/classes.scss
@@ -17,7 +17,7 @@
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  z-index: 50000;
+  z-index: 99999;
 
   @media screen and (max-width: 400px) {
     width: calc(100vw - 36px);


### PR DESCRIPTION
Increased z-index to the same value as we have for popover as toasts were not visible in modal frontstage in itwin.js.
Ideally, I think we should reuse Popover for toasts, modals, so we are sure our components are always visible.