### PR TITLE
feat!: Add export maps

### DIFF
--- a/packages/itwinui-css/backstop/tests/index.html
+++ b/packages/itwinui-css/backstop/tests/index.html
@@ -70,7 +70,7 @@
       @import url("./assets/demo.css");
       @import url("@itwin/itwinui-variables");
       @import url("@itwin/itwinui-variables/os.css");
-      @import url("@itwin/itwinui-css/css/global.css");
+      @import url("@itwin/itwinui-css/global");
       @import url("@itwin/itwinui-css/css/anchor.css");
     </style>
 

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -9,6 +9,12 @@
     "CHANGELOG.md",
     "LICENSE.md"
   ],
+  "exports": {
+    ".": "./css/all.css",
+    "./all": "./css/all.css",
+    "./global": "./css/global.css",
+    "./*": "./*"
+  },
   "description": "CSS library for building beautiful and well working web UI components within Bentley Systems & iTwin.js applications.",
   "homepage": "https://github.com/iTwin/iTwinUI",
   "keywords": [

--- a/packages/itwinui-variables/package.json
+++ b/packages/itwinui-variables/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "main": "index.css",
   "style": "index.css",
+  "exports": {
+    ".": "./index.css",
+    "./*": "./*"
+  },
   "files": [
     "index.css",
     "os.css",


### PR DESCRIPTION
This will allow modern tools to import using the following paths:
```js
import '@itwin/itwinui-css';
import '@itwin/itwinui-css/all';
import '@itwin/itwinui-css/global';
import '@itwin/itwinui-variables';
```

The `./*` is used to allow internal imports.
```js
import '@itwin/itwinui-css/css/all.css';
import '@itwin/itwinui-css/css/alert.css';
import '@itwin/itwinui-variables/index.css';
import '@itwin/itwinui-variables/os.css';
```

The build is passing and the pages are displaying correctly which means it's working. We are using a lot of different combinations of the above in our html pages. I changed one of the imports to `import '@itwin/itwinui-css/global'` just to double confirm.