### PR TITLE
chore: Added aliases in root for commands in css package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "lint": "turbo run lint",
     "lint:copyright": "node packages/shared/copyrightLinter.js",
     "push-docker": "yarn workspace @itwin/itwinui-css push-docker",
-    "approve": "yarn workspace @itwin/itwinui-css approve"
+    "createComponent": "yarn workspace @itwin/itwinui-css createComponent",
+    "approve": "yarn workspace @itwin/itwinui-css approve",
+    "clean:images": "yarn workspace @itwin/itwinui-css clean:images"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "turbo run test --",
     "lint": "turbo run lint",
     "lint:copyright": "node packages/shared/copyrightLinter.js",
-    "push-docker": "yarn workspace @itwin/itwinui-css push-docker"
+    "push-docker": "yarn workspace @itwin/itwinui-css push-docker",
+    "approve": "yarn workspace @itwin/itwinui-css approve"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Closes #748

* Added aliases for commands in `CONTRIBUTING.md` with no specified folder to run in (so users assume to run in root):
  * [`createComponent`](https://github.com/iTwin/iTwinUI/blob/main/CONTRIBUTING.md#adding-a-new-component)
  * [`approve`](https://github.com/iTwin/iTwinUI/blob/main/CONTRIBUTING.md#how-to-run-tests)
  * [`clean:images`](https://github.com/iTwin/iTwinUI/blob/main/CONTRIBUTING.md#how-to-run-tests)

#### Checklist

* [x] Tests passes