### PR TITLE
feat: Move visually-hidden from global to utils

### DIFF
--- a/packages/itwinui-css/src/style/global.scss
+++ b/packages/itwinui-css/src/style/global.scss
@@ -49,10 +49,6 @@ html {
   }
 }
 
-.iui-visually-hidden {
-  @include visually-hidden;
-}
-
 [class*='iui-'],
 [class*='iui-'] * {
   // Text highlight
@@ -62,8 +58,8 @@ html {
   @include iui-scrollbar;
 }
 
-[class*=iui-]:where(:not(.iui-body)),
-[class*=iui-]:where(:not(.iui-body))::before,
-[class*=iui-]:where(:not(.iui-body))::after {
+[class*='iui-']:where(:not(.iui-body)),
+[class*='iui-']:where(:not(.iui-body))::before,
+[class*='iui-']:where(:not(.iui-body))::after {
   box-sizing: border-box;
 }

--- a/packages/itwinui-css/src/style/global.scss
+++ b/packages/itwinui-css/src/style/global.scss
@@ -58,8 +58,8 @@ html {
   @include iui-scrollbar;
 }
 
-[class*='iui-']:where(:not(.iui-body)),
-[class*='iui-']:where(:not(.iui-body))::before,
-[class*='iui-']:where(:not(.iui-body))::after {
+[class*=iui-]:where(:not(.iui-body)),
+[class*=iui-]:where(:not(.iui-body))::before,
+[class*=iui-]:where(:not(.iui-body))::after {
   box-sizing: border-box;
 }

--- a/packages/itwinui-css/src/utils/classes.scss
+++ b/packages/itwinui-css/src/utils/classes.scss
@@ -5,3 +5,4 @@
 @import './input-container/classes';
 @import './notification-marker/classes';
 @import './popover/classes';
+@import './visually-hidden/classes';

--- a/packages/itwinui-css/src/utils/index.scss
+++ b/packages/itwinui-css/src/utils/index.scss
@@ -5,3 +5,4 @@
 @import './mixins';
 @import './notification-marker/index';
 @import './popover/index';
+@import './visually-hidden/index';

--- a/packages/itwinui-css/src/utils/mixins.scss
+++ b/packages/itwinui-css/src/utils/mixins.scss
@@ -79,42 +79,6 @@
   }
 }
 
-/// Simulates display: none but keeps the element in DOM tree
-@mixin iui-display-none {
-  opacity: 0;
-  height: 0.1px;
-  width: 0.1px;
-  margin: 0;
-  padding: 0;
-}
-
-/// Visually hides an element but keeps it accessible to screen readers.
-/// Because it applies some potentially invasive styles, use this mixin on a wrapper element for best results.
-/// If it contains a focusable element, make sure to revert/exclude these styles.
-@mixin visually-hidden {
-  clip-path: inset(50%);
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  height: 1px;
-  width: 1px;
-  padding: 0;
-  margin: -1px;
-  border-width: 0;
-}
-
-/// Reverts visually-hidden styles, making it visible again.
-@mixin visually-hidden-revert {
-  clip-path: revert;
-  overflow: visible;
-  position: static;
-  white-space: normal;
-  height: auto;
-  width: auto;
-  padding: 0;
-  margin: 0;
-}
-
 /// Classes for react-transition-group
 /// Used for expand/collapse transitions. Needs height/width to be set in JS.
 @mixin iui-transition-group {

--- a/packages/itwinui-css/src/utils/visually-hidden/classes.scss
+++ b/packages/itwinui-css/src/utils/visually-hidden/classes.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+@import './visually-hidden';
+
+.iui-visually-hidden {
+  @include visually-hidden;
+}

--- a/packages/itwinui-css/src/utils/visually-hidden/index.scss
+++ b/packages/itwinui-css/src/utils/visually-hidden/index.scss
@@ -1,0 +1,3 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+@import './visually-hidden';

--- a/packages/itwinui-css/src/utils/visually-hidden/visually-hidden.scss
+++ b/packages/itwinui-css/src/utils/visually-hidden/visually-hidden.scss
@@ -1,5 +1,6 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 // See LICENSE.md in the project root for license terms and full copyright notice.
+
 /// Visually hides an element but keeps it accessible to screen readers.
 /// Because it applies some potentially invasive styles, use this mixin on a wrapper element for best results.
 /// If it contains a focusable element, make sure to revert/exclude these styles.

--- a/packages/itwinui-css/src/utils/visually-hidden/visually-hidden.scss
+++ b/packages/itwinui-css/src/utils/visually-hidden/visually-hidden.scss
@@ -1,0 +1,28 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+/// Visually hides an element but keeps it accessible to screen readers.
+/// Because it applies some potentially invasive styles, use this mixin on a wrapper element for best results.
+/// If it contains a focusable element, make sure to revert/exclude these styles.
+@mixin visually-hidden {
+  clip-path: inset(50%);
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  height: 1px;
+  width: 1px;
+  padding: 0;
+  margin: -1px;
+  border-width: 0;
+}
+
+/// Reverts visually-hidden styles, making it visible again.
+@mixin visually-hidden-revert {
+  clip-path: revert;
+  overflow: visible;
+  position: static;
+  white-space: normal;
+  height: auto;
+  width: auto;
+  padding: 0;
+  margin: 0;
+}


### PR DESCRIPTION
Was working on global styles when i noticed that `iui-visually-hidden` is just sitting in `global.scss` for no reason, so I've moved it to utils.

Also noticed that `iui-display-none` is not used anywhere so removed it.