### PR TITLE
chore: Add demo page background color switcher

### DIFF
--- a/packages/itwinui-css/backstop/scenarios/footer.js
+++ b/packages/itwinui-css/backstop/scenarios/footer.js
@@ -10,6 +10,7 @@ module.exports = [
   scenario('Type visible in viewport', {
     selectors: ['viewport'],
     viewports: [{ width: 800, height: 600 }],
+    hideSelectors: ['theme-button'],
     scrollToSelector: ['.iui-legal-footer'],
   }),
 
@@ -17,6 +18,7 @@ module.exports = [
   scenario('State hover and focus', {
     selectors: ['viewport'],
     viewports: [{ width: 800, height: 600 }],
+    hideSelectors: ['theme-button'],
     scrollToSelector: ['.iui-legal-footer'],
     actions: [hover('#test-link-1'), focus('#test-link-2')],
   }),

--- a/packages/itwinui-css/backstop/tests/assets/demo.css
+++ b/packages/itwinui-css/backstop/tests/assets/demo.css
@@ -8,28 +8,24 @@
   font-weight: 300;
   src: url('fonts/noto-sans-v27-latin-300.woff2') format('woff2');
 }
-
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 400;
   src: url('fonts/noto-sans-v27-latin-regular.woff2') format('woff2');
 }
-
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 600;
   src: url('fonts/noto-sans-v27-latin-600.woff2') format('woff2');
 }
-
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 700;
   src: url('fonts/noto-sans-v27-latin-700.woff2') format('woff2');
 }
-
 @font-face {
   font-family: 'Noto Sans';
   font-style: italic;
@@ -48,38 +44,42 @@ p {
   margin: 0;
   padding: 0;
   border: none;
-  font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial,
-    sans-serif;
+  font-family: var(--iui-font-sans);
   font-weight: 400;
 }
 
 body {
   margin: 0;
-  padding: 24px;
+  padding: var(--iui-size-l);
   overflow: overlay;
+  transition: background-color var(--iui-duration-1) ease;
 }
 
 h1 {
-  font-size: 32px;
-  margin-bottom: 12px;
+  font-size: var(--iui-font-size-5);
+  margin-bottom: var(--iui-size-s);
 }
 
 h2 {
-  font-size: 22px;
-  margin-bottom: 12px;
+  font-size: var(--iui-font-size-4);
+  margin-bottom: var(--iui-size-s);
 }
 
 h3 {
-  font-size: 16px;
+  font-size: var(--iui-font-size-3);
 }
 
 hr {
   border-top: 1px solid var(--iui-color-background-border);
-  margin: 12px 0;
+  margin: var(--iui-size-s) 0;
 }
 
 /** For sections in backstop tests */
 section[id^='demo'] {
   width: -moz-fit-content; /* stylelint-disable */
   width: fit-content;
+}
+
+.force-background-1 {
+  background-color: var(--iui-color-background-1) !important;
 }

--- a/packages/itwinui-css/backstop/tests/assets/demo.css
+++ b/packages/itwinui-css/backstop/tests/assets/demo.css
@@ -79,7 +79,3 @@ section[id^='demo'] {
   width: -moz-fit-content; /* stylelint-disable */
   width: fit-content;
 }
-
-.force-background-1 {
-  background-color: var(--iui-color-background-1) !important;
-}

--- a/packages/itwinui-css/backstop/tests/assets/demo.css
+++ b/packages/itwinui-css/backstop/tests/assets/demo.css
@@ -8,24 +8,28 @@
   font-weight: 300;
   src: url('fonts/noto-sans-v27-latin-300.woff2') format('woff2');
 }
+
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 400;
   src: url('fonts/noto-sans-v27-latin-regular.woff2') format('woff2');
 }
+
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 600;
   src: url('fonts/noto-sans-v27-latin-600.woff2') format('woff2');
 }
+
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 700;
   src: url('fonts/noto-sans-v27-latin-700.woff2') format('woff2');
 }
+
 @font-face {
   font-family: 'Noto Sans';
   font-style: italic;
@@ -44,34 +48,34 @@ p {
   margin: 0;
   padding: 0;
   border: none;
-  font-family: var(--iui-font-sans);
+  font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial,
+    sans-serif;
   font-weight: 400;
 }
 
 body {
   margin: 0;
-  padding: var(--iui-size-l);
+  padding: 24px;
   overflow: overlay;
-  transition: background-color var(--iui-duration-1) ease;
 }
 
 h1 {
-  font-size: var(--iui-font-size-5);
-  margin-bottom: var(--iui-size-s);
+  font-size: 32px;
+  margin-bottom: 12px;
 }
 
 h2 {
-  font-size: var(--iui-font-size-4);
-  margin-bottom: var(--iui-size-s);
+  font-size: 22px;
+  margin-bottom: 12px;
 }
 
 h3 {
-  font-size: var(--iui-font-size-3);
+  font-size: 16px;
 }
 
 hr {
   border-top: 1px solid var(--iui-color-background-border);
-  margin: var(--iui-size-s) 0;
+  margin: 12px 0;
 }
 
 /** For sections in backstop tests */

--- a/packages/itwinui-css/backstop/tests/assets/theme.js
+++ b/packages/itwinui-css/backstop/tests/assets/theme.js
@@ -3,27 +3,33 @@ class ThemeButton extends HTMLElement {
     super();
     const html = /* html */ `
       <div class="settings-root">
-        <button aria-label="Settings">
+        <button title="Page settings" id="page-settings-menu-button" aria-label="Page settings" aria-haspopup="true" aria-controls="page-settings-menu">
           <svg width="1rem" height="1rem" fill="currentColor" aria-hidden="true" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path d="m16 9.42256v-2.85566l-2.20352-.44435a6.05356 6.05356 0 0 0 -.37645-.903l1.2427-1.87048-2.01923-2.01931-1.86669 1.24016a6.047 6.047 0 0 0 -.91294-.38153l-.44131-2.18839h-2.85566l-.44131 2.18839a6.0501 6.0501 0 0 0 -.91778.38383l-1.85881-1.23495-2.01924 2.01923 1.2388 1.86464a6.05267 6.05267 0 0 0 -.38067.91511l-2.18789.44119v2.85566l2.20054.44373a6.059 6.059 0 0 0 .37924.90383l-1.24251 1.87034 2.01923 2.01924 1.88089-1.24959a6.049 6.049 0 0 0 .8949.372l.44515 2.20735h2.85566l.44683-2.21567a6.05213 6.05213 0 0 0 .88907-.37186l1.882 1.25026 2.01923-2.01923-1.25089-1.88287a6.04854 6.04854 0 0 0 .37291-.89285zm-8.0053 1.61456a3.04782 3.04782 0 1 1 3.04782-3.04782 3.04781 3.04781 0 0 1 -3.04782 3.04782z"/>
           </svg>
         </button>
-        <article class="popup">
+        <article class="popup" id="page-settings-menu" role="menu" aria-labelledby="page-settings-menu-button">
           <fieldset>
-            <legend>Choose theme</legend>
+            <legend>Theme</legend>
             <label tabindex="-1"><input type="radio" name="theme" value="light" /><span>Light</span></label>
             <label tabindex="-1"><input type="radio" name="theme" value="dark" /><span>Dark</span></label>
             <label tabindex="-1"><input type="radio" name="theme" value="light-hc" /><span>High contrast light</span></label>
             <label tabindex="-1"><input type="radio" name="theme" value="dark-hc" /><span>High contrast dark</span></label>
+          </fieldset>
+
+          <fieldset>
+            <legend>Background color</legend>
+            <label tabindex="-1"><input type="radio" name="background" value="bg1" onclick="document.body.classList.add('force-background-1');" /><span>Background 1</span></label>
+            <label tabindex="-1"><input type="radio" name="background" value="bg2" onclick="document.body.classList.remove('force-background-1');" checked /><span>Background 2</span></label>
           </fieldset>
         </article>
       </div>
     `;
     const style = /* css */ `
       :host {
-        position: absolute;
-        top: 0;
-        right: 8px;
+        position: fixed;
+        top: var(--iui-size-xs);
+        right: var(--iui-size-xs);
         z-index: 2;
         accent-color: var(--iui-color-foreground-primary);
         pointer-events: none;
@@ -33,49 +39,74 @@ class ThemeButton extends HTMLElement {
         justify-items: end;
         overflow: hidden;
       }
-      button[aria-label="Settings"] {
+      button[aria-label="Page settings"] {
         pointer-events: auto;
-        padding: 0.5rem;
+        padding: var(--iui-size-xs);
         font: inherit;
         border: none;
         border-radius: 50%;
-        background: transparent;
+        background-color: hsl(var(--iui-color-foreground-1-hsl) / 0.1);
+        backdrop-filter: blur(5px);
         display: inline-grid;
         cursor: pointer;
+        outline-offset: -1px;
+        transition: background-color var(--iui-duration-1) ease;
         -webkit-tap-highlight-color: transparent;
       }
       @media (pointer: coarse) {
-        button[aria-label="Settings"] {
-          padding: 1rem;
+        button[aria-label="Page settings"] {
+          padding: var(--iui-size-m);
         }
       }
-      button[aria-label="Settings"]:hover {
-        background: hsl(0 0% 50% / 0.3);
+      button[aria-label="Page settings"]:hover,
+      button[aria-label="Page settings"]:focus-within {
+        background-color: hsl(var(--iui-color-foreground-1-hsl) / 0.2);
       }
       .popup {
         visibility: hidden; 
         pointer-events: none;
-        box-shadow: 0 1px 5px hsl(0 0% 0% / 0.25);
+        box-shadow: var(--iui-shadow-1);
         background-color: var(--iui-color-background-1);
-        padding: 0.5rem 0.25rem;
-        margin: 0.25rem;
+        padding: var(--iui-size-xs) var(--iui-size-s);
+        margin: var(--iui-size-2xs);
+        display: flex;
+        flex-direction: column;
+        gap: var(--iui-size-xs);
+        opacity: 0;
+        user-select: none;
       }
       .settings-root:focus-within .popup {
         visibility: visible;
         pointer-events: auto;
+        opacity: 1;
+      }
+      @media (forced-colors: active) {
+        button[aria-label="Page settings"],
+        button[aria-label="Page settings"]:hover,
+        button[aria-label="Page settings"]:focus-within {
+          backdrop-filter: none;
+          background-color: Canvas;
+        }
+        
+        button[aria-label="Page settings"],
+        .popup {
+          border: 1px solid;
+        }
       }
       @media (prefers-reduced-motion: no-preference) {
         .popup {
           transform: translateX(100%);
-          transition: transform 200ms ease-in, visibility 0s 200ms;
+          transition: transform var(--iui-duration-1) ease-in, visibility 0s linear var(--iui-duration-1), opacity var(--iui-duration-1) ease-in;
         }
         .settings-root:focus-within .popup {
           transform: translateX(0%);
-          transition: transform 200ms ease-out;
+          transition: transform var(--iui-duration-1) ease-out, visibility 0s linear 0s, opacity var(--iui-duration-1) ease-out;
         }
       }
       fieldset {
         display: grid;
+        border-radius: var(--iui-border-radius-1);
+        border: 1px solid var(--iui-color-background-border);
       }
       fieldset > * {
         display: inline-flex;
@@ -95,7 +126,7 @@ class ThemeButton extends HTMLElement {
       </style>
       ${html}
     `;
-    this.button = this.shadowRoot.querySelector('[aria-label="Settings"]');
+    this.button = this.shadowRoot.querySelector('[aria-label="Page settings"]');
 
     // set default state
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/packages/itwinui-css/backstop/tests/assets/theme.js
+++ b/packages/itwinui-css/backstop/tests/assets/theme.js
@@ -19,8 +19,8 @@ class ThemeButton extends HTMLElement {
 
           <fieldset>
             <legend>Background color</legend>
-            <label tabindex="-1"><input type="radio" name="background" value="bg1" onclick="document.body.classList.add('force-background-1');" /><span>Background 1</span></label>
-            <label tabindex="-1"><input type="radio" name="background" value="bg2" onclick="document.body.classList.remove('force-background-1');" checked /><span>Background 2</span></label>
+            <label tabindex="-1"><input type="radio" name="background" value="bg1" /><span>Background 1</span></label>
+            <label tabindex="-1"><input type="radio" name="background" value="bg2" checked /><span>Background 2</span></label>
           </fieldset>
         </article>
       </div>
@@ -151,15 +151,31 @@ class ThemeButton extends HTMLElement {
     `;
   };
 
+  changeBackground = ({ target: { value: _background } }) => {
+    if (_background == 'bg1') {
+      document.body.style.backgroundColor = 'var(--iui-color-background-1)';
+    } else {
+      document.body.removeAttribute('style');
+    }
+  };
+
   connectedCallback() {
     this.shadowRoot.querySelectorAll('input[name="theme"]').forEach((radio) => {
       radio.addEventListener('change', this.changeTheme);
+    });
+
+    this.shadowRoot.querySelectorAll('input[name="background"]').forEach((radio) => {
+      radio.addEventListener('change', this.changeBackground);
     });
   }
 
   disconnectedCallback() {
     this.shadowRoot.querySelectorAll('input[name="theme"]').forEach((radio) => {
       radio.removeEventListener('change', this.changeTheme);
+    });
+
+    this.shadowRoot.querySelectorAll('input[name="background"]').forEach((radio) => {
+      radio.removeEventListener('change', this.changeBackground);
     });
   }
 }

--- a/packages/itwinui-css/backstop/tests/assets/theme.js
+++ b/packages/itwinui-css/backstop/tests/assets/theme.js
@@ -152,7 +152,7 @@ class ThemeButton extends HTMLElement {
   };
 
   changeBackground = ({ target: { value: _background } }) => {
-    if (_background == 'bg1') {
+    if (_background === 'bg1') {
       document.body.style.backgroundColor = 'var(--iui-color-background-1)';
     } else {
       document.body.removeAttribute('style');


### PR DESCRIPTION
- Add ability to switch the `<body>` background color between 1 & 2 from within `theme.js`.
- Updated visual styling within `theme.js`.
- Page settings button is now fixed top right of the viewport to prevent needing to scroll to the top of the page to adjust settings.
- Hiding the page settings button in `footer.js` test images.

![Screen Shot 2022-10-14 at 6 32 31 PM](https://user-images.githubusercontent.com/849817/195953268-061e74ec-7d00-4d5f-a897-814893eaf75a.png)

I found this useful when working on #762.