### PR TITLE
fix(Breadcrumbs): `color` is not updating

### DIFF
--- a/backstop/tests/breadcrumbs.html
+++ b/backstop/tests/breadcrumbs.html
@@ -16,19 +16,8 @@
     <title>Breadcrumbs | iTwinUI</title>
     <link
       rel="stylesheet"
-      href="../../lib/css/global.css"
+      href="../../lib/css/all.css"
     />
-
-    <link
-      rel="stylesheet"
-      href="../../lib/css/button.css"
-    />
-
-    <link
-      rel="stylesheet"
-      href="../../lib/css/breadcrumbs.css"
-    />
-
     <link
       rel="stylesheet"
       href="../assets/demo.css"

--- a/backstop/tests/breadcrumbs.html
+++ b/backstop/tests/breadcrumbs.html
@@ -16,8 +16,19 @@
     <title>Breadcrumbs | iTwinUI</title>
     <link
       rel="stylesheet"
-      href="../../lib/css/all.css"
+      href="../../lib/css/global.css"
     />
+
+    <link
+      rel="stylesheet"
+      href="../../lib/css/button.css"
+    />
+
+    <link
+      rel="stylesheet"
+      href="../../lib/css/breadcrumbs.css"
+    />
+
     <link
       rel="stylesheet"
       href="../assets/demo.css"
@@ -72,7 +83,7 @@
           ></svg-caret-down-small>
         </button>
         <ol class="iui-breadcrumbs-list">
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <a href="#">Root</a>
           </li>
           <li
@@ -81,7 +92,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <span class="iui-breadcrumbs-text">&mldr;</span>
           </li>
           <li
@@ -90,7 +101,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <a
               href="#"
               id="test-1"
@@ -102,7 +113,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <a
               href="#"
               id="test-2"
@@ -114,7 +125,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <a aria-current="page">You are here</a>
           </li>
         </ol>
@@ -140,7 +151,7 @@
           ></svg-caret-down-small>
         </button>
         <ol class="iui-breadcrumbs-list">
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <button class="iui-button iui-default">
               <span class="iui-button-label">Root</span>
             </button>
@@ -151,7 +162,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <span class="iui-breadcrumbs-text">&mldr;</span>
           </li>
           <li
@@ -160,7 +171,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <button
               class="iui-button iui-default"
               id="test-3"
@@ -174,7 +185,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <button
               class="iui-button iui-default"
               id="test-4"
@@ -188,7 +199,7 @@
           >
             <svg-chevron-right aria-hidden="true"></svg-chevron-right>
           </li>
-          <li class="iui-breadcrumbs-item">
+          <li class="iui-breadcrumbs-item iui-breadcrumbs-item-overrides">
             <button
               class="iui-button iui-default"
               aria-current="page"

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -36,8 +36,11 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    @include themed {
-      color: t(iui-text-color);
+
+    &:not(.iui-button) {
+      @include themed {
+        color: t(iui-text-color);
+      }
     }
   }
 
@@ -66,7 +69,7 @@
       &,
       &:hover,
       &:active {
-        color: var(--iui-color-foreground-primary);
+        --_iui-button-text-color: var(--iui-color-foreground-primary);
       }
     }
   }

--- a/src/breadcrumbs/breadcrumbs.scss
+++ b/src/breadcrumbs/breadcrumbs.scss
@@ -66,7 +66,7 @@
       &,
       &:hover,
       &:active {
-        --_iui-button-text-color: var(--iui-color-foreground-primary);
+        color: var(--iui-color-foreground-primary);
       }
     }
   }

--- a/src/breadcrumbs/classes.scss
+++ b/src/breadcrumbs/classes.scss
@@ -12,6 +12,9 @@
 
 .iui-breadcrumbs-item {
   @include iui-breadcrumbs-item;
+}
+
+.iui-breadcrumbs-item-overrides {
   @include iui-breadcrumbs-item-overrides;
 }
 


### PR DESCRIPTION
Both `.iui-breadcrumbs-item-overrides > *` and `.iui-button` selectors have the same specificity, so `.iui-button` props are placed after the `.iui-breadcrumbs-item-overrides > *` props in CSS because of alphabetical order. This does not happen in React.

The only prop that `.iui-button` overrides is `color`. `iui-breadcrumbs-item-overrides` is temporary and will be removed once we have implemented `iui-breadcrumbs-button`.