### PR TITLE
fix(Checkbox): Change `outline-width` for visibility checkboxes

### DIFF
--- a/packages/itwinui-css/src/checkbox/checkbox.scss
+++ b/packages/itwinui-css/src/checkbox/checkbox.scss
@@ -126,6 +126,8 @@
     --_iui-checkbox-border-color: transparent;
     --_iui-checkbox-background-color: transparent;
 
+    outline-width: 1px;
+
     &:where(:not(:checked):not(:indeterminate)) {
       --_iui-checkbox-svg-color: var(--iui-color-foreground-2);
     }


### PR DESCRIPTION
Visibility checkboxes only require `outline-width: 1px` due to no visible border.  Was inheriting `outline-width: 2px` from non-visibility checkboxes.

**Before:**
![Screen Shot 2022-10-04 at 4 19 43 PM](https://user-images.githubusercontent.com/849817/193918380-a1de4dec-a5c1-4a39-884b-588d0af19bab.png)

**After:**
![Screen Shot 2022-10-04 at 4 19 23 PM](https://user-images.githubusercontent.com/849817/193918316-a3075535-be5f-4439-96d9-d398f41eec01.png)