### PR TITLE
ci: Fix npm publish not detecting package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,6 +39,6 @@ jobs:
       - run: yarn build
 
       - run: npm publish --access public
-        working-directory: './packages/${{ github.event.inputs.package }}/'
+        working-directory: './packages/${{ inputs.package }}/'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}


### PR DESCRIPTION
From https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#example