### PR TITLE
fix: Progress overlay should intercept clicks

### DIFF
--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -1050,8 +1050,7 @@
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
           consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
           pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-          est
-          laborum.
+          est laborum.
         </div>
         <div class="iui-progress-indicator-overlay">
           <!-- Linear indeterminate with label -->
@@ -1075,8 +1074,7 @@
           magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
           consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
           pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-          est
-          laborum.
+          est laborum.
         </div>
 
         <div class="iui-progress-indicator-overlay">

--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -39,10 +39,10 @@
       .demo-overlay-wrapper {
         border: 1px solid var(--iui-color-border);
         position: relative;
+        margin-bottom: 12px;
       }
       .demo-overlay-content {
         padding: 12px;
-        margin-bottom: 12px;
       }
     </style>
   </head>

--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -1107,10 +1107,7 @@
 
     <script type="module">
       (async () => {
-        // when not supported (firefox 107), this property will be undefined rather than false
-        const isInertSupported = document.documentElement.inert === false;
-
-        if (!isInertSupported) {
+        if (!HTMLElement.prototype.hasOwnProperty('inert')) {
           await import('https://unpkg.com/wicg-inert@3.1.2/dist/inert.min.js');
         }
       })();

--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -37,11 +37,11 @@
       }
 
       .demo-overlay-wrapper {
+        border: 1px solid var(--iui-color-border);
         position: relative;
       }
       .demo-overlay-content {
         padding: 12px;
-        border: 1px solid var(--iui-color-border);
         margin-bottom: 12px;
       }
     </style>

--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -36,10 +36,12 @@
         margin-right: 16px;
       }
 
-      #demo-overlay-content {
+      .demo-overlay-wrapper {
+        position: relative;
+      }
+      .demo-overlay-content {
         padding: 12px;
         border: 1px solid var(--iui-color-border);
-        position: relative;
         margin-bottom: 12px;
       }
     </style>
@@ -1039,17 +1041,19 @@
     <h2>Overlay</h2>
     <section id="demo-overlay">
 
-      <div id="demo-overlay-content">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-
+      <div class="demo-overlay-wrapper">
         <div
-          class="iui-progress-indicator-overlay"
-          tabindex="0"
+          class="demo-overlay-content"
+          inert
         >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est
+          laborum.
+        </div>
+        <div class="iui-progress-indicator-overlay">
           <!-- Linear indeterminate with label -->
           <div class="iui-progress-indicator-linear">
             <div class="iui-track">
@@ -1062,17 +1066,20 @@
         </div>
       </div>
 
-      <div id="demo-overlay-content">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-
+      <div class="demo-overlay-wrapper">
         <div
-          class="iui-progress-indicator-overlay"
-          tabindex="0"
+          class="demo-overlay-content"
+          inert
         >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est
+          laborum.
+        </div>
+
+        <div class="iui-progress-indicator-overlay">
           <!-- Radial indeterminate -->
           <div class="iui-progress-indicator-radial iui-indeterminate">
             <svg
@@ -1099,5 +1106,16 @@
         </div>
       </div>
     </section>
+
+    <script type="module">
+      (async () => {
+        // when not supported (firefox 107), this property will be undefined rather than false
+        const isInertSupported = document.documentElement.inert === false;
+
+        if (!isInertSupported) {
+          await import('https://unpkg.com/wicg-inert@3.1.2/dist/inert.min.js');
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/packages/itwinui-css/src/progress-indicator/classes.scss
+++ b/packages/itwinui-css/src/progress-indicator/classes.scss
@@ -29,3 +29,7 @@
 .iui-progress-indicator-overlay {
   @include iui-progress-indicator-overlay;
 }
+
+.iui-progress-indicator-overlay .iui-overlay-exiting {
+  @include iui-progress-overlay-exiting;
+}

--- a/packages/itwinui-css/src/progress-indicator/overlay.scss
+++ b/packages/itwinui-css/src/progress-indicator/overlay.scss
@@ -12,33 +12,27 @@
   top: 0;
   left: 0;
   z-index: 10000;
-  pointer-events: none;
 
   // Blur fallback
   @include iui-blur($hsl: var(--iui-color-background-hsl), $opacity: 3);
-
-  // Focus trap
-  &:focus {
-    outline: 0;
-  }
 
   .iui-progress-indicator-linear {
     width: 50%;
     max-width: 33vw;
   }
+}
 
-  // Fade out on completion
-  @keyframes closeAnimation {
-    from {
-      opacity: var(--iui-opacity-1);
-    }
-
-    to {
-      opacity: 0;
-    }
+// Fade out on completion
+@keyframes closeAnimation {
+  from {
+    opacity: var(--iui-opacity-1);
   }
 
-  .iui-overlay-exiting {
-    animation: closeAnimation var(--iui-duration-1) linear;
+  to {
+    opacity: 0;
   }
+}
+
+@mixin iui-progress-overlay-exiting {
+  animation: closeAnimation var(--iui-duration-1) linear;
 }


### PR DESCRIPTION
Main code change: removed `pointer-events: none`. Not sure why we had it before.

Also:
- removed tabindex and focus rule from overlay
- added `inert` attribute to content to fix focus, with polyfill for firefox
- moved `iui-overlay-exiting` class to `classes.scss` (unrelated change, because it was confusing me when reading the mixin)

Fixes #826