### PR TITLE
Revert "chore: Remove `index.html` anchor from demo page"

### DIFF
--- a/packages/itwinui-css/vite.config.ts
+++ b/packages/itwinui-css/vite.config.ts
@@ -97,7 +97,7 @@ function addMetaTags(): Plugin {
 function getComponentList() {
   return fs
     .readdirSync(new URL('./backstop/tests', import.meta.url))
-    .flatMap((file) => (file.endsWith('.html') && file !== 'index.html' ? [file.split('.')[0]] : []));
+    .flatMap((file) => (file.endsWith('.html') ? [file.split('.')[0]] : []));
 }
 
 function lightningCssPlugin(): Plugin {


### PR DESCRIPTION
Reverts iTwin/iTwinUI#853

excluding it from the componentList results in the file not even being generated, so https://itwin.github.io/iTwinUI is currently 404ing