### PR TITLE
chore: Clean up z-index values

### DIFF
--- a/src/file-upload/file-upload.scss
+++ b/src/file-upload/file-upload.scss
@@ -36,7 +36,6 @@
       opacity: 0;
       overflow: hidden;
       position: absolute;
-      z-index: -1;
     }
 
     > svg,

--- a/src/information-panel/information-panel.scss
+++ b/src/information-panel/information-panel.scss
@@ -17,7 +17,6 @@
   box-sizing: border-box;
   max-width: 100%;
   max-height: 100%;
-  z-index: 2; // Needs to be higher than table's column resizers.
   @media (prefers-reduced-motion: no-preference) {
     transition: visibility $iui-speed-instant $iui-speed-fast ease-in, transform $iui-speed-fast ease-out,
       opacity $iui-speed-fast ease;

--- a/src/radio-tile/radio-tile.scss
+++ b/src/radio-tile/radio-tile.scss
@@ -27,6 +27,7 @@
   box-sizing: border-box;
   padding: $iui-s;
   position: relative;
+  z-index: 1;
   @media (prefers-reduced-motion: no-preference) {
     transition: border-color $iui-speed-fast ease-out;
   }
@@ -36,7 +37,7 @@
   }
 
   &:hover {
-    z-index: 1;
+    z-index: 2;
     @include themed {
       border-color: rgba(t(iui-color-foreground-body-rgb), t(iui-opacity-2));
     }
@@ -81,7 +82,7 @@
 
   &:checked + * {
     padding: $iui-s - 1;
-    z-index: 2;
+    z-index: 3;
     @media (forced-colors: active) {
       border-color: Highlight;
     }
@@ -117,7 +118,7 @@
 
   &:disabled + * {
     cursor: not-allowed;
-    z-index: -1;
+    z-index: 0;
     @include themed {
       border-color: t(iui-color-background-disabled);
       background-color: t(iui-color-background-disabled);
@@ -157,7 +158,7 @@
   }
 
   &:disabled:checked + * {
-    z-index: 2;
+    z-index: 3;
     @media (forced-colors: active) {
       border-color: GrayText;
     }

--- a/src/radio-tile/radio-tile.scss
+++ b/src/radio-tile/radio-tile.scss
@@ -27,7 +27,6 @@
   box-sizing: border-box;
   padding: $iui-s;
   position: relative;
-  z-index: 1;
   @media (prefers-reduced-motion: no-preference) {
     transition: border-color $iui-speed-fast ease-out;
   }
@@ -37,7 +36,7 @@
   }
 
   &:hover {
-    z-index: 2;
+    z-index: 1;
     @include themed {
       border-color: rgba(t(iui-color-foreground-body-rgb), t(iui-opacity-2));
     }
@@ -59,7 +58,7 @@
   user-select: none;
   // Create stacking context
   position: relative;
-  z-index: 0;
+  isolation: isolate;
 }
 
 @mixin iui-radio-tile-input {
@@ -82,7 +81,7 @@
 
   &:checked + * {
     padding: $iui-s - 1;
-    z-index: 3;
+    z-index: 2;
     @media (forced-colors: active) {
       border-color: Highlight;
     }
@@ -118,7 +117,7 @@
 
   &:disabled + * {
     cursor: not-allowed;
-    z-index: 0;
+    z-index: -1;
     @include themed {
       border-color: t(iui-color-background-disabled);
       background-color: t(iui-color-background-disabled);
@@ -158,7 +157,7 @@
   }
 
   &:disabled:checked + * {
-    z-index: 3;
+    z-index: 2;
     @media (forced-colors: active) {
       border-color: GrayText;
     }

--- a/src/slider/slider.scss
+++ b/src/slider/slider.scss
@@ -41,6 +41,7 @@ $tick-height: $iui-baseline; // 11px
   flex-grow: 1;
   cursor: pointer;
   touch-action: pan-y;
+  isolation: isolate;
 
   &.iui-grabbing {
     cursor: grabbing;

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -64,7 +64,6 @@
       transform: translateX(50%);
       touch-action: none;
       cursor: ew-resize;
-      z-index: 1;
       opacity: 0;
 
       > .iui-resizer-bar {

--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -8,6 +8,7 @@
   @include iui-reset;
   display: flex;
   flex-direction: column;
+  isolation: isolate;
 
   * {
     box-sizing: border-box;
@@ -64,6 +65,7 @@
       transform: translateX(50%);
       touch-action: none;
       cursor: ew-resize;
+      z-index: 1;
       opacity: 0;
 
       > .iui-resizer-bar {

--- a/src/tile/tile.scss
+++ b/src/tile/tile.scss
@@ -197,7 +197,6 @@
   }
 
   ~ .iui-thumbnail-icon {
-    z-index: 1;
     cursor: pointer;
     @media (prefers-reduced-motion: no-preference) {
       transition: fill $iui-speed-fast ease;

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -85,7 +85,7 @@
     aspect-ratio: 1 / 1;
     border-radius: 50%;
     transition: background-color $iui-speed-fast ease-out, opacity $iui-speed-fast ease-out;
-    z-index: 2;
+    z-index: 1;
     @media (prefers-reduced-motion: no-preference) {
       transition: transform $iui-speed-fast ease-out, background-color $iui-speed-fast ease-out,
         opacity $iui-speed-fast ease-out;
@@ -141,6 +141,7 @@
 
     ~ .iui-toggle-switch-icon {
       opacity: var(--iui-opacity-1);
+      z-index: 0;
     }
   }
   // #endregion Checked toggle switch
@@ -211,7 +212,7 @@
     padding: $iui-toggle-switch-handle-size * 0.125;
     margin: $iui-toggle-switch-handle-offset + $iui-toggle-switch-border-thickness;
     display: flex;
-    z-index: 1;
+    z-index: 0;
     transition: opacity $iui-speed-fast ease-out;
     pointer-events: none;
     fill: var(--iui-color-foreground-accessory);

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -133,7 +133,7 @@
       transform: translateX($iui-toggle-switch-handle-size + $iui-toggle-switch-handle-offset);
       background-color: var(--iui-color-foreground-accessory);
       opacity: var(--iui-opacity-2);
-      @media (fozrced-colors: active) {
+      @media (forced-colors: active) {
         background-color: HighlightText;
         opacity: 1;
       }

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -85,7 +85,7 @@
     aspect-ratio: 1 / 1;
     border-radius: 50%;
     transition: background-color $iui-speed-fast ease-out, opacity $iui-speed-fast ease-out;
-    z-index: 1;
+    z-index: 2;
     @media (prefers-reduced-motion: no-preference) {
       transition: transform $iui-speed-fast ease-out, background-color $iui-speed-fast ease-out,
         opacity $iui-speed-fast ease-out;
@@ -133,7 +133,7 @@
       transform: translateX($iui-toggle-switch-handle-size + $iui-toggle-switch-handle-offset);
       background-color: var(--iui-color-foreground-accessory);
       opacity: var(--iui-opacity-2);
-      @media (forced-colors: active) {
+      @media (fozrced-colors: active) {
         background-color: HighlightText;
         opacity: 1;
       }
@@ -211,7 +211,7 @@
     padding: $iui-toggle-switch-handle-size * 0.125;
     margin: $iui-toggle-switch-handle-offset + $iui-toggle-switch-border-thickness;
     display: flex;
-    z-index: 0;
+    z-index: 1;
     transition: opacity $iui-speed-fast ease-out;
     pointer-events: none;
     fill: var(--iui-color-foreground-accessory);

--- a/src/toggle-switch/toggle-switch.scss
+++ b/src/toggle-switch/toggle-switch.scss
@@ -141,7 +141,6 @@
 
     ~ .iui-toggle-switch-icon {
       opacity: var(--iui-opacity-1);
-      z-index: 0;
     }
   }
   // #endregion Checked toggle switch


### PR DESCRIPTION
These are the following components I looked at when modifying z-index values

**button-group.scss**
- z-index values are used for prioritizing overlapping borders for disabled, hovered, and focused buttons
- **Solution:** I left this alone.

**file-upload.scss**
- z-index value was used so that `cursor: pointer` is applied to `iui-browse-input`, but the size of the element is really small and I'm not sure why it isn't `0 x 0`.
- **Solution:** Removed z-index.

**information-panel.scss**
- z-index was used to make sure the information panel was in front of the column resizer. However, since the information panel comes after the table in the HTML I don't see a need for it.
- **Solution:** Removed z-index for both information panel and table resizer.

**radio-tile.scss**
- Similar to button group, z index was used to prioritize overlapping borders for disabled, hovered, focused, and checked radio tiles.
- **Solution:** Decremented all z-index values by 1 and added `isolation: isolate` to `iui-radio-tile-container`.

**slider.scss**
- z-index is used to keep `iui-slider-thumb` above `iui-slider-ticks`. I tried fixing this by placing the `iui-slider-ticks` before the `iui-slider-thumb` in the HTML, but that caused issues with the `iui-tooltip` positioning.
- **Solution:** Left z-index alone, but added `isolation: isolate` to the slider container.

**table.scss**
- z-index was used for the table resizer.
- **Solution:** Removed z-index.

**tile.scss**
- z-index was used on thumbnail icons for tiles which already had a thumbnail.
- **Solution:** Removed z-index.

**toggle-switch.scss**
- z-index is used for hiding an icon when unchecking a switch. `iui-toggle-switch-icon` is initially set to `z-index: 1`, but `iui-toggle-switch` gets switched to `z-index: 2` while it's being unchecked.
- **Solution:** Decremented each z-index value by 1.