### PR TITLE
fix(variables): Combine `:root` and light theme selector

### DIFF
--- a/packages/itwinui-css/src/utils/notification-marker/classes.scss
+++ b/packages/itwinui-css/src/utils/notification-marker/classes.scss
@@ -9,7 +9,7 @@
     @include iui-notification-marker-urgent;
   }
 
-  @each $status in positive, warning, negative, white {
+  @each $status in positive, warning, negative, 'white' {
     &[data-iui-variant='#{$status}'] {
       @include iui-notification-marker-status($status);
     }

--- a/packages/itwinui-css/src/utils/notification-marker/notification-marker.scss
+++ b/packages/itwinui-css/src/utils/notification-marker/notification-marker.scss
@@ -62,7 +62,7 @@ $iui-notification-marker-cutout-radius: calc(0.5 * $iui-notification-marker-cuto
 }
 
 @mixin iui-notification-marker-status($status: informational) {
-  @if $status == white {
+  @if $status == 'white' {
     --_iui-notification-marker-color: var(--iui-color-#{$status});
   } @else {
     --_iui-notification-marker-color: var(--iui-color-icon-#{$status});

--- a/packages/itwinui-variables/src/index.scss
+++ b/packages/itwinui-variables/src/index.scss
@@ -7,7 +7,8 @@
 @use './duration' as *;
 @use './colors';
 
-@mixin common {
+// global vars shared between all themes
+:root {
   @include spacing;
   @include component-heights;
   @include border-radii;
@@ -18,14 +19,7 @@
   @include colors.unthemed;
 }
 
-:root {
-  // global vars shared between all themes
-  @include common;
-
-  // default to light theme if data attribute not set anywhere
-  @include themes.light-theme;
-}
-
+:root, // default to light theme on :root if data attribute not set
 [data-iui-theme='light'] {
   @include themes.light-theme;
 


### PR DESCRIPTION
`:root` and `[data-iui-theme=light]` selectors can be combined to reduce duplication.

Also noticed that sass was complaining about `white` (apparently it thinks it's the color white) so I added quotes around it.