### PR TITLE
WIP: Rohan/vertical slider

### DIFF
--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -228,7 +228,7 @@
         // var diffY = event.offsetY;
         // var diffY = event.pageX - rect.left;
         var diffY = event.pageY - rect.top;
-        console.log(rect.top, rect.bottom, event.pageY);
+        // console.log(rect.top, rect.bottom, event.pageY);
 
         // console.log("VALUES: ", event.pageY, rect.top, diffY, event.offsetY, event.screenY);
         // console.log("VALUES: ", event.pageY, event.offsetY, event.screenY, rect.top, diffY);
@@ -244,6 +244,7 @@
           percent = limitMin;
         if (percent > limitMax)
           percent = limitMax;
+        // console.log(`${percent} %`);
 
         thumb.setAttribute("aria-valuenow", percent);
         setTooltipVertical(percent, toolTip);

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -66,20 +66,21 @@
 
     <h2>Ranges Vertical</h2>
     <section id="demo-range-vertical">
-      <div class="iui-input-container">
+      <div class="iui-input-container ">
         <div class="iui-label">Price range</div>
 
-        <div class="iui-slider-component-container iui-input-group">
+        <div
+          class="iui-slider-component-container iui-vertical iui-input-group"
+          style="height: 500px;"
+        >
           <span class="iui-slider-min">0</span>
           <div class="
               iui-slider-container iui-range-slider">
             <div class="iui-slider-rail"></div>
+            <div class="iui-slider-track">
+              <!-- style="left: 20%; right: 20%;" -->
+            </div>
             <div
-              class="iui-slider-track"
-              style="left: 20%; right: 20%;"
-            ></div>
-            <div
-              style="left: 20%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -88,15 +89,14 @@
               aria-valuenow="20"
               aria-valuemax="79"
               data-range-max="100"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 20%;"
             >
+              <!-- style="left: 20%;" -->
+            </div>
+            <output class="iui-tooltip">
+              <!-- style="left: 20%;" -->
               20
             </output>
             <div
-              style="left: 80%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -105,11 +105,11 @@
               aria-valuenow="80"
               aria-valuemax="100"
               data-range-min="0"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 80%;"
             >
+              <!-- style="left: 80%;" -->
+            </div>
+            <output class="iui-tooltip">
+              <!-- style="left: 80%;" -->
               80
             </output>
           </div>
@@ -349,6 +349,8 @@
         event.stopPropagation();
       }
 
+      // TODO: Make sure moveSliderVertical has similar code to the initialize method for consistency
+      // TODO: See if moveSliderVertical and moveSlider can be combined when code is similar to avoid code duplication
       function moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb) {
         // console.log("event.pageY", event.pageY);
 
@@ -394,16 +396,16 @@
           var progressPercent = 100 - percent;
           progress.style.top = `${progressPercent}%`;
         }
-        // else if (mode === "range-left") {
-        //   otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
-        //   thumb.style.left = `${percent}%`;
-        //   progress.style.left = `${percent}%`;
-        // } else if (mode === "range-right") {
-        //   otherThumb && otherThumb.setAttribute("aria-valuemax", percent - 1);
-        //   thumb.style.left = `${percent}%`;
-        //   var progressPercent = 100 - percent;
-        //   progress.style.right = `${progressPercent}%`;
-        // }
+        else if (mode === "range-left") {
+          otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
+          thumb.style.bottom = `${percent}%`;
+          progress.style.bottom = `${percent}%`;
+        } else if (mode === "range-right") {
+          otherThumb && otherThumb.setAttribute("aria-valuemax", percent - 1);
+          thumb.style.top = `${100 - percent}%`;
+          var progressPercent = 100 - percent;
+          progress.style.top = `${progressPercent}%`;
+        }
 
         event.preventDefault();
         event.stopPropagation();
@@ -443,16 +445,17 @@
           // progress.style.top = `78%`;
           // progress.style.bottom = `0%`;
         }
-        // else if (mode === "range-left") {
-        //   thumb.style.left = `${percent}%`;
-        //   progress = sliderContainer.querySelector(".iui-slider-track");
-        //   progress.style.left = `${percent}%`;
-        // } else if (mode === "range-right") {
-        //   thumb.style.left = `${percent}%`;
-        //   progress = sliderContainer.querySelector(".iui-slider-track");
-        //   progressPercent = 100 - percent;
-        //   progress.style.right = `${progressPercent}%`;
-        // }
+        else if (mode === "range-left") {
+          thumb.style.bottom = `${percent}%`;
+          progress = sliderContainer.querySelector(".iui-slider-track");
+          progress.style.bottom = `${percent}%`;
+          // thumb.style.left = "100px";
+        } else if (mode === "range-right") {
+          thumb.style.top = `${100 - percent}%`;
+          progress = sliderContainer.querySelector(".iui-slider-track");
+          progressPercent = 100 - percent;
+          progress.style.top = `${progressPercent}%`;
+        }
 
         // setTooltip(percent, toolTip);
         setTooltipVertical(percent, toolTip);

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -117,6 +117,75 @@
         </div>
 
       </div>
+
+      <div class="iui-input-container">
+        <div class="iui-label">Range with ticks</div>
+
+        <div
+          class="iui-slider-component-container iui-vertical iui-input-group"
+          style="height: 500px;"
+        >
+          <span class="iui-slider-min">0</span>
+          <div class="
+            iui-slider-container iui-range-slider">
+            <div class="iui-slider-rail"></div>
+            <div
+              class="iui-slider-track"
+              style="left: 20%; right: 20%;"
+            ></div>
+            <div
+              style="left: 20%;"
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="Start Value"
+              aria-valuemin="0"
+              aria-valuenow="20"
+              aria-valuemax="79"
+              data-range-max="100"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 20%;"
+            >
+              20
+            </output>
+            <div
+              style="left: 80%;"
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="End Value"
+              aria-valuemin="21"
+              aria-valuenow="80"
+              aria-valuemax="100"
+              data-range-min="0"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 80%;"
+            >
+              80
+            </output>
+            <div class="iui-slider-ticks">
+              <!-- You could generate the ticks based on your min, max & step values. -->
+              <span class="iui-slider-tick">0</span>
+              <span class="iui-slider-tick">10</span>
+              <span class="iui-slider-tick">20</span>
+              <span class="iui-slider-tick">30</span>
+              <span class="iui-slider-tick">40</span>
+              <span class="iui-slider-tick">50</span>
+              <span class="iui-slider-tick">60</span>
+              <span class="iui-slider-tick">70</span>
+              <span class="iui-slider-tick">80</span>
+              <span class="iui-slider-tick">90</span>
+              <span class="iui-slider-tick">100</span>
+            </div>
+          </div>
+          <span class="iui-slider-max">100</span>
+        </div>
+
+      </div>
     </section>
 
     <h2>Default vertical</h2>

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -66,92 +66,6 @@
 
     <h2>Default vertical</h2>
 
-    <div class="iui-input-container">
-      <div class="iui-label">Slider with ticks</div>
-
-      <div
-        class="iui-slider-component-container iui-vertical iui-input-group"
-        style="height: 500px;"
-      >
-        <span class="iui-slider-min">0</span>
-        <div class="iui-slider-container iui-progress-slider">
-          <div class="iui-slider-rail"></div>
-          <div class="iui-slider-track">
-            <!--style="right: 50%;"-->
-          </div>
-          <div
-            class="iui-slider-thumb"
-            role="slider"
-            tabindex="0"
-            aria-label="Percent Complete"
-            aria-valuemin="0"
-            aria-valuenow="50"
-            aria-valuemax="100"
-            id="test-slider-2"
-          >
-            <!--style="left: 50%;"-->
-          </div>
-          <output class="iui-tooltip">
-            <!-- style="left: 50%;" -->
-            50
-          </output>
-          <div class="iui-slider-ticks">
-            <!-- You could generate the ticks based on your min, max & step values. -->
-
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">0</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">10</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">20</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">30</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">40</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">50</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">60</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">70</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">80</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">90</b>
-            </div>
-            <div class="iui-slider-tick">
-              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">100</b>
-            </div>
-
-            <!-- <span class="iui-slider-tick">0</span>
-            <span class="iui-slider-tick">10</span>
-            <span class="iui-slider-tick">20</span>
-            <span class="iui-slider-tick">30</span>
-            <span class="iui-slider-tick">40</span>
-            <span class="iui-slider-tick">50</span>
-            <span class="iui-slider-tick">60</span>
-            <span class="iui-slider-tick">70</span>
-            <span class="iui-slider-tick">80</span>
-            <span class="iui-slider-tick">90</span>
-            <span class="iui-slider-tick">100</span> -->
-          </div>
-        </div>
-        <span class="iui-slider-max">100</span>
-      </div>
-
-    </div>
-
-    <!-- TODO: Re-add deleted example horizontal sliders -->
-
     <section id="demo-default-vertical">
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
@@ -197,6 +111,92 @@
         </div>
 
       </div>
+
+      <div class="iui-input-container">
+        <div class="iui-label">Slider with ticks</div>
+
+        <div
+          class="iui-slider-component-container iui-vertical iui-input-group"
+          style="height: 500px;"
+        >
+          <span class="iui-slider-min">0</span>
+          <div class="iui-slider-container iui-progress-slider">
+            <div class="iui-slider-rail"></div>
+            <div class="iui-slider-track">
+              <!--style="right: 50%;"-->
+            </div>
+            <div
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="Percent Complete"
+              aria-valuemin="0"
+              aria-valuenow="50"
+              aria-valuemax="100"
+              id="test-slider-2"
+            >
+              <!--style="left: 50%;"-->
+            </div>
+            <output class="iui-tooltip">
+              <!-- style="left: 50%;" -->
+              50
+            </output>
+            <div class="iui-slider-ticks">
+              <!-- You could generate the ticks based on your min, max & step values. -->
+
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">0</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">10</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">20</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">30</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">40</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">50</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">60</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">70</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">80</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">90</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">100</b>
+              </div>
+
+              <!-- <span class="iui-slider-tick">0</span>
+            <span class="iui-slider-tick">10</span>
+            <span class="iui-slider-tick">20</span>
+            <span class="iui-slider-tick">30</span>
+            <span class="iui-slider-tick">40</span>
+            <span class="iui-slider-tick">50</span>
+            <span class="iui-slider-tick">60</span>
+            <span class="iui-slider-tick">70</span>
+            <span class="iui-slider-tick">80</span>
+            <span class="iui-slider-tick">90</span>
+            <span class="iui-slider-tick">100</span> -->
+            </div>
+          </div>
+          <span class="iui-slider-max">100</span>
+        </div>
+
+      </div>
+
+      <!-- TODO: Re-add deleted example horizontal sliders -->
     </section>
 
     <script>

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -83,10 +83,8 @@
           </span>
           <div class="iui-slider-container iui-progress-slider">
             <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="bottom: 50%;"
-            ></div>
+            <div class="iui-slider-track"></div>
+            <!--style="bottom: 50%;"-->
             <div
               style="bottom: 50%;"
               class="iui-slider-thumb"
@@ -295,22 +293,25 @@
         const toolTip = getToolTip(thumb, mode);
 
         if (mode === "progress") {
-          thumb.style.left = `${percent}%`;
+          // thumb.style.left = `${percent}%`;
+          thumb.style.top = `${percent}%`;
           progress = sliderContainer.querySelector(".iui-slider-track");
           progressPercent = 100 - percent;
-          progress.style.right = `${progressPercent}%`;
-        } else if (mode === "range-left") {
-          thumb.style.left = `${percent}%`;
-          progress = sliderContainer.querySelector(".iui-slider-track");
-          progress.style.left = `${percent}%`;
-        } else if (mode === "range-right") {
-          thumb.style.left = `${percent}%`;
-          progress = sliderContainer.querySelector(".iui-slider-track");
-          progressPercent = 100 - percent;
-          progress.style.right = `${progressPercent}%`;
+          progress.style.bottom = `${progressPercent}%`;
         }
+        // else if (mode === "range-left") {
+        //   thumb.style.left = `${percent}%`;
+        //   progress = sliderContainer.querySelector(".iui-slider-track");
+        //   progress.style.left = `${percent}%`;
+        // } else if (mode === "range-right") {
+        //   thumb.style.left = `${percent}%`;
+        //   progress = sliderContainer.querySelector(".iui-slider-track");
+        //   progressPercent = 100 - percent;
+        //   progress.style.right = `${progressPercent}%`;
+        // }
 
-        setTooltip(percent, toolTip);
+        // setTooltip(percent, toolTip);
+        setTooltipVertical(percent, toolTip);
 
         // window.addEventListener("mousedown", function () {
         //   var handleMouseMove = function (event) {

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -64,8 +64,62 @@
     <hr />
     <br>
 
-    <h2>Default vertical</h2>
+    <h2>Ranges Vertical</h2>
+    <section id="demo-range-vertical">
+      <div class="iui-input-container">
+        <div class="iui-label">Price range</div>
 
+        <div class="iui-slider-component-container iui-input-group">
+          <span class="iui-slider-min">0</span>
+          <div class="
+              iui-slider-container iui-range-slider">
+            <div class="iui-slider-rail"></div>
+            <div
+              class="iui-slider-track"
+              style="left: 20%; right: 20%;"
+            ></div>
+            <div
+              style="left: 20%;"
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="Start Value"
+              aria-valuemin="0"
+              aria-valuenow="20"
+              aria-valuemax="79"
+              data-range-max="100"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 20%;"
+            >
+              20
+            </output>
+            <div
+              style="left: 80%;"
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="End Value"
+              aria-valuemin="21"
+              aria-valuenow="80"
+              aria-valuemax="100"
+              data-range-min="0"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 80%;"
+            >
+              80
+            </output>
+          </div>
+          <span class="iui-slider-max">100</span>
+        </div>
+
+      </div>
+    </section>
+
+    <h2>Default vertical</h2>
     <section id="demo-default-vertical">
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
@@ -111,6 +165,8 @@
         </div>
 
       </div>
+
+      <br /><br />
 
       <div class="iui-input-container">
         <div class="iui-label">Slider with ticks</div>

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -64,9 +64,94 @@
     <hr />
     <br>
 
+    <h2>Default vertical</h2>
+
+    <div class="iui-input-container">
+      <div class="iui-label">Slider with ticks</div>
+
+      <div
+        class="iui-slider-component-container iui-vertical iui-input-group"
+        style="height: 500px;"
+      >
+        <span class="iui-slider-min">0</span>
+        <div class="iui-slider-container iui-progress-slider">
+          <div class="iui-slider-rail"></div>
+          <div class="iui-slider-track">
+            <!--style="right: 50%;"-->
+          </div>
+          <div
+            class="iui-slider-thumb"
+            role="slider"
+            tabindex="0"
+            aria-label="Percent Complete"
+            aria-valuemin="0"
+            aria-valuenow="50"
+            aria-valuemax="100"
+            id="test-slider-2"
+          >
+            <!--style="left: 50%;"-->
+          </div>
+          <output class="iui-tooltip">
+            <!-- style="left: 50%;" -->
+            50
+          </output>
+          <div class="iui-slider-ticks">
+            <!-- You could generate the ticks based on your min, max & step values. -->
+
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">0</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">10</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">20</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">30</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">40</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">50</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">60</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">70</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">80</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">90</b>
+            </div>
+            <div class="iui-slider-tick">
+              <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">100</b>
+            </div>
+
+            <!-- <span class="iui-slider-tick">0</span>
+            <span class="iui-slider-tick">10</span>
+            <span class="iui-slider-tick">20</span>
+            <span class="iui-slider-tick">30</span>
+            <span class="iui-slider-tick">40</span>
+            <span class="iui-slider-tick">50</span>
+            <span class="iui-slider-tick">60</span>
+            <span class="iui-slider-tick">70</span>
+            <span class="iui-slider-tick">80</span>
+            <span class="iui-slider-tick">90</span>
+            <span class="iui-slider-tick">100</span> -->
+          </div>
+        </div>
+        <span class="iui-slider-max">100</span>
+      </div>
+
+    </div>
+
     <!-- TODO: Re-add deleted example horizontal sliders -->
 
-    <h2>Default vertical</h2>
     <section id="demo-default-vertical">
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -247,7 +247,7 @@
               tabindex="0"
               aria-label="Volume Setting"
               aria-valuemin="0"
-              aria-valuenow="20"
+              aria-valuenow="50"
               aria-valuemax="100"
               id="test-slider-1"
             ></div>
@@ -489,7 +489,6 @@
           percent = limitMin;
         if (percent > limitMax)
           percent = limitMax;
-        // console.log(`${percent} %`);
 
         thumb.setAttribute("aria-valuenow", percent);
         setTooltipVertical(percent, toolTip);
@@ -497,16 +496,19 @@
           thumb.style.top = `${100 - percent}%`;
           var progressPercent = 100 - percent;
           progress.style.top = `${progressPercent}%`;
+          console.log(`${percent}%`);
         }
         else if (mode === "range-left") {
           otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
           thumb.style.bottom = `${percent}%`;
           progress.style.bottom = `${percent}%`;
+          console.log(`${percent}% - ${otherThumb.getAttribute("aria-valuenow")}%`);
         } else if (mode === "range-right") {
           otherThumb && otherThumb.setAttribute("aria-valuemax", percent - 1);
           thumb.style.top = `${100 - percent}%`;
           var progressPercent = 100 - percent;
           progress.style.top = `${progressPercent}%`;
+          console.log(`${otherThumb.getAttribute("aria-valuenow")}% - ${percent}%`);
         }
 
         event.preventDefault();

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -269,7 +269,7 @@
       <br /><br />
 
       <div class="iui-input-container">
-        <div class="iui-label">Range with ticks</div>
+        <div class="iui-label">Range with ticks123</div>
 
         <div class="iui-slider-component-container iui-input-group">
           <span class="iui-slider-min">0</span>
@@ -401,17 +401,14 @@
       </div>
     </section>
 
-    <br />
 
-    <h2>Default vertical</h2>
+    <h2>Default Vertical</h2>
     <section id="demo-default-vertical">
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
 
-        <div
-          class="iui-slider-component-container iui-vertical iui-input-group"
-          style="height: 500px;"
-        >
+        <div class="iui-slider-component-container iui-vertical iui-input-group">
+          <!-- iui-input-group is part of the slider component container -->
           <span class="iui-slider-min">
             <svg-sound-mute
               class="iui-icon"
@@ -422,10 +419,10 @@
             <div class="iui-slider-rail"></div>
             <div
               class="iui-slider-track"
-              style="bottom: 50%;"
+              style="right: 50%;"
             ></div>
             <div
-              style="bottom: 50%;"
+              style="left: 50%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -437,7 +434,7 @@
             ></div>
             <output
               class="iui-tooltip"
-              style="bottom: 50%;"
+              style="left: 50%;"
             >
               50
             </output>
@@ -451,7 +448,108 @@
         </div>
 
       </div>
+
+      <br /><br />
+
+      <div class="iui-input-container">
+        <div class="iui-label">Slider with ticks</div>
+
+        <div class="iui-slider-component-container iui-input-group">
+          <span class="iui-slider-min">0</span>
+          <div class="iui-slider-container iui-progress-slider">
+            <div class="iui-slider-rail"></div>
+            <div
+              class="iui-slider-track"
+              style="right: 50%;"
+            ></div>
+            <div
+              style="left: 50%;"
+              class="iui-slider-thumb"
+              role="slider"
+              tabindex="0"
+              aria-label="Percent Complete"
+              aria-valuemin="0"
+              aria-valuenow="50"
+              aria-valuemax="100"
+              id="test-slider-2"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 50%;"
+            >
+              50
+            </output>
+            <div class="iui-slider-ticks">
+              <!-- You could generate the ticks based on your min, max & step values. -->
+              <span class="iui-slider-tick">0</span>
+              <span class="iui-slider-tick">10</span>
+              <span class="iui-slider-tick">20</span>
+              <span class="iui-slider-tick">30</span>
+              <span class="iui-slider-tick">40</span>
+              <span class="iui-slider-tick">50</span>
+              <span class="iui-slider-tick">60</span>
+              <span class="iui-slider-tick">70</span>
+              <span class="iui-slider-tick">80</span>
+              <span class="iui-slider-tick">90</span>
+              <span class="iui-slider-tick">100</span>
+            </div>
+          </div>
+          <span class="iui-slider-max">100</span>
+        </div>
+
+      </div>
+
+      <br /><br />
+
+      <div class="iui-input-container iui-disabled">
+        <div class="iui-label">Disabled slider</div>
+
+        <div class="iui-slider-component-container iui-input-group iui-disabled">
+          <span class="iui-slider-min">0</span>
+          <div class="iui-slider-container iui-progress-slider">
+            <div class="iui-slider-rail"></div>
+            <div
+              class="iui-slider-track"
+              style="right: 50%;"
+            ></div>
+            <div
+              style="left: 50%;"
+              class="iui-slider-thumb"
+              role="slider"
+              aria-label="Percent Complete"
+              aria-valuemin="0"
+              aria-valuenow="50"
+              aria-valuemax="100"
+              id="test-slider-2"
+            ></div>
+            <output
+              class="iui-tooltip"
+              style="left: 50%;"
+            >
+              50
+            </output>
+            <div class="iui-slider-ticks">
+              <!-- You could generate the ticks based on your min, max & step values. -->
+              <span class="iui-slider-tick">0</span>
+              <span class="iui-slider-tick">10</span>
+              <span class="iui-slider-tick">20</span>
+              <span class="iui-slider-tick">30</span>
+              <span class="iui-slider-tick">40</span>
+              <span class="iui-slider-tick">50</span>
+              <span class="iui-slider-tick">60</span>
+              <span class="iui-slider-tick">70</span>
+              <span class="iui-slider-tick">80</span>
+              <span class="iui-slider-tick">90</span>
+              <span class="iui-slider-tick">100</span>
+            </div>
+          </div>
+          <span class="iui-slider-max">100</span>
+        </div>
+
+      </div>
     </section>
+
+
 
     <script>
 
@@ -537,49 +635,6 @@
         event.stopPropagation();
       }
 
-      function moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb) {
-        var min = getMinValueFromThumb(thumb);
-        var limitMin = getMinLimitValueFromThumb(thumb);
-        var max = getMaxValueFromThumb(thumb);
-        var limitMax = getMaxLimitValueFromThumb(thumb);
-        var rect = track.getBoundingClientRect();
-        // var trackWidth = rect.width;
-        var trackHeight = rect.height;
-        // var diffX = event.pageX - rect.left;
-        var diffY = event.pageY - rect.top;
-        if (diffY > rect.height)
-          diffY = rect.height;
-        if (diffY < 0)
-          diffY = 0;
-
-        var percent = parseInt(((max - min) * diffY) / trackHeight);
-        if (percent < limitMin)
-          percent = limitMin;
-        if (percent > limitMax)
-          percent = limitMax;
-
-        thumb.setAttribute("aria-valuenow", percent);
-        setTooltip(percent, toolTip);
-        if (mode === "progress") {
-          thumb.style.top = `${percent}%`;
-          var progressPercent = 100 - percent;
-          progress.style.bottom = `${progressPercent}%`;
-        }
-        // else if (mode === "range-left") {
-        //   otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
-        //   thumb.style.left = `${percent}%`;
-        //   progress.style.left = `${percent}%`;
-        // } else if (mode === "range-right") {
-        //   otherThumb && otherThumb.setAttribute("aria-valuemax", percent - 1);
-        //   thumb.style.left = `${percent}%`;
-        //   var progressPercent = 100 - percent;
-        //   progress.style.right = `${progressPercent}%`;
-        // }
-
-        event.preventDefault();
-        event.stopPropagation();
-      }
-
       function getOtherRangeThumb(thumb) {
         var parent = thumb.parentNode;
         const allThumbs = parent.querySelectorAll(".iui-slider-thumb");
@@ -632,8 +687,7 @@
           var ownerDoc = thumb.ownerDocument;
           var track = sliderContainer.querySelector(".iui-slider-rail");
           var handleMouseMove = function (event) {
-            // moveSlider(event, thumb, track, progress, mode, toolTip, otherThumb);
-            moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb);
+            moveSlider(event, thumb, track, progress, mode, toolTip, otherThumb);
           };
 
           var handleMouseUp = function (event) {

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -269,7 +269,7 @@
       <br /><br />
 
       <div class="iui-input-container">
-        <div class="iui-label">Range with ticks123</div>
+        <div class="iui-label">Range with ticks</div>
 
         <div class="iui-slider-component-container iui-input-group">
           <span class="iui-slider-min">0</span>
@@ -401,14 +401,17 @@
       </div>
     </section>
 
+    <br />
 
-    <h2>Default Vertical</h2>
+    <h2>Default vertical</h2>
     <section id="demo-default-vertical">
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
 
-        <div class="iui-slider-component-container iui-vertical iui-input-group">
-          <!-- iui-input-group is part of the slider component container -->
+        <div
+          class="iui-slider-component-container iui-vertical iui-input-group"
+          style="height: 500px;"
+        >
           <span class="iui-slider-min">
             <svg-sound-mute
               class="iui-icon"
@@ -419,10 +422,10 @@
             <div class="iui-slider-rail"></div>
             <div
               class="iui-slider-track"
-              style="right: 50%;"
+              style="bottom: 50%;"
             ></div>
             <div
-              style="left: 50%;"
+              style="bottom: 50%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -434,7 +437,7 @@
             ></div>
             <output
               class="iui-tooltip"
-              style="left: 50%;"
+              style="bottom: 50%;"
             >
               50
             </output>
@@ -448,108 +451,7 @@
         </div>
 
       </div>
-
-      <br /><br />
-
-      <div class="iui-input-container">
-        <div class="iui-label">Slider with ticks</div>
-
-        <div class="iui-slider-component-container iui-input-group">
-          <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="right: 50%;"
-            ></div>
-            <div
-              style="left: 50%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="Percent Complete"
-              aria-valuemin="0"
-              aria-valuenow="50"
-              aria-valuemax="100"
-              id="test-slider-2"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 50%;"
-            >
-              50
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-
-      <br /><br />
-
-      <div class="iui-input-container iui-disabled">
-        <div class="iui-label">Disabled slider</div>
-
-        <div class="iui-slider-component-container iui-input-group iui-disabled">
-          <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="right: 50%;"
-            ></div>
-            <div
-              style="left: 50%;"
-              class="iui-slider-thumb"
-              role="slider"
-              aria-label="Percent Complete"
-              aria-valuemin="0"
-              aria-valuenow="50"
-              aria-valuemax="100"
-              id="test-slider-2"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 50%;"
-            >
-              50
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
     </section>
-
-
 
     <script>
 
@@ -635,6 +537,49 @@
         event.stopPropagation();
       }
 
+      function moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb) {
+        var min = getMinValueFromThumb(thumb);
+        var limitMin = getMinLimitValueFromThumb(thumb);
+        var max = getMaxValueFromThumb(thumb);
+        var limitMax = getMaxLimitValueFromThumb(thumb);
+        var rect = track.getBoundingClientRect();
+        // var trackWidth = rect.width;
+        var trackHeight = rect.height;
+        // var diffX = event.pageX - rect.left;
+        var diffY = event.pageY - rect.top;
+        if (diffY > rect.height)
+          diffY = rect.height;
+        if (diffY < 0)
+          diffY = 0;
+
+        var percent = parseInt(((max - min) * diffY) / trackHeight);
+        if (percent < limitMin)
+          percent = limitMin;
+        if (percent > limitMax)
+          percent = limitMax;
+
+        thumb.setAttribute("aria-valuenow", percent);
+        setTooltip(percent, toolTip);
+        if (mode === "progress") {
+          thumb.style.top = `${percent}%`;
+          var progressPercent = 100 - percent;
+          progress.style.bottom = `${progressPercent}%`;
+        }
+        // else if (mode === "range-left") {
+        //   otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
+        //   thumb.style.left = `${percent}%`;
+        //   progress.style.left = `${percent}%`;
+        // } else if (mode === "range-right") {
+        //   otherThumb && otherThumb.setAttribute("aria-valuemax", percent - 1);
+        //   thumb.style.left = `${percent}%`;
+        //   var progressPercent = 100 - percent;
+        //   progress.style.right = `${progressPercent}%`;
+        // }
+
+        event.preventDefault();
+        event.stopPropagation();
+      }
+
       function getOtherRangeThumb(thumb) {
         var parent = thumb.parentNode;
         const allThumbs = parent.querySelectorAll(".iui-slider-thumb");
@@ -687,7 +632,8 @@
           var ownerDoc = thumb.ownerDocument;
           var track = sliderContainer.querySelector(".iui-slider-rail");
           var handleMouseMove = function (event) {
-            moveSlider(event, thumb, track, progress, mode, toolTip, otherThumb);
+            // moveSlider(event, thumb, track, progress, mode, toolTip, otherThumb);
+            moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb);
           };
 
           var handleMouseUp = function (event) {

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -92,7 +92,7 @@
               tabindex="0"
               aria-label="Volume Setting"
               aria-valuemin="0"
-              aria-valuenow="50"
+              aria-valuenow="20"
               aria-valuemax="100"
               id="test-slider-1"
             ></div>
@@ -128,7 +128,7 @@
         // return;
 
         if (tooltip) {
-          tooltip.style.top = `${percent}%`;
+          tooltip.style.bottom = `${percent}%`;
           tooltip.innerHTML = `${percent}`;
         }
       }
@@ -239,7 +239,7 @@
         if (diffY < 0)
           diffY = 0;
 
-        var percent = parseInt(((max - min) * diffY) / trackHeight);
+        var percent = 100 - parseInt(((max - min) * diffY) / trackHeight);
         if (percent < limitMin)
           percent = limitMin;
         if (percent > limitMax)
@@ -249,9 +249,9 @@
         thumb.setAttribute("aria-valuenow", percent);
         setTooltipVertical(percent, toolTip);
         if (mode === "progress") {
-          thumb.style.top = `${percent}%`;
+          thumb.style.top = `${100 - percent}%`;
           var progressPercent = 100 - percent;
-          progress.style.bottom = `${progressPercent}%`;
+          progress.style.top = `${progressPercent}%`;
         }
         // else if (mode === "range-left") {
         //   otherThumb && otherThumb.setAttribute("aria-valuemin", percent + 1);
@@ -295,10 +295,12 @@
 
         if (mode === "progress") {
           // thumb.style.left = `${percent}%`;
-          thumb.style.top = `${percent}%`;
+          thumb.style.top = `${100 - percent}%`;
           progress = sliderContainer.querySelector(".iui-slider-track");
           progressPercent = 100 - percent;
-          progress.style.bottom = `${progressPercent}%`;
+          progress.style.top = `${progressPercent}%`;
+          // progress.style.top = `78%`;
+          // progress.style.bottom = `0%`;
         }
         // else if (mode === "range-left") {
         //   thumb.style.left = `${percent}%`;

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -129,12 +129,10 @@
           <div class="
             iui-slider-container iui-range-slider">
             <div class="iui-slider-rail"></div>
+            <div class="iui-slider-track">
+              <!-- style="left: 20%; right: 20%;" -->
+            </div>
             <div
-              class="iui-slider-track"
-              style="left: 20%; right: 20%;"
-            ></div>
-            <div
-              style="left: 20%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -143,15 +141,14 @@
               aria-valuenow="20"
               aria-valuemax="79"
               data-range-max="100"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 20%;"
             >
+              <!-- style="left: 20%;" -->
+            </div>
+            <output class="iui-tooltip">
+              <!-- style="left: 20%;" -->
               20
             </output>
             <div
-              style="left: 80%;"
               class="iui-slider-thumb"
               role="slider"
               tabindex="0"
@@ -160,16 +157,52 @@
               aria-valuenow="80"
               aria-valuemax="100"
               data-range-min="0"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 80%;"
             >
+              <!-- style="left: 80%;" -->
+            </div>
+            <output class="iui-tooltip">
+              <!-- style="left: 80%;" -->
               80
             </output>
+
             <div class="iui-slider-ticks">
               <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
+
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">0</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">10</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">20</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">30</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">40</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">50</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">60</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">70</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">80</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">90</b>
+              </div>
+              <div class="iui-slider-tick">
+                <span class="iui-slider-tick-mark"></span><b class="iui-slider-tick-number">100</b>
+              </div>
+
+              <!-- <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
               <span class="iui-slider-tick">30</span>
@@ -179,7 +212,7 @@
               <span class="iui-slider-tick">70</span>
               <span class="iui-slider-tick">80</span>
               <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
+              <span class="iui-slider-tick">100</span> -->
             </div>
           </div>
           <span class="iui-slider-max">100</span>

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -64,344 +64,7 @@
     <hr />
     <br>
 
-    <h2>Default</h2>
-    <section id="demo-default">
-      <div class="iui-input-container">
-        <div class="iui-label">Volume</div>
-
-        <div class="iui-slider-component-container iui-input-group">
-          <span class="iui-slider-min">
-            <svg-sound-mute
-              class="iui-icon"
-              aria-hidden="true"
-            ></svg-sound-mute>
-          </span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="right: 50%;"
-            ></div>
-            <div
-              style="left: 50%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="Volume Setting"
-              aria-valuemin="0"
-              aria-valuenow="50"
-              aria-valuemax="100"
-              id="test-slider-1"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 50%;"
-            >
-              50
-            </output>
-          </div>
-          <span class="iui-slider-max">
-            <svg-sound-loud
-              class="iui-icon"
-              aria-hidden="true"
-            ></svg-sound-loud>
-          </span>
-        </div>
-
-      </div>
-
-      <br /><br />
-
-      <div class="iui-input-container">
-        <div class="iui-label">Slider with ticks</div>
-
-        <div class="iui-slider-component-container iui-input-group">
-          <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="right: 50%;"
-            ></div>
-            <div
-              style="left: 50%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="Percent Complete"
-              aria-valuemin="0"
-              aria-valuenow="50"
-              aria-valuemax="100"
-              id="test-slider-2"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 50%;"
-            >
-              50
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-
-      <br /><br />
-
-      <div class="iui-input-container iui-disabled">
-        <div class="iui-label">Disabled slider</div>
-
-        <div class="iui-slider-component-container iui-input-group iui-disabled">
-          <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="right: 50%;"
-            ></div>
-            <div
-              style="left: 50%;"
-              class="iui-slider-thumb"
-              role="slider"
-              aria-label="Percent Complete"
-              aria-valuemin="0"
-              aria-valuenow="50"
-              aria-valuemax="100"
-              id="test-slider-2"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 50%;"
-            >
-              50
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-    </section>
-
-    <br />
-
-    <h2>Ranges</h2>
-    <section id="demo-range">
-      <div class="iui-input-container">
-        <div class="iui-label">Price range</div>
-
-        <div class="iui-slider-component-container iui-input-group">
-          <span class="iui-slider-min">0</span>
-          <div class="
-              iui-slider-container iui-range-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="left: 20%; right: 20%;"
-            ></div>
-            <div
-              style="left: 20%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="Start Value"
-              aria-valuemin="0"
-              aria-valuenow="20"
-              aria-valuemax="79"
-              data-range-max="100"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 20%;"
-            >
-              20
-            </output>
-            <div
-              style="left: 80%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="End Value"
-              aria-valuemin="21"
-              aria-valuenow="80"
-              aria-valuemax="100"
-              data-range-min="0"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 80%;"
-            >
-              80
-            </output>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-
-      <br /><br />
-
-      <div class="iui-input-container">
-        <div class="iui-label">Range with ticks</div>
-
-        <div class="iui-slider-component-container iui-input-group">
-          <span class="iui-slider-min">0</span>
-          <div class="
-            iui-slider-container iui-range-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="left: 20%; right: 20%;"
-            ></div>
-            <div
-              style="left: 20%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="Start Value"
-              aria-valuemin="0"
-              aria-valuenow="20"
-              aria-valuemax="79"
-              data-range-max="100"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 20%;"
-            >
-              20
-            </output>
-            <div
-              style="left: 80%;"
-              class="iui-slider-thumb"
-              role="slider"
-              tabindex="0"
-              aria-label="End Value"
-              aria-valuemin="21"
-              aria-valuenow="80"
-              aria-valuemax="100"
-              data-range-min="0"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 80%;"
-            >
-              80
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-
-      <br /><br />
-
-      <div class="iui-input-container iui-disabled">
-        <div class="iui-label">Disabled range</div>
-
-        <div class="iui-slider-component-container iui-input-group iui-disabled">
-          <span class="iui-slider-min">0</span>
-          <div class="
-            iui-slider-container iui-range-slider">
-            <div class="iui-slider-rail"></div>
-            <div
-              class="iui-slider-track"
-              style="left: 20%; right: 20%;"
-            ></div>
-            <div
-              style="left: 20%;"
-              class="iui-slider-thumb"
-              role="slider"
-              aria-label="Start Value"
-              aria-valuemin="0"
-              aria-valuenow="20"
-              aria-valuemax="79"
-              data-range-max="100"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 20%;"
-            >
-              20
-            </output>
-            <div
-              style="left: 80%;"
-              class="iui-slider-thumb"
-              role="slider"
-              aria-label="End Value"
-              aria-valuemin="21"
-              aria-valuenow="80"
-              aria-valuemax="100"
-              data-range-min="0"
-            ></div>
-            <output
-              class="iui-tooltip"
-              style="left: 80%;"
-            >
-              80
-            </output>
-            <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
-              <span class="iui-slider-tick">0</span>
-              <span class="iui-slider-tick">10</span>
-              <span class="iui-slider-tick">20</span>
-              <span class="iui-slider-tick">30</span>
-              <span class="iui-slider-tick">40</span>
-              <span class="iui-slider-tick">50</span>
-              <span class="iui-slider-tick">60</span>
-              <span class="iui-slider-tick">70</span>
-              <span class="iui-slider-tick">80</span>
-              <span class="iui-slider-tick">90</span>
-              <span class="iui-slider-tick">100</span>
-            </div>
-          </div>
-          <span class="iui-slider-max">100</span>
-        </div>
-
-      </div>
-    </section>
-
-    <br />
+    <!-- TODO: Re-add deleted example horizontal sliders -->
 
     <h2>Default vertical</h2>
     <section id="demo-default-vertical">
@@ -458,6 +121,16 @@
       function setTooltip(percent, tooltip) {
         if (tooltip) {
           tooltip.style.left = `${percent}%`;
+          tooltip.innerHTML = `${percent}`;
+        }
+      }
+
+      function setTooltipVertical(percent, tooltip) {
+        // setTooltip(percent, tooltip);
+        // return;
+
+        if (tooltip) {
+          tooltip.style.top = `${percent}%`;
           tooltip.innerHTML = `${percent}`;
         }
       }
@@ -538,15 +211,31 @@
       }
 
       function moveSliderVertical(event, thumb, track, progress, mode, toolTip, otherThumb) {
+        // console.log("event.pageY", event.pageY);
+
         var min = getMinValueFromThumb(thumb);
         var limitMin = getMinLimitValueFromThumb(thumb);
         var max = getMaxValueFromThumb(thumb);
         var limitMax = getMaxLimitValueFromThumb(thumb);
+
+        // console.log("VALUES: ", min, limitMin, max, limitMax);
+
         var rect = track.getBoundingClientRect();
         // var trackWidth = rect.width;
         var trackHeight = rect.height;
         // var diffX = event.pageX - rect.left;
+        // var diffY = event.pageY - rect.top;
+        // var diffY = event.pageX - 541.5;
+        // var diffY = event.offsetY - rect.top;
+        // var diffY = event.offsetY;
+        // var diffY = event.pageX - rect.left;
         var diffY = event.pageY - rect.top;
+        console.log(rect.top, rect.bottom, event.pageY);
+
+        // console.log("VALUES: ", event.pageY, rect.top, diffY, event.offsetY, event.screenY);
+        // console.log("VALUES: ", event.pageY, event.offsetY, event.screenY, rect.top, diffY);
+        // console.log(rect);
+
         if (diffY > rect.height)
           diffY = rect.height;
         if (diffY < 0)
@@ -559,7 +248,7 @@
           percent = limitMax;
 
         thumb.setAttribute("aria-valuenow", percent);
-        setTooltip(percent, toolTip);
+        setTooltipVertical(percent, toolTip);
         if (mode === "progress") {
           thumb.style.top = `${percent}%`;
           var progressPercent = 100 - percent;
@@ -622,6 +311,19 @@
         }
 
         setTooltip(percent, toolTip);
+
+        // window.addEventListener("mousedown", function () {
+        //   var handleMouseMove = function (event) {
+        //     var track = sliderContainer.querySelector(".iui-slider-rail");
+        //     console.log(track.getBoundingClientRect());
+        //     console.log(event.pageX, event.pageY);
+        //   };
+
+        //   window.addEventListener("mousemove", handleMouseMove);
+        //   window.addEventListener("mouseup", function () {
+        //     window.removeEventListener("mousemove", handleMouseMove);
+        //   });
+        // });
 
         thumb.addEventListener("mousedown", function () {
           if (sliderContainer.parentElement.classList.contains('iui-disabled'))

--- a/packages/itwinui-css/src/slider/classes.scss
+++ b/packages/itwinui-css/src/slider/classes.scss
@@ -6,6 +6,11 @@
   @include iui-slider-component-container;
 }
 
+// See if this is the correct place for non-iui related selectors
+#demo-default-vertical {
+  @include demo-default-vertical;
+}
+
 .iui-slider-container {
   @include iui-slider-container;
 }

--- a/packages/itwinui-css/src/slider/classes.scss
+++ b/packages/itwinui-css/src/slider/classes.scss
@@ -7,7 +7,8 @@
 }
 
 // See if this is the correct place for non-iui related selectors
-#demo-default-vertical {
+#demo-default-vertical,
+#demo-range-vertical {
   @include demo-default-vertical;
 }
 

--- a/packages/itwinui-css/src/slider/classes.scss
+++ b/packages/itwinui-css/src/slider/classes.scss
@@ -25,11 +25,3 @@
 .iui-slider-track {
   @include iui-slider-track;
 }
-
-.iui-slider-min {
-  @include iui-slider-endpoints(min);
-}
-
-.iui-slider-max {
-  @include iui-slider-endpoints(max);
-}

--- a/packages/itwinui-css/src/slider/classes.scss
+++ b/packages/itwinui-css/src/slider/classes.scss
@@ -25,3 +25,11 @@
 .iui-slider-track {
   @include iui-slider-track;
 }
+
+.iui-slider-min {
+  @include iui-slider-endpoints(min);
+}
+
+.iui-slider-max {
+  @include iui-slider-endpoints(max);
+}

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -52,6 +52,7 @@ $tick-height: $iui-baseline; // 11px
 
   svg {
     @include iui-icons-default;
+    // TODO: Confirm why this padding was there
     margin-top: $iui-xs;
   }
 }

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -126,8 +126,12 @@ $tick-height: $iui-baseline; // 11px
 
   @at-root .iui-vertical & {
     width: $track-height;
-    top: unset;
+    // top: 0;
+    top: 0;
+    // height: 100%;
+    height: unset;
     left: $iui-sm;
+    // height: 100%;
   }
 }
 

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -16,7 +16,7 @@ $tick-height: $iui-baseline; // 11px
   }
 
   &.iui-vertical {
-    flex-direction: column;
+    flex-direction: column-reverse;
     min-height: auto;
     min-width: $iui-baseline * 2;
   }
@@ -33,7 +33,7 @@ $tick-height: $iui-baseline; // 11px
     text-align: center;
   }
 
-  @if $endpoints == min {
+  @if $endpoints == max {
     margin-right: $iui-sm;
     text-align: right;
 
@@ -42,7 +42,7 @@ $tick-height: $iui-baseline; // 11px
     }
   }
 
-  @if $endpoints == max {
+  @if $endpoints == min {
     margin-left: $iui-sm;
 
     @at-root .iui-vertical & {
@@ -130,7 +130,8 @@ $tick-height: $iui-baseline; // 11px
     width: $track-height;
     // width: 50px;
     // top: 0;
-    top: 0;
+    // top: 0;
+    bottom: 0;
     // height: 100%;
     height: unset;
     left: $iui-sm;

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -103,7 +103,9 @@ $tick-height: $iui-baseline; // 11px
 
   @at-root .iui-vertical & {
     top: unset;
-    left: $track-height + 1; // position center of thumb in center of track
+    // left: $track-height + 1; // position center of thumb in center of track
+    // left: ;
+    left: $track-height + 1;
     transform: translateY(
       (-$thumb-height - 2) * 0.5
     ); // Adjust the left (set in code) by radius of thumb so thumb center is at value position
@@ -126,6 +128,7 @@ $tick-height: $iui-baseline; // 11px
 
   @at-root .iui-vertical & {
     width: $track-height;
+    // width: 50px;
     // top: 0;
     top: 0;
     // height: 100%;

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -11,48 +11,32 @@ $tick-height: $iui-baseline; // 11px
   display: flex;
   min-height: $iui-baseline * 2;
 
+  .iui-slider-min,
+  .iui-slider-max {
+    user-select: all;
+    margin-top: $iui-xxs;
+
+    svg {
+      @include iui-icons-default;
+      margin-top: $iui-xs;
+    }
+  }
+
+  .iui-slider-min {
+    margin-right: $iui-sm;
+    text-align: right;
+  }
+
+  .iui-slider-max {
+    margin-left: $iui-sm;
+  }
+
   &.iui-disabled {
     @include iui-slider-disabled;
   }
 
   &.iui-vertical {
     flex-direction: column;
-    min-height: auto;
-    min-width: $iui-baseline * 2;
-  }
-}
-
-/// @arg $endpoints Can be one of: min, max
-@mixin iui-slider-endpoints($endpoints) {
-  user-select: all;
-  margin-top: $iui-xxs;
-
-  @at-root .iui-vertical & {
-    margin: 0;
-    margin-left: $iui-xxs;
-    text-align: center;
-  }
-
-  @if $endpoints == min {
-    margin-right: $iui-sm;
-    text-align: right;
-
-    @at-root .iui-vertical & {
-      margin-bottom: $iui-sm;
-    }
-  }
-
-  @if $endpoints == max {
-    margin-left: $iui-sm;
-
-    @at-root .iui-vertical & {
-      margin-top: $iui-sm;
-    }
-  }
-
-  svg {
-    @include iui-icons-default;
-    margin-top: $iui-xs;
   }
 }
 
@@ -75,13 +59,6 @@ $tick-height: $iui-baseline; // 11px
   @include themed {
     background-color: t(iui-color-background-border);
   }
-
-  @at-root .iui-vertical & {
-    width: $track-height;
-    height: 100%;
-    top: unset;
-    left: $iui-sm;
-  }
 }
 
 @mixin iui-slider-thumb {
@@ -101,14 +78,6 @@ $tick-height: $iui-baseline; // 11px
     border: 1px solid t(iui-color-background-border);
   }
 
-  @at-root .iui-vertical & {
-    top: unset;
-    left: $track-height + 1; // position center of thumb in center of track
-    transform: translateY(
-      (-$thumb-height - 2) * 0.5
-    ); // Adjust the left (set in code) by radius of thumb so thumb center is at value position
-  }
-
   &:active {
     cursor: grabbing;
   }
@@ -122,12 +91,6 @@ $tick-height: $iui-baseline; // 11px
   top: $iui-sm;
   @include themed {
     background-color: t(iui-color-foreground-primary);
-  }
-
-  @at-root .iui-vertical & {
-    width: $track-height;
-    top: unset;
-    left: $iui-sm;
   }
 }
 

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -11,32 +11,48 @@ $tick-height: $iui-baseline; // 11px
   display: flex;
   min-height: $iui-baseline * 2;
 
-  .iui-slider-min,
-  .iui-slider-max {
-    user-select: all;
-    margin-top: $iui-xxs;
-
-    svg {
-      @include iui-icons-default;
-      margin-top: $iui-xs;
-    }
-  }
-
-  .iui-slider-min {
-    margin-right: $iui-sm;
-    text-align: right;
-  }
-
-  .iui-slider-max {
-    margin-left: $iui-sm;
-  }
-
   &.iui-disabled {
     @include iui-slider-disabled;
   }
 
   &.iui-vertical {
     flex-direction: column;
+    min-height: auto;
+    min-width: $iui-baseline * 2;
+  }
+}
+
+/// @arg $endpoints Can be one of: min, max
+@mixin iui-slider-endpoints($endpoints) {
+  user-select: all;
+  margin-top: $iui-xxs;
+
+  @at-root .iui-vertical & {
+    margin: 0;
+    margin-left: $iui-xxs;
+    text-align: center;
+  }
+
+  @if $endpoints == min {
+    margin-right: $iui-sm;
+    text-align: right;
+
+    @at-root .iui-vertical & {
+      margin-bottom: $iui-sm;
+    }
+  }
+
+  @if $endpoints == max {
+    margin-left: $iui-sm;
+
+    @at-root .iui-vertical & {
+      margin-top: $iui-sm;
+    }
+  }
+
+  svg {
+    @include iui-icons-default;
+    margin-top: $iui-xs;
   }
 }
 
@@ -59,6 +75,13 @@ $tick-height: $iui-baseline; // 11px
   @include themed {
     background-color: t(iui-color-background-border);
   }
+
+  @at-root .iui-vertical & {
+    width: $track-height;
+    height: 100%;
+    top: unset;
+    left: $iui-sm;
+  }
 }
 
 @mixin iui-slider-thumb {
@@ -78,6 +101,14 @@ $tick-height: $iui-baseline; // 11px
     border: 1px solid t(iui-color-background-border);
   }
 
+  @at-root .iui-vertical & {
+    top: unset;
+    left: $track-height + 1; // position center of thumb in center of track
+    transform: translateY(
+      (-$thumb-height - 2) * 0.5
+    ); // Adjust the left (set in code) by radius of thumb so thumb center is at value position
+  }
+
   &:active {
     cursor: grabbing;
   }
@@ -91,6 +122,12 @@ $tick-height: $iui-baseline; // 11px
   top: $iui-sm;
   @include themed {
     background-color: t(iui-color-foreground-primary);
+  }
+
+  @at-root .iui-vertical & {
+    width: $track-height;
+    top: unset;
+    left: $iui-sm;
   }
 }
 

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -56,6 +56,11 @@ $tick-height: $iui-baseline; // 11px
   }
 }
 
+@mixin demo-default-vertical {
+  display: flex;
+  gap: 2rem;
+}
+
 @mixin iui-slider-container {
   position: relative;
   flex-grow: 1;

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -141,23 +141,41 @@ $tick-height: $iui-baseline; // 11px
 
 @mixin iui-slider-ticks {
   position: relative;
-  padding-top: $iui-m;
+  padding-left: $iui-m;
   display: flex;
+  flex-direction: column-reverse;
   pointer-events: none;
   justify-content: space-between;
+  align-items: flex-start;
   user-select: none;
+  height: 100%;
 
   .iui-slider-tick {
+    // TODO: Implement for horizontal and vertical (Using @at-root, etc.)
     position: relative;
     display: flex;
     pointer-events: none;
     justify-content: center;
-    width: 1px;
-    height: $tick-height;
-    line-height: $tick-height * 4;
-    margin-bottom: $tick-height * 2;
-    @include themed {
-      background-color: t(iui-color-background-4);
+    // line-height: $tick-height * 4;
+    // margin-bottom: $tick-height * 2;
+    align-items: center;
+    // gap: $tick-height * 2; // TODO: Confirm if gap value is okay for column (horizontal slider too)
+
+    .iui-slider-tick-mark {
+      display: inline-block;
+      width: $tick-height;
+      height: 1px;
+      margin-right: 4px; // TODO: Confirm if margin value is okay for column (horizontal slider too)
+
+      @include themed {
+        background-color: t(iui-color-background-4);
+      }
+    }
+
+    .iui-slider-tick-number {
+      position: absolute;
+      left: $tick-height * 2;
+      font-weight: normal;
     }
   }
 }

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -22,6 +22,11 @@
     color: t(iui-color-foreground-accessory);
     border: 1px solid rgba(t(iui-color-foreground-accessory-rgb), t(iui-opacity-4));
   }
+
+  @at-root .iui-vertical & {
+    width: unset;
+    height: max-content;
+  }
 }
 
 @mixin iui-tooltip-hidden {


### PR DESCRIPTION
Goals:

* Have a vertical slider as mentioned in #699 
  * Extend the current horizontal slider functionality to also support having vertical sliders

Tasks:

* [ ] Default sliders
  * [x] Without ticks
  * [x] With ticks
  * [ ] Disabled with ticks
* [ ] Range sliders
  * [x] Without ticks
  * [x] With ticks
  * [ ] Disabled with ticks

Screenshots (click to enlarge):

![vertical_slider_with_ticks](https://user-images.githubusercontent.com/45748283/179021711-89a790d6-7b0b-42db-a9f5-04e5564cc04a.gif)
<img width="600px" src="https://user-images.githubusercontent.com/45748283/179021711-89a790d6-7b0b-42db-a9f5-04e5564cc04a.gif">
![vertical_range_slider_with_ticks](https://user-images.githubusercontent.com/45748283/179021724-e6a95d3e-d312-4090-92c5-fe60acdcceba.gif)

Bugs to solve:

* Unexpected thumb offset when the page is scrolled: I think has something to do with `event.pageY` inside the `mousemove` event callback. _I need to investigate it more but would appreciate your input if you know why this is happening._
  * 
* The below thumb of the range slider has an unexpected vertical offset (shown in the second screenshot above)