### PR TITLE
chore: Fix jest trying to run transformed test files

### DIFF
--- a/packages/itwinui-react/jest.config.js
+++ b/packages/itwinui-react/jest.config.js
@@ -2,76 +2,59 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
 // For a detailed explanation regarding each configuration property, visit:
-
 // https://jestjs.io/docs/en/configuration.html
-
 module.exports = {
   // All imported modules in your tests should be mocked automatically
-
   // automock: false,
 
   // Stop running tests after `n` failures
-
   // bail: 0,
 
   // The directory where Jest should store its cached dependency information
-
   // cacheDirectory: "",
 
   // Automatically clear mock calls and instances between every test
-
   // clearMocks: false,
 
   // Indicates whether the coverage information should be collected while executing the test
-
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-
   coveragePathIgnorePatterns: [
     '/node_modules/',
     'src/core/Table/filters/defaultFilterFunctions.ts',
   ],
 
   // A list of reporter names that Jest uses when writing coverage reports
-
   coverageReporters: ['json', 'lcov', 'text', 'clover', 'cobertura'],
 
   // An object that configures minimum threshold enforcement for coverage results
-
   // coverageThreshold: undefined,
 
   // A path to a custom dependency extractor
-
   // dependencyExtractor: undefined,
 
   // Make calling deprecated APIs throw helpful error messages
-
   // errorOnDeprecated: false,
 
   // Force coverage collection from ignored files using an array of glob patterns
-
   // forceCoverageMatch: [],
 
   // A path to a module which exports an async function that is triggered once before all test suites
-
   // globalSetup: undefined,
 
   // A path to a module which exports an async function that is triggered once after all test suites
-
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-
   globals: {
     'ts-jest': {
       tsconfig: {
@@ -81,182 +64,131 @@ module.exports = {
   },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-
   // maxWorkers: "50%",
 
   // An array of directory names to be searched recursively up from the requiring module's location
-
   // moduleDirectories: [
-
   //   "node_modules"
-
   // ],
 
   // An array of file extensions your modules use
-
   // moduleFileExtensions: [
-
   //   "js",
-
   //   "json",
-
   //   "jsx",
-
   //   "ts",
-
   //   "tsx",
-
   //   "node"
-
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': '<rootDir>/src/__mocks__/styleMock.js',
     '\\.(gif|ttf|eot|svg)$': '<rootDir>/src/__mocks__/fileMock.js',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-
   // modulePathIgnorePatterns: [],
 
   // Activates notifications for test results
-
   // notify: false,
 
   // An enum that specifies notification mode. Requires { notify: true }
-
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-
   // preset: undefined,
 
   // Run tests from one or more projects
-
   // projects: undefined,
 
   // Use this configuration option to add custom reporters to Jest
-
   reporters: ['default', ['jest-junit', { outputName: 'coverage/junit.xml' }]],
 
   // Automatically reset mock state between every test
-
   // resetMocks: false,
 
   // Reset the module registry before running each individual test
-
   // resetModules: false,
 
   // A path to a custom resolver
-
   // resolver: undefined,
 
   // Automatically restore mock state between every test
-
   // restoreMocks: false,
 
   // The root directory that Jest should scan for tests and modules within
-
   // rootDir: undefined,
 
   // A list of paths to directories that Jest should use to search for files in
-
   // roots: [
-
   //   "<rootDir>"
-
   // ],
 
   // Allows you to use a custom runner instead of Jest's default test runner
-
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-
   // setupFiles: ['./setupTests.js'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-
   setupFilesAfterEnv: ['./setupTests.ts'],
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-
   testEnvironment: 'jsdom',
 
   // Options that will be passed to the testEnvironment
-
   // testEnvironmentOptions: {},
 
   // Adds a location field to test results
-
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-
   // testMatch: [
-
   //   "**/__tests__/**/*.[jt]s?(x)",
-
   //   "**/?(*.)+(spec|test).[tj]s?(x)"
-
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-
   testPathIgnorePatterns: ['/node_modules/', '/esm/', '/cjs/'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-
   // testRegex: [],
 
   // This option allows the use of a custom results processor
-
   // testResultsProcessor: undefined,
 
   // This option allows use of a custom test runner
-
   // testRunner: "jasmine2",
 
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-
   // testURL: "http://localhost",
 
   // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-
   // timers: "real",
 
   // A map from regular expressions to paths to transformers
-
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [
-
   //   "\\\\node_modules\\\\"
-
   // ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
-
   // verbose: undefined,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-
   watchPathIgnorePatterns: ['stories/*'],
 
   // Whether to use watchman for file crawling
-
   // watchman: true,
 };

--- a/packages/itwinui-react/jest.config.js
+++ b/packages/itwinui-react/jest.config.js
@@ -209,11 +209,11 @@ module.exports = {
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
 
-  // testPathIgnorePatterns: [
-
-  //   "\\\\node_modules\\\\"
-
-  // ],
+  testPathIgnorePatterns: [
+    '\\\\node_modules\\\\',
+    '\\\\esm\\\\',
+    '\\\\cjs\\\\',
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
 

--- a/packages/itwinui-react/jest.config.js
+++ b/packages/itwinui-react/jest.config.js
@@ -209,11 +209,7 @@ module.exports = {
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
 
-  testPathIgnorePatterns: [
-    '\\\\node_modules\\\\',
-    '\\\\esm\\\\',
-    '\\\\cjs\\\\',
-  ],
+  testPathIgnorePatterns: ['/node_modules/', '/esm/', '/cjs/'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
 


### PR DESCRIPTION
Fixes #874 by ignoring telling jest to ignore the test files built by swc.

Also fixed formatting of jest config to remove extra newlines.