### PR TITLE
chore: Open Graph title is sentence case and uses spaces

### DIFF
--- a/packages/itwinui-css/vite.config.ts
+++ b/packages/itwinui-css/vite.config.ts
@@ -70,7 +70,7 @@ function addMetaTags(): Plugin {
   const metaContent = (componentName) => `
     <meta name="description" content="An open-source design system that helps us build a unified web experience.">
     <meta property="og:site_name" content="iTwinUI">
-    <meta property="og:title" content="${componentName}">
+    <meta property="og:title" content="${componentName[0].toUpperCase() + componentName.replace(/-/g, ' ').slice(1)}">
     <meta property="og:description" content="An open-source design system that helps us build a unified web experience.">
     <meta property="og:image" content="https://itwin.github.io/iTwinUI/backstop/assets/logo.png">
     <meta property="og:image:alt" content="iTwinUI logo">


### PR DESCRIPTION
Previously: `<meta property="og:title" content="information-panel">`
Now: `<meta property="og:title" content="Information panel">`