### PR TITLE
chore: Fix `@charset` warning caused by copyright banner

### DIFF
--- a/packages/shared/copyrightLinter.js
+++ b/packages/shared/copyrightLinter.js
@@ -39,7 +39,21 @@ if (filePaths) {
           case '.js':
           case '.ts':
           case '.css':
-            fs.writeFileSync(filePath, `${copyrightBannerJs}\n${fileContent}`);
+            if (fileContent.startsWith('@charset')) {
+              // @charset must be the first line in the file so insert the copyright banner after it
+              fs.writeFileSync(
+                filePath,
+                fileContent.replace(
+                  '@charset "UTF-8";',
+                  `@charset "UTF-8";\n${copyrightBannerJs}`
+                )
+              );
+            } else {
+              fs.writeFileSync(
+                filePath,
+                `${copyrightBannerJs}\n${fileContent}`
+              );
+            }
             break;
           case '.html':
             fs.writeFileSync(


### PR DESCRIPTION
Our build was causing this warning:
```
@charset must precede all other statements.
```

So I've modified the copyright linter to insert the comment *after* the `@charset` rule.