### PR TITLE
chore: Update copyright notice year in all licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright © Bentley Systems, Incorporated. All rights reserved.
+Copyright © 2021-2023 Bentley Systems, Incorporated. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/itwinui-css/LICENSE.md
+++ b/packages/itwinui-css/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright © Bentley Systems, Incorporated. All rights reserved.
+Copyright © 2021-2023 Bentley Systems, Incorporated. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/itwinui-react/LICENSE.md
+++ b/packages/itwinui-react/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright © Bentley Systems, Incorporated. All rights reserved.
+Copyright © 2021-2023 Bentley Systems, Incorporated. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/itwinui-variables/LICENSE.md
+++ b/packages/itwinui-variables/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright © Bentley Systems, Incorporated. All rights reserved.
+Copyright © 2022-2023 Bentley Systems, Incorporated. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Legally this should not be a requirement (some _very_ popular packages like [react](https://unpkg.com/react/LICENSE) don't include the year), but it's "policy" so I've added the year range in all licenses.

This is now one more thing we need to update every year, in addition to the footer (#945)