### PR TITLE
fix(Table): Zebra stripes content no longer goes on top of stick column

### DIFF
--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -196,6 +196,11 @@
   &.iui-zebra-striping .iui-row:nth-child(even):not(.iui-selected) .iui-cell {
     @include themed {
       background-color: rgba(t(iui-color-foreground-body-rgb), 0.02);
+      background: linear-gradient(
+        rgba(t(iui-color-foreground-body-rgb), 0.02),
+        rgba(t(iui-color-foreground-body-rgb), 0.02)
+      ),
+        linear-gradient(t(iui-color-background-1), t(iui-color-background-1));
     }
   }
 

--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -195,7 +195,6 @@
 
   &.iui-zebra-striping .iui-row:nth-child(even):not(.iui-selected) .iui-cell {
     @include themed {
-      background-color: rgba(t(iui-color-foreground-body-rgb), 0.02);
       background: linear-gradient(
         rgba(t(iui-color-foreground-body-rgb), 0.02),
         rgba(t(iui-color-foreground-body-rgb), 0.02)


### PR DESCRIPTION
![zebra-on-top-fixed](https://user-images.githubusercontent.com/36186912/181694482-b955366a-0549-4b4d-9a16-22813c159e78.gif)

Closes #691 