### PR TITLE
chore: Fix focus of multiselect tag web components

### DIFF
--- a/packages/itwinui-css/backstop/tests/assets/selectTag.js
+++ b/packages/itwinui-css/backstop/tests/assets/selectTag.js
@@ -12,10 +12,7 @@ class SelectTag extends HTMLElement {
     const dismissible = this.hasAttribute('dismissible');
 
     const innerHtml = `
-    <span
-      class="iui-select-tag"
-      tabindex="0"
-    >
+    <span class="iui-select-tag">
       <span
         class="iui-select-tag-label"
         title="${value}"
@@ -24,7 +21,7 @@ class SelectTag extends HTMLElement {
       </span>
       ${
         dismissible
-          ? `<button class="iui-select-tag-button" aria-label="Delete tag" type="button" tabindex="-1">
+          ? `<button class="iui-select-tag-button" aria-label="Delete tag" type="button">
             <svg-close-small class="iui-select-tag-button-icon" aria-hidden="true"></svg-close-small>
           </button>`
           : ''


### PR DESCRIPTION
Focus was appearing around the entire tag within multiselect.  Our CSS does not style outline on the entire tag, only the close button within the tag.  The web component has been updated to correct this.

**Before:** 
![Screenshot 2022-11-01 at 11 58 16 AM](https://user-images.githubusercontent.com/849817/199278802-b259e003-7e9b-4b2b-9381-05c31e059e88.png)

**After:**
![Screenshot 2022-11-01 at 11 58 48 AM](https://user-images.githubusercontent.com/849817/199278927-bad2e841-3530-471a-b72d-06f9d7ade454.png)