### PR TITLE
ci: Fix `inputs` syntax for npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,14 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: "Which package to publish? e.g. itwinui-css or itwinui-variables"
+        description: "Which package to publish?"
         required: true
-        type: string
+        type: choice
         default: itwinui-css
+        options:
+          - itwinui-css
+          - itwinui-variables
   workflow_call:
     inputs:
       package:
-        description: "Which package to publish? e.g. itwinui-css or itwinui-variables"
         required: true
         type: string
         default: itwinui-css
@@ -37,6 +39,6 @@ jobs:
       - run: yarn build
 
       - run: npm publish --access public
-        working-directory: './packages/${{ env.INPUT_PACKAGE }}/'
+        working-directory: './packages/${{ github.event.inputs.package }}/'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,13 +1,20 @@
 name: Publish to npm
-inputs:
-  package:
-    description: 'Which package to publish? e.g. itwinui-css or itwinui-variables'
-    required: true
-    default: itwinui-css
 
 on:
   workflow_dispatch:
+    inputs:
+      package:
+        description: "Which package to publish? e.g. itwinui-css or itwinui-variables"
+        required: true
+        type: string
+        default: itwinui-css
   workflow_call:
+    inputs:
+      package:
+        description: "Which package to publish? e.g. itwinui-css or itwinui-variables"
+        required: true
+        type: string
+        default: itwinui-css
     secrets:
       NPMJS_PUBLISH_ITWIN:
         required: true
@@ -30,6 +37,6 @@ jobs:
       - run: yarn build
 
       - run: npm publish --access public
-        working-directory: './packages/${{ env.INPUT_PACKAGE }}/'
+        working-directory: "./packages/${{ env.INPUT_PACKAGE }}/"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,6 +37,6 @@ jobs:
       - run: yarn build
 
       - run: npm publish --access public
-        working-directory: "./packages/${{ env.INPUT_PACKAGE }}/"
+        working-directory: './packages/${{ env.INPUT_PACKAGE }}/'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}

--- a/packages/itwinui-variables/package.json
+++ b/packages/itwinui-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-variables",
-  "version": "0.1.0-dev.0",
+  "version": "0.1.0",
   "author": "Bentley Systems",
   "license": "MIT",
   "main": "index.css",

--- a/packages/itwinui-variables/package.json
+++ b/packages/itwinui-variables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-variables",
-  "version": "0.1.0",
+  "version": "0.1.0-dev.0",
   "author": "Bentley Systems",
   "license": "MIT",
   "main": "index.css",


### PR DESCRIPTION
Syntax was invalid previously. `inputs` should go under triggers and `type: string` is required.

Manually dispatching the workflow will now show a dropdown:
![ ](https://user-images.githubusercontent.com/9084735/178032017-b78e30dc-8a86-4ca4-8a03-108be4d47329.png)

Successfully tested publishing a dev version of itwinui-variables: https://github.com/iTwin/iTwinUI/actions/runs/2637306789

Calling the workflow from other workflows also supports passing the `package` input.