### PR TITLE
chore(createComponent): `theme.js` import added

### DIFF
--- a/packages/itwinui-css/scripts/createComponent.js
+++ b/packages/itwinui-css/scripts/createComponent.js
@@ -91,6 +91,10 @@ const demoHtmlFactory = (directory) => {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>${componentName} | iTwinUI</title>
+    
+    <script type="module">
+      import "./assets/theme.js";
+    </script>
     <style>
       @import url("./assets/demo.css") layer(demo);
       @import url('@itwin/itwinui-variables') layer(variables);


### PR DESCRIPTION
Using `yarn createComponent` now includes the following code in the `<head>` of the component's `html` file 

```html
<script type="module">
  import "./assets/theme.js";
</script>
```

Closes #776 