### PR TITLE
fix(Code): Remove `user-select: all` and extra declarations

### DIFF
--- a/packages/itwinui-css/src/code/code.scss
+++ b/packages/itwinui-css/src/code/code.scss
@@ -3,13 +3,11 @@
 @import '../utils/index';
 
 @mixin iui-code {
-  @include iui-reset;
   display: inline-block;
   font-family: var(--iui-font-mono);
   font-size: var(--iui-font-size-0);
   padding: 0 var(--iui-size-2xs);
   border-radius: var(--iui-border-radius-1);
-  user-select: all;
   background-color: var(--iui-color-background);
   border: 1px solid var(--iui-color-border);
   color: var(--iui-color-text);


### PR DESCRIPTION
Removed `user-select: all` because it is bad from a usability perspective. It breaks lots of expected behaviors like being able to select part of the text or triple-click to select the whole line.

Also removed `iui-reset` because most of those delcarations are unnecessary (either they are the default or they are being overridden or both).