### PR TITLE
chore: Fix prettier config in itwinui-css

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,0 @@
-[*]
-end_of_line = lf
-insert_final_newline = true
-indent_size = 2
-indent_style = space
-max_line_length = 120
-quote_type = single

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -27,7 +27,8 @@
     "selector-max-compound-selectors": 4,
     "selector-max-id": 1,
     "selector-no-qualifying-type": null,
-    "scss/dollar-variable-pattern": null
+    "scss/dollar-variable-pattern": null,
+    "max-line-length": 120
   },
   "ignoreFiles": ["lib/**/*", "**/*.html"],
   "customSyntax": "postcss-scss"

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -27,8 +27,7 @@
     "selector-max-compound-selectors": 4,
     "selector-max-id": 1,
     "selector-no-qualifying-type": null,
-    "scss/dollar-variable-pattern": null,
-    "max-line-length": 120
+    "scss/dollar-variable-pattern": null
   },
   "ignoreFiles": ["lib/**/*", "**/*.html"],
   "customSyntax": "postcss-scss"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,8 @@
   "html.format.wrapLineLength": 120,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true
   },
   "[html]": {
     "editor.defaultFormatter": "vscode.html-language-features"

--- a/packages/configs/package.json
+++ b/packages/configs/package.json
@@ -8,7 +8,8 @@
     "copyrightLinter.js",
     "eslint-preset.js",
     "prettier-config.js",
-    "prettier-astro-config.js"
+    "prettier-astro-config.js",
+    "prettier-scss-config.js"
   ],
   "scripts": {
     "clean": "rimraf .turbo && rimraf node_modules"

--- a/packages/configs/prettier-scss-config.js
+++ b/packages/configs/prettier-scss-config.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+const baseConfig = require('./prettier-config.js');
+
+module.exports = {
+  ...baseConfig,
+  printWidth: 120,
+};

--- a/packages/itwinui-css/backstop/engine_scripts/puppet/browserActionsHelper.js
+++ b/packages/itwinui-css/backstop/engine_scripts/puppet/browserActionsHelper.js
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 const { ScenarioActions } = require('../../scenarioHelper');
 
 async function performAction(page, action) {
@@ -31,7 +35,7 @@ async function performAction(page, action) {
         },
         action.value.selector,
         action.value.distanceX,
-        action.value.distanceY
+        action.value.distanceY,
       );
       break;
     }

--- a/packages/itwinui-css/backstop/scenarioHelper.js
+++ b/packages/itwinui-css/backstop/scenarioHelper.js
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 function scenario(testCase, options = {}) {
   return Object.assign(
     {
@@ -18,7 +22,7 @@ function scenario(testCase, options = {}) {
       misMatchThreshold: 0.001,
       requireSameDimensions: true,
     },
-    options
+    options,
   );
 }
 

--- a/packages/itwinui-css/backstop/scenarios/dialog.js
+++ b/packages/itwinui-css/backstop/scenarios/dialog.js
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 const { scenario, click } = require('../scenarioHelper');
 
 module.exports = [
@@ -24,6 +28,6 @@ module.exports = [
       actions: [click(`input[value=${placement}`), click('#open-dialog')],
       selectors: ['document'],
       hideSelectors: ['body > :not(:is(#default-dialog, #full-page-dialog, #draggable-dialog))'],
-    })
+    }),
   ),
 ];

--- a/packages/itwinui-css/backstop/tests/assets/demo.css
+++ b/packages/itwinui-css/backstop/tests/assets/demo.css
@@ -48,8 +48,7 @@ p {
   margin: 0;
   padding: 0;
   border: none;
-  font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial,
-    sans-serif;
+  font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;
 }
 

--- a/packages/itwinui-css/backstop/tests/assets/theme.js
+++ b/packages/itwinui-css/backstop/tests/assets/theme.js
@@ -1,3 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 class ThemeButton extends HTMLElement {
   constructor() {
     super();
@@ -133,7 +137,7 @@ class ThemeButton extends HTMLElement {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const prefersHC = window.matchMedia('(prefers-contrast: more)').matches;
     this.shadowRoot.querySelector(
-      `input[value=${prefersDark ? 'dark' : 'light'}${prefersHC ? '-hc' : ''}`
+      `input[value=${prefersDark ? 'dark' : 'light'}${prefersHC ? '-hc' : ''}`,
     ).checked = true;
     document.documentElement.dataset.iuiTheme = prefersDark ? 'dark' : 'light';
     document.documentElement.dataset.iuiContrast = prefersHC ? 'high' : undefined;

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -62,5 +62,6 @@
     "clean:images": "node scripts/removeOldTestImages.js",
     "print": "node scripts/print.js",
     "push-docker": "node scripts/pushDocker.js"
-  }
+  },
+  "prettier": "configs/prettier-scss-config.js"
 }

--- a/packages/itwinui-css/scripts/pushDocker.js
+++ b/packages/itwinui-css/scripts/pushDocker.js
@@ -11,7 +11,7 @@ spawn(
   {
     stdio: 'inherit',
     shell: true,
-  }
+  },
 )
   .on('error', (error) => {
     process.exitCode = 1;

--- a/packages/itwinui-css/scripts/watchScss.mjs
+++ b/packages/itwinui-css/scripts/watchScss.mjs
@@ -28,9 +28,7 @@ const inputsAndOutputsList = [
 
 // sass cli expects this format (https://sass-lang.com/documentation/cli/dart-sass)
 // src/all.scss:css/all.css src/alert/classes.scss:css/alert.css
-const spaceSeparatedInputsAndOutputs = inputsAndOutputsList
-  .map(([scss, css]) => `${scss}:${css}`)
-  .join(' ');
+const spaceSeparatedInputsAndOutputs = inputsAndOutputsList.map(([scss, css]) => `${scss}:${css}`).join(' ');
 
 spawn(`yarn sass --watch ${spaceSeparatedInputsAndOutputs}`, {
   stdio: 'inherit',

--- a/packages/itwinui-css/vite.config.ts
+++ b/packages/itwinui-css/vite.config.ts
@@ -13,10 +13,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: Object.fromEntries(
-        getComponentList().map((name) => [
-          name,
-          resolve(__dirname, `./backstop/tests/${name}.html`),
-        ]),
+        getComponentList().map((name) => [name, resolve(__dirname, `./backstop/tests/${name}.html`)]),
       ),
       output: {
         dir: './backstop/minified',
@@ -74,9 +71,7 @@ function addMetaTags(): Plugin {
   const metaContent = (componentName) => `
     <meta name="description" content="An open-source design system that helps us build a unified web experience.">
     <meta property="og:site_name" content="iTwinUI">
-    <meta property="og:title" content="${
-      componentName[0].toUpperCase() + componentName.replace(/-/g, ' ').slice(1)
-    }">
+    <meta property="og:title" content="${componentName[0].toUpperCase() + componentName.replace(/-/g, ' ').slice(1)}">
     <meta property="og:description" content="An open-source design system that helps us build a unified web experience.">
     <meta property="og:image" content="https://itwin.github.io/iTwinUI/backstop/assets/logo.png">
     <meta property="og:image:alt" content="iTwinUI logo">
@@ -110,10 +105,7 @@ function getComponentList() {
 
 function lightningCssPlugin(): Plugin {
   const queryWhitelist = ['direct'];
-  const matcherRegex = new RegExp(
-    `\\.css\\??(?:${queryWhitelist.join('|')})?$`,
-    'i',
-  );
+  const matcherRegex = new RegExp(`\\.css\\??(?:${queryWhitelist.join('|')})?$`, 'i');
   return {
     name: 'lightning-css',
     transform(css, id) {


### PR DESCRIPTION
Before #868, we were relying on `editorconfig` which sets a line length of 120. This is now set in prettier.

This will fix the unintentional formatting changes we saw in https://github.com/iTwin/iTwinUI/pull/935#discussion_r1057810187 and https://github.com/iTwin/iTwinUI/pull/860#discussion_r1060937554

Also noticed and fixed stylelint was missing from fixOnSave (bad merge in #868).