### PR TITLE
chore: Fix output css path in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
-      - 'v1.0'
+      - "main"
+      - "v1.0"
   pull_request:
     branches:
-      - 'main'
-      - 'v1.0'
+      - "main"
+      - "v1.0"
 
 jobs:
   build:
@@ -56,8 +56,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2.2.3
         with:
-          name: 'backstop_test_results'
-          path: '${{ github.workspace }}/packages/itwinui-css/backstop/results/'
+          name: "backstop_test_results"
+          path: "${{ github.workspace }}/packages/itwinui-css/backstop/results/"
 
       - name: Host test results on gh pages
         continue-on-error: true
@@ -139,7 +139,7 @@ jobs:
         with:
           branch: gh-pages
           folder: ${{ github.workspace }}/packages/itwinui-css/css
-          target-folder: lib/css
+          target-folder: css
           git-config-name: github-actions[bot]
           git-config-email: github-actions[bot]@users.noreply.github.com
 
@@ -152,8 +152,8 @@ jobs:
           clean-exclude: |
             v1
             backstop
-            lib/css/all.css
-            lib/css/global.css
+            css/all.css
+            css/global.css
             ${{ steps.open_prs.outputs.result }}
           git-config-name: github-actions[bot]
           git-config-email: github-actions[bot]@users.noreply.github.com
@@ -210,7 +210,7 @@ jobs:
         with:
           branch: gh-pages
           folder: ${{ github.workspace }}/packages/itwinui-css/css
-          target-folder: v1/lib/css
+          target-folder: v1/css
           git-config-name: github-actions[bot]
           git-config-email: github-actions[bot]@users.noreply.github.com
 
@@ -223,8 +223,8 @@ jobs:
           clean-exclude: |
             v1
             backstop
-            lib/css/all.css
-            lib/css/global.css
+            css/all.css
+            css/global.css
             ${{ steps.open_prs.outputs.result }}
           git-config-name: github-actions[bot]
           git-config-email: github-actions[bot]@users.noreply.github.com

--- a/packages/itwinui-css/backstop/gh-pages/main/index.html
+++ b/packages/itwinui-css/backstop/gh-pages/main/index.html
@@ -67,7 +67,7 @@
     />
     <link
       rel="stylesheet"
-      href="lib/css/global.css"
+      href="css/global.css"
     />
     <link
       rel="stylesheet"
@@ -163,7 +163,7 @@
     <hr />
     <section></section>
     <script>(async () => {
-        const contents = await fetch('https://api.github.com/repos/itwin/itwinui/contents/backstop/tests');
+        const contents = await fetch('https://api.github.com/repos/itwin/itwinui/contents/packages/itwinui-css/backstop/tests');
         const fileNames = (await contents.json()).map(file => file.name).filter(fileName => fileName !== 'index.html');
         let htmlString = `<ul>${fileNames.map(fileName => `<li><a class="iui-anchor" href="./backstop/minified/${fileName}">${fileName}</a></li>`).join('')}</ul>`;
         document.getElementsByTagName('section')[0].innerHTML = htmlString;

--- a/packages/itwinui-css/backstop/gh-pages/v1/index.html
+++ b/packages/itwinui-css/backstop/gh-pages/v1/index.html
@@ -67,7 +67,7 @@
     />
     <link
       rel="stylesheet"
-      href="lib/css/global.css"
+      href="css/global.css"
     />
     <link
       rel="stylesheet"
@@ -163,7 +163,7 @@
     <hr />
     <section></section>
     <script>(async () => {
-        const contents = await fetch('https://api.github.com/repos/itwin/itwinui/contents/backstop/tests?ref=v1.0');
+        const contents = await fetch('https://api.github.com/repos/itwin/itwinui/contents/packages/itwinui-css/backstop/tests?ref=v1.0');
         const fileNames = (await contents.json()).map(file => file.name).filter(fileName => fileName !== 'index.html');
         let htmlString = `<ul>${fileNames.map(fileName => `<li><a class="iui-anchor" href="./backstop/minified/${fileName}">${fileName}</a></li>`).join('')}</ul>`;
         document.getElementsByTagName('section')[0].innerHTML = htmlString;


### PR DESCRIPTION
After #651 and #668, the github pages got messed up. This should hopefully fix it.