### PR TITLE
fix(Stepper): Use correct color variable for high contrast themes

### DIFF
--- a/packages/itwinui-css/src/stepper/stepper.scss
+++ b/packages/itwinui-css/src/stepper/stepper.scss
@@ -63,10 +63,10 @@
     --_iui-stepper-step-border-color: var(--iui-color-background-border);
     --_iui-stepper-step-number-color: var(--iui-text-color-muted);
     --_iui-stepper-step-text-color: var(--iui-text-color-muted);
-    --_iui-stepper-step-track-before-color: var(--iui-color-background-5);
+    --_iui-stepper-step-track-before-color: var(--iui-color-background-border);
 
     &:not(:last-of-type) {
-      --_iui-stepper-step-track-after-color: var(--iui-color-background-5);
+      --_iui-stepper-step-track-after-color: var(--iui-color-background-border);
     }
   }
 


### PR DESCRIPTION
Swapped `--iui-color-background-5` for `--iui-color-background-border` in 2 places.  Does not effect visuals for non-high contrast themes.

**Before:**
![Screen Shot 2022-07-27 at 2 36 07 PM](https://user-images.githubusercontent.com/849817/181348102-33baca77-6389-4886-970d-4747c742f5d9.png)

**After**
![Screen Shot 2022-07-27 at 2 37 18 PM](https://user-images.githubusercontent.com/849817/181348127-d15bc763-d254-4c82-bac6-954e5ad900c3.png)

