### PR TITLE
fix(Select, ComboBox): Fix icon to not overlap outline

### DIFF
--- a/packages/itwinui-css/src/utils/input-container/input-container.scss
+++ b/packages/itwinui-css/src/utils/input-container/input-container.scss
@@ -187,7 +187,8 @@
   &.iui-actionable {
     align-items: center;
     height: calc(100% - 4px); // subtract 2px on both sides to avoid overlapping with border/outline
-    margin-right: 1px;
+    margin-right: 2px; // shift 2px from the right to avoid overlapping with border/outline
+    border-radius: var(--iui-border-radius-1);
     padding-inline: calc(var(--iui-size-xs) + 1px);
     cursor: pointer;
     box-sizing: content-box;


### PR DESCRIPTION
Fixes #794.

In the following snippet:
```css
height: calc(100% - 4px);
margin-right: 2px;
border-radius: var(--iui-border-radius-1);
```
- The `-4px` in height prevents it from overlapping the top and bottom outlines.
- The 2px right margin prevents it from overlapping the right outline.
- The border radius prevents it from clipping the rounded corners.