### PR TITLE
feat(Alert): Use data attributes

### DIFF
--- a/packages/itwinui-css/backstop/tests/alert.html
+++ b/packages/itwinui-css/backstop/tests/alert.html
@@ -45,7 +45,8 @@
     <hr />
 
     <div
-      class="iui-alert-informational"
+      class="iui-alert"
+      data-iui-variant="informational"
       id="demo-informational"
     >
       <svg-info-circular
@@ -73,7 +74,8 @@
     <br />
 
     <div
-      class="iui-alert-positive"
+      class="iui-alert"
+      data-iui-variant="positive"
       id="demo-positive"
     >
       <svg-status-success
@@ -101,7 +103,8 @@
     <br />
 
     <div
-      class="iui-alert-warning"
+      class="iui-alert"
+      data-iui-variant="warning"
       id="demo-warning"
     >
       <svg-status-warning
@@ -129,7 +132,8 @@
     <br />
 
     <div
-      class="iui-alert-negative"
+      class="iui-alert"
+      data-iui-variant="negative"
       id="demo-negative"
     >
       <svg-status-error
@@ -157,7 +161,8 @@
     <br />
 
     <div
-      class="iui-alert-informational"
+      class="iui-alert"
+      data-iui-variant="informational"
       id="demo-long-text"
     >
       <svg-info-circular
@@ -191,7 +196,9 @@
 
     <div id="stickyContainer">
       <div
-        class="iui-alert-informational iui-sticky"
+        class="iui-alert"
+        data-iui-variant="informational"
+        data-iui-sticky="true"
         id="demo-sticky"
       >
         <svg-info-circular

--- a/packages/itwinui-css/backstop/tests/alert.html
+++ b/packages/itwinui-css/backstop/tests/alert.html
@@ -46,7 +46,7 @@
 
     <div
       class="iui-alert"
-      data-iui-variant="informational"
+      data-iui-status="informational"
       id="demo-informational"
     >
       <svg-info-circular
@@ -75,7 +75,7 @@
 
     <div
       class="iui-alert"
-      data-iui-variant="positive"
+      data-iui-status="positive"
       id="demo-positive"
     >
       <svg-status-success
@@ -104,7 +104,7 @@
 
     <div
       class="iui-alert"
-      data-iui-variant="warning"
+      data-iui-status="warning"
       id="demo-warning"
     >
       <svg-status-warning
@@ -133,7 +133,7 @@
 
     <div
       class="iui-alert"
-      data-iui-variant="negative"
+      data-iui-status="negative"
       id="demo-negative"
     >
       <svg-status-error
@@ -162,7 +162,7 @@
 
     <div
       class="iui-alert"
-      data-iui-variant="informational"
+      data-iui-status="informational"
       id="demo-long-text"
     >
       <svg-info-circular
@@ -197,8 +197,8 @@
     <div id="stickyContainer">
       <div
         class="iui-alert"
-        data-iui-variant="informational"
-        data-iui-sticky="true"
+        data-iui-status="informational"
+        data-iui-variant="sticky"
         id="demo-sticky"
       >
         <svg-info-circular

--- a/packages/itwinui-css/src/alert/alert.scss
+++ b/packages/itwinui-css/src/alert/alert.scss
@@ -39,7 +39,6 @@
 }
 
 @mixin iui-alert-link {
-  @include iui-anchor-status;
   @include iui-anchor-underline('on-initial');
   border-radius: var(--iui-border-radius-1);
   cursor: pointer;

--- a/packages/itwinui-css/src/alert/alert.scss
+++ b/packages/itwinui-css/src/alert/alert.scss
@@ -29,6 +29,9 @@
   @include iui-icon-style('m');
   margin-left: var(--iui-size-m);
   fill: var(--_iui-alert-icon-color, var(--iui-color-icon-muted));
+  @media (forced-colors: active) {
+    fill: CanvasText;
+  }
 }
 
 @mixin iui-alert-message {

--- a/packages/itwinui-css/src/alert/alert.scss
+++ b/packages/itwinui-css/src/alert/alert.scss
@@ -9,28 +9,27 @@
 
   --_iui-alert-border-color: var(--iui-color-border);
 
-  border-radius: var(--iui-border-radius-1);
+  border-radius: var(--_iui-alert-border-radius, var(--iui-border-radius-1));
   display: flex;
   align-items: center;
   color: var(--iui-color-text);
   background-color: var(--iui-color-background);
   border: 1px solid var(--_iui-alert-border-color);
   box-shadow: inset var(--iui-size-2xs) 0 0 var(--_iui-alert-border-color);
-  @media (forced-colors: active) {
-    background-color: Canvas;
-  }
+}
 
-  &.iui-sticky {
-    border-radius: 0;
-    position: sticky;
-    top: 0;
-    left: 0;
-  }
+@mixin iui-alert-sticky {
+  --_iui-alert-border-radius: 0;
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
 }
 
 @mixin iui-alert-icon {
   @include iui-icon-style('m');
   margin-left: var(--iui-size-m);
+  fill: var(--_iui-alert-icon-color, var(--iui-color-icon-muted));
 }
 
 @mixin iui-alert-message {
@@ -38,6 +37,7 @@
 }
 
 @mixin iui-alert-link {
+  @include iui-anchor-status;
   @include iui-anchor-underline('on-initial');
   border-radius: var(--iui-border-radius-1);
   cursor: pointer;
@@ -62,16 +62,10 @@
 /// @arg $statusColor Can be one of: informational, positive, warning, negative
 /// @arg $rootSelector Selector of the root alert element. Defaults to .iui-alert
 @mixin iui-alert-category($statusColor, $rootSelector: '.iui-alert') {
-  @include iui-alert;
   --_iui-alert-border-color: var(--iui-color-border-#{$statusColor});
+  --_iui-alert-icon-color: var(--iui-color-icon-#{$statusColor});
 
-  #{$rootSelector}-icon {
-    fill: var(--iui-color-icon-#{$statusColor});
-  }
-
-  #{$rootSelector}-message {
-    @include iui-text-selection($statusColor);
-  }
+  @include iui-text-selection($statusColor);
 
   #{$rootSelector}-link {
     @include iui-anchor-status($statusColor);

--- a/packages/itwinui-css/src/alert/alert.scss
+++ b/packages/itwinui-css/src/alert/alert.scss
@@ -9,7 +9,7 @@
 
   --_iui-alert-border-color: var(--iui-color-border);
 
-  border-radius: var(--_iui-alert-border-radius, var(--iui-border-radius-1));
+  border-radius: var(--iui-border-radius-1);
   display: flex;
   align-items: center;
   color: var(--iui-color-text);
@@ -19,11 +19,10 @@
 }
 
 @mixin iui-alert-sticky {
-  --_iui-alert-border-radius: 0;
+  border-radius: 0;
   position: sticky;
   top: 0;
   left: 0;
-  right: 0;
 }
 
 @mixin iui-alert-icon {

--- a/packages/itwinui-css/src/alert/classes.scss
+++ b/packages/itwinui-css/src/alert/classes.scss
@@ -4,16 +4,20 @@
 
 .iui-alert {
   @include iui-alert;
+
+  @each $status in informational, positive, warning, negative {
+    &:where([data-iui-variant='#{$status}']) {
+      @include iui-alert-category($statusColor: $status);
+    }
+  }
+
+  &:where([data-iui-sticky='true']) {
+    @include iui-alert-sticky;
+  }
 }
 
 .iui-alert-button {
   @include iui-alert-button;
-}
-
-@each $status in informational, positive, warning, negative {
-  .iui-alert-#{$status} {
-    @include iui-alert-category($statusColor: $status);
-  }
 }
 
 .iui-alert-icon {

--- a/packages/itwinui-css/src/alert/classes.scss
+++ b/packages/itwinui-css/src/alert/classes.scss
@@ -6,12 +6,12 @@
   @include iui-alert;
 
   @each $status in informational, positive, warning, negative {
-    &:where([data-iui-variant='#{$status}']) {
+    &:where([data-iui-status='#{$status}']) {
       @include iui-alert-category($statusColor: $status);
     }
   }
 
-  &:where([data-iui-sticky='true']) {
+  &:where([data-iui-variant='sticky']) {
     @include iui-alert-sticky;
   }
 }


### PR DESCRIPTION
- **Use `class="iui-alert" data-iui-status="informational"`.** In #623 we changed from using `.iui-alert .iui-informational` to `.iui-alert-informational` to achieve lower specificity.  We want to keep the base `.iui-alert` for targeting regardless of status.
- **Use `class="iui-alert" data-iui-variant="sticky"`**.

Specificity is under 0, 3, 0 & `alert.css` went from 406 lines to 310.