### PR TITLE
fix(Table): Keyboard Navigation Support

### DIFF
--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -88,7 +88,7 @@
 
       .iui-table-sort,
       .iui-table-filter-button {
-        opacity: revert;
+        opacity: 1;
       }
     }
   }
@@ -128,7 +128,7 @@
     background-color: var(--iui-color-background-4);
 
     .iui-table-sort {
-      opacity: revert;
+      opacity: 1;
       fill: var(--iui-icon-color-actionable);
     }
   }
@@ -168,12 +168,12 @@
       }
 
       > .iui-slot:not([aria-disabled='true']) > .iui-table-more-options {
-        opacity: revert;
+        opacity: 1;
       }
     }
 
     &:focus-within > .iui-slot:not([aria-disabled='true']) > .iui-table-more-options {
-      opacity: revert;
+      opacity: 1;
     }
 
     .iui-table-row-expander > .iui-button-icon {

--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -48,7 +48,7 @@
     }
 
     .iui-table-filter-button:not([data-iui-active='true']) {
-      visibility: hidden;
+      opacity: 0;
     }
 
     > .iui-table-resizer {
@@ -88,7 +88,7 @@
 
       .iui-table-sort,
       .iui-table-filter-button {
-        visibility: visible;
+        opacity: revert;
       }
     }
   }
@@ -120,7 +120,7 @@
 
   // Sort icon
   .iui-table-sort {
-    visibility: hidden;
+    opacity: 0;
   }
 
   // Sorted column
@@ -128,7 +128,7 @@
     background-color: var(--iui-color-background-4);
 
     .iui-table-sort {
-      visibility: visible;
+      opacity: revert;
       fill: var(--iui-icon-color-actionable);
     }
   }
@@ -155,7 +155,7 @@
     }
 
     > .iui-slot > .iui-table-more-options {
-      visibility: hidden;
+      opacity: 0;
     }
 
     &:hover:not([aria-disabled='true']) {
@@ -168,12 +168,12 @@
       }
 
       > .iui-slot:not([aria-disabled='true']) > .iui-table-more-options {
-        visibility: visible;
+        opacity: revert;
       }
     }
 
     &:focus-within > .iui-slot:not([aria-disabled='true']) > .iui-table-more-options {
-      visibility: visible;
+      opacity: revert;
     }
 
     .iui-table-row-expander > .iui-button-icon {
@@ -269,7 +269,7 @@
       color: var(--iui-text-color-muted);
 
       &.iui-slot:hover > .iui-table-more-options {
-        visibility: hidden;
+        opacity: 0;
       }
 
       img,


### PR DESCRIPTION
I changed all `visibility: hidden` to `opacity: 0` and all `visibility: visible` to `opacity: revert`. This helps to solve the problem of keyboard navigation in the table in the react repo.

I tried to use `iui-visually-hidden` and `iui-visually-hidden-revert`, but it negatively affected the look of the table. I thought this was the better solution to 1) keeping the button in the DOM, 2) keeping the button dimensions the same throughout, and 3) allowing keyboard navigation.

Goes with https://github.com/iTwin/iTwinUI-react/pull/802