### PR TITLE
fix: Make dialog positioned and remove unneeded styles

### DIFF
--- a/packages/itwinui-css/backstop/tests/dialog.html
+++ b/packages/itwinui-css/backstop/tests/dialog.html
@@ -29,6 +29,17 @@
       body > button.iui-button {
         margin: 5px 0;
       }
+      test-container-section {
+        display: flex;
+        gap: 5px;
+      }
+      test-container-section > * {
+        display: block;
+        height: 500px;
+        border: 1px solid var(--iui-color-background-border);
+        width: 50%;
+        position: relative;
+      }
     </style>
   </head>
   <body class="iui-root">
@@ -268,21 +279,21 @@
       </div>
     </div>
 
-    <div style="display: flex; gap: 5px;">
-      <div style="border: 1px solid var(--iui-color-background-border); width: 50%; height: 500px">
+    <test-container-section>
+      <div>
         <button
           aria-label="Open relative to container dialog"
           id="open-relative-to-container-dialog"
           type="button"
           class="iui-button"
           onclick="toggleDialog('draggable-dialog-relative')"
-          style="position: absolute;"
         >
           Open relative to container dialog
         </button>
         <div
           class="iui-dialog-wrapper"
           id="draggable-dialog-relative"
+          data-iui-relative
         >
           <div class="iui-dialog iui-dialog-default iui-dialog-draggable">
             <div class="iui-dialog-title-bar iui-dialog-title-bar-filled">
@@ -331,20 +342,20 @@
         </div>
       </div>
 
-      <div style="border: 1px solid var(--iui-color-background-border); width: 50%; height: 500px; position: relative;">
+      <div>
         <button
           aria-label="Open with backdrop relative to container dialog"
           id="open-with-backdrop-relative-to-container-dialog"
           type="button"
           class="iui-button"
           onclick="toggleDialog('relative-dialog-with-backdrop')"
-          style="position: absolute;"
         >
           Open with backdrop relative to container dialog
         </button>
         <div
           class="iui-dialog-wrapper"
           id="relative-dialog-with-backdrop"
+          data-iui-relative
         >
           <div class="iui-backdrop"></div>
           <div class="iui-dialog iui-dialog-default">
@@ -393,7 +404,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </test-container-section>
 
     <script>
       function toggleDialog(dialogId) {

--- a/packages/itwinui-css/backstop/tests/dialog.html
+++ b/packages/itwinui-css/backstop/tests/dialog.html
@@ -293,7 +293,7 @@
         <div
           class="iui-dialog-wrapper"
           id="draggable-dialog-relative"
-          data-iui-relative
+          data-iui-relative="true"
         >
           <div class="iui-dialog iui-dialog-default iui-dialog-draggable">
             <div class="iui-dialog-title-bar iui-dialog-title-bar-filled">
@@ -355,7 +355,7 @@
         <div
           class="iui-dialog-wrapper"
           id="relative-dialog-with-backdrop"
-          data-iui-relative
+          data-iui-relative="true"
         >
           <div class="iui-backdrop"></div>
           <div class="iui-dialog iui-dialog-default">

--- a/packages/itwinui-css/backstop/tests/dialog.html
+++ b/packages/itwinui-css/backstop/tests/dialog.html
@@ -442,33 +442,22 @@
         const { width, height } = element.getBoundingClientRect();
 
         let active = false;
-        let currentX;
-        let currentY;
         let initialX;
         let initialY;
-        let xOffset;
-        let yOffset;
+        let initialTransform;
 
         document.addEventListener("mouseup", dragEnd, false);
         document.addEventListener("mousemove", drag, false);
 
         function dragStart(e) {
-          // Workaround for initial drag
-          if (xOffset == null && yOffset == null) {
-            initialX = e.clientX + width / 2;
-            initialY = e.clientY + height / 3;
-          } else {
-            initialX = e.clientX - xOffset;
-            initialY = e.clientY - yOffset;
-          }
-
           active = true;
+
+          initialX = e.clientX;
+          initialY = e.clientY;
+          intialTransform = new DOMMatrix(getComputedStyle(element).transform);
         }
 
         function dragEnd(e) {
-          initialX = currentX;
-          initialY = currentY;
-
           active = false;
         }
 
@@ -476,13 +465,12 @@
           if (active) {
             e.preventDefault();
 
-            currentX = e.clientX - initialX;
-            currentY = e.clientY - initialY;
+            const diffX = e.clientX - initialX;
+            const diffY = e.clientY - initialY;
 
-            xOffset = currentX;
-            yOffset = currentY;
+            const newTranslate = intialTransform.translate(diffX, diffY).transformPoint();
 
-            element.style.transform = "translate(" + currentX + "px, " + currentY + "px)";
+            element.style.transform = `translate(${newTranslate.x}px, ${newTranslate.y}px)`;
           }
         }
       }

--- a/packages/itwinui-css/src/dialog/classes.scss
+++ b/packages/itwinui-css/src/dialog/classes.scss
@@ -12,10 +12,7 @@
 
 .iui-dialog-default {
   @include iui-dialog-default;
-
-  &:where(:not(.iui-dialog-draggable)) {
-    @include iui-dialog-placement;
-  }
+  @include iui-dialog-placement;
 }
 
 .iui-dialog-full-page {

--- a/packages/itwinui-css/src/dialog/classes.scss
+++ b/packages/itwinui-css/src/dialog/classes.scss
@@ -12,7 +12,10 @@
 
 .iui-dialog-default {
   @include iui-dialog-default;
-  @include iui-dialog-placement;
+
+  &:where(:not(.iui-dialog-draggable)) {
+    @include iui-dialog-placement;
+  }
 }
 
 .iui-dialog-full-page {

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -113,10 +113,6 @@ $iui-dialog-width: 380px;
 }
 
 @mixin iui-dialog-draggable {
-  max-width: 100%;
-  max-height: 100vh;
-  min-width: $iui-dialog-width;
-  min-height: 144px;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--iui-color-background-border);

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -14,7 +14,7 @@ $iui-dialog-width: 380px;
   pointer-events: none;
   transform: translateX(0); // creates containing block for position: fixed
 
-  &[data-iui-relative] {
+  &[data-iui-relative='true'] {
     position: absolute;
   }
 }

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -5,7 +5,7 @@
 $iui-dialog-width: 380px;
 
 @mixin iui-dialog-wrapper {
-  position: relative;
+  position: fixed;
   overflow: hidden;
   top: 0;
   left: 0;
@@ -13,6 +13,10 @@ $iui-dialog-width: 380px;
   height: 100%;
   pointer-events: none;
   transform: translateX(0); // creates containing block for position: fixed
+
+  &[data-iui-relative] {
+    position: absolute;
+  }
 }
 
 @mixin iui-dialog {
@@ -22,7 +26,6 @@ $iui-dialog-width: 380px;
   box-shadow: var(--iui-shadow-5);
   position: fixed;
   padding: var(--iui-size-s) var(--iui-size-m);
-  overflow: hidden;
   pointer-events: auto;
   background-color: var(--iui-color-background-1);
   @media (forced-colors: active) {


### PR DESCRIPTION
1. Changed from `position: relative` to `position: fixed` and added a modifier `data-iui-relative` for `position: absolute`
2. Removed sizing rules from draggable dialog because they are already set in default dialog

After spending some time on it, I was unable to remove default placement rules from draggable dialog because the JS (in itwinui-react) relies on it to calculate the initial position.