### PR TITLE
docs: Add alias to run `yarn build:watch` from the root folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Install the recommended [plugins](./.vscode/extensions.json) for linter warnings
 
 `yarn build`
 
-You can also use `yarn build:watch` to rebuild automatically when files change.
+You can also use `yarn build:watch` from the root or `packages/itwinui-css` folders to rebuild automatically when files change.
 
 ### To preview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,14 +79,6 @@ We provide a script that can automatically create all the necessary files for yo
 
 For running tests you will need [Docker](https://www.docker.com/products/docker-desktop). It helps to avoid cross-platform rendering differences.
 
-#### How to set up Docker:
-
-- Make sure Docker is running.
-
-- Create the docker image needed for testing by running `yarn build-docker` from the root folder.
-
-#### How to run tests:
-
 - To run tests for a specific component, use this command:
 
   `yarn test --filter=[component_name]` (e.g. `yarn test --filter=side-navigation`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,8 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
 
 #### How to set up Docker:
 
-- Download and install [Docker](https://www.docker.com/products/docker-desktop) and make sure Docker is running
+- Make sure Docker is running
+
 - Create the docker image needed for testing by running `yarn build-docker` from the `/packages/itwinui-css/` folder
 
 #### How to run tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,14 @@ We provide a script that can automatically create all the necessary files for yo
 
 ### Testing
 
+#### How to set up Docker:
+
+- Make sure Docker is running.
+
+- Create the docker image needed for testing by running `yarn build-docker` from the root folder.
+
+#### How to run tests:
+
 For running tests you will need [Docker](https://www.docker.com/products/docker-desktop). It helps to avoid cross-platform rendering differences.
 
 - To run tests for a specific component, use this command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,9 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
 
 #### How to set up Docker:
 
-- Make sure Docker is running
+- Make sure Docker is running.
 
-- Create the docker image needed for testing by running `yarn build-docker` from the `/packages/itwinui-css/` folder
+- Create the docker image needed for testing by running `yarn build-docker` from the root folder.
 
 #### How to run tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Install the recommended [plugins](./.vscode/extensions.json) for linter warnings
 
 `yarn build`
 
-You can also use `yarn build:watch` from the root or `packages/itwinui-css` folders to rebuild automatically when files change.
+You can also use `yarn build:watch` from the root or the `packages/itwinui-css` folders to rebuild automatically when files change.
 
 ### To preview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ You can also use `yarn build:watch` to rebuild automatically when files change.
 
 ### To preview
 
-The minified html files are outputted into the `backstop/minified/` folder and can be opened directly in your browser. You may want to use a local http server (e.g. with the  [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)).
+The minified html files are outputted into the `backstop/minified/` folder and can be opened directly in your browser. You may want to use a local http server (e.g. with the [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)).
 
 ### To run visual tests
 
@@ -69,15 +69,22 @@ We provide a script that can automatically create all the necessary files for yo
   - Use existing Sass variables for spacing (margin, padding, sizing, etc).
   - Use [`themed`](https://github.com/iTwin/iTwinUI/blob/main/src/style/theme.scss#L430) mixin wherever color is involved.
 - Define classes for your mixin in `src/[component-name]/classes.scss` file.
-  - *Running the `createComponent` command will do this for you.*
+  - _Running the `createComponent` command will do this for you._
 - Make sure your component index and classes are imported in `src/index.scss` and `src/classes.scss`.
-  - *Running the `createComponent` command will also do this for you but you need to manually sort the imports alphabetically.*
+  - _Running the `createComponent` command will also do this for you but you need to manually sort the imports alphabetically._
 - Write tests for your new component in `backstop/tests/[component-name].html` and `backstop/scenarios/[component-name].js`. See [Testing](#Testing) section below.
 - After running `yarn build` you can open minified html in browser to check up, how your component looks like from `backstop/minified`.
 
 ### Testing
 
 For running tests you will need [Docker](https://www.docker.com/products/docker-desktop). It helps to avoid cross-platform rendering differences.
+
+#### How to set up Docker:
+
+- Download and install [Docker](https://www.docker.com/products/docker-desktop) and make sure Docker is running
+- Create the docker image needed for testing by running `yarn build-docker` from the `/packages/itwinui-css/` folder
+
+#### How to run tests:
 
 - To run tests for a specific component, use this command:
 
@@ -100,23 +107,17 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
   - For actions like click, hover use according functions from `scenarioHelper.js` and pass them as scenario options `actions` property.
     ```js
     const { scenario, hover } = require('../scenarioHelper');
-    module.exports = [
-      scenario('hover', { actions: [hover('.element-selector')] }),
-    ];
+    module.exports = [scenario('hover', { actions: [hover('.element-selector')] })];
     ```
   - If you want to select only specific part of the test elements, pass `selectors` property to the options.
     ```js
     const { scenario } = require('../scenarioHelper');
-    module.exports = [
-      scenario('selected part', { selectors: ['.selected-part-selector'] }),
-    ];
+    module.exports = [scenario('selected part', { selectors: ['.selected-part-selector'] })];
     ```
   - If you want to hide some elements because they might be moving e.g. spinner, pass `hideSelectors` property to the options.
     ```js
     const { scenario } = require('../scenarioHelper');
-    module.exports = [
-      scenario('hide part', { hideSelectors: ['.hide-selector'] }),
-    ];
+    module.exports = [scenario('hide part', { hideSelectors: ['.hide-selector'] })];
     ```
   - More information about options can be found in [BackstopJS GitHub](https://github.com/garris/BackstopJS#advanced-scenarios).
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dev": "turbo run dev",
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "lint:copyright": "node packages/shared/copyrightLinter.js"
+    "lint:copyright": "node packages/shared/copyrightLinter.js",
+    "build-docker": "cd packages/itwinui-css && node scripts/buildDocker.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "turbo run build",
+    "build:watch": "yarn workspace @itwin/itwinui-css build:watch",
     "dev": "turbo run dev",
     "test": "turbo run test",
     "lint": "turbo run lint",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "lint:copyright": "node packages/shared/copyrightLinter.js",
-    "build-docker": "cd packages/itwinui-css && node scripts/buildDocker.js"
+    "build-docker": "cd packages/itwinui-css && yarn build-docker"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "lint:copyright": "node packages/shared/copyrightLinter.js",
-    "build-docker": "cd packages/itwinui-css && yarn build-docker"
+    "build-docker": "yarn workspace @itwin/itwinui-css build-docker"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Closes #714. 

### TODO:

* [x] Add an alias in the root `package.json` to run `yarn build:watch` from the root folder instead of just the `packages/itwinui-css` folder
* [x] Add in CONTRIBUTING.md that `yarn build:watch` can be run from the root or the `packages/itwinui-css` folders