### PR TITLE
feat(Timepicker): Allow virtualization

### DIFF
--- a/packages/itwinui-css/src/time-picker/time-picker.scss
+++ b/packages/itwinui-css/src/time-picker/time-picker.scss
@@ -38,7 +38,7 @@
     @include iui-reset;
     list-style: none;
 
-    > li {
+    li {
       @include iui-focus;
       padding: calc(var(--iui-size-s) * 0.5) var(--iui-size-m);
       border-radius: var(--iui-border-radius-1);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37936169/197069961-c8d7866e-6cea-4be8-8a9c-171a5d28b7d5.png)

I need the selector for `li` to be more generic to accomodate additional `div`s in between `ol` and its `li`s when virtualization is enabled in `Timepicker` on the React side. This change will style any `li` under `ol`, even when it's not a direct child.