### PR TITLE
feat(Menu): Add CSS variable for max-height on scrollable menu

### DIFF
--- a/packages/itwinui-css/backstop/tests/menu.html
+++ b/packages/itwinui-css/backstop/tests/menu.html
@@ -35,7 +35,7 @@
       }
 
       #demo-scrollable {
-        height: 96px;
+        --iui-menu-max-height: 96px;
       }
 
       #demo-header {

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -7,6 +7,8 @@
 $iui-active-outline: thin solid t(iui-color-foreground-primary);
 
 @mixin iui-list-menu {
+  max-height: var(--iui-menu-max-height);
+
   @include iui-reset;
   list-style-type: none;
   user-select: none;
@@ -28,7 +30,7 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
   &:where(.iui-scroll) {
     overflow-y: auto;
     overflow-y: overlay;
-    max-height: var(--iui-menu-max-height);
+    --iui-menu-max-height: 315px;
   }
 }
 

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -25,9 +25,10 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
     border-radius: $iui-border-radius;
   }
 
-  &.iui-scroll {
+  &:where(.iui-scroll) {
     overflow-y: auto;
     overflow-y: overlay;
+    max-height: var(--iui-menu-max-height);
   }
 }
 

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -7,14 +7,13 @@
 $iui-active-outline: thin solid t(iui-color-foreground-primary);
 
 @mixin iui-list-menu {
-  max-height: var(--iui-menu-max-height);
-
   @include iui-reset;
   list-style-type: none;
   user-select: none;
   width: 100%;
   margin: 0;
   padding: 0;
+  max-height: var(--iui-menu-max-height);
 
   .iui-header-menu-icon {
     margin: 0 $iui-xs;
@@ -27,7 +26,7 @@ $iui-active-outline: thin solid t(iui-color-foreground-primary);
     border-radius: $iui-border-radius;
   }
 
-  &:where(.iui-scroll) {
+  &.iui-scroll {
     overflow-y: auto;
     overflow-y: overlay;
     --iui-menu-max-height: 315px;


### PR DESCRIPTION
- Add `--iui-menu-max-height` to `.iui-scroll` modifier.  Variable is unset in SCSS, value is set in demo `<head>`.
- Use `:where` to keep specificity at 0,1,0.

Closes #733.