### PR TITLE
fix(Table): Allows to resize table header as before

### DIFF
--- a/src/table/table.scss
+++ b/src/table/table.scss
@@ -36,6 +36,7 @@
   .iui-row {
     display: flex;
     flex-grow: 1;
+    min-width: 100%;
   }
 
   .iui-cell {


### PR DESCRIPTION
My sticky columns PR apparently broke Table resizing that after some point header wouldn't reduce in size while body still can:
![table-header-resize-bug](https://user-images.githubusercontent.com/36186912/169814450-14559c47-2a66-47f0-9db5-d276c560bd33.gif)

