### PR TITLE
chore: Remove `index` anchor from html demo page

### DIFF
--- a/packages/itwinui-css/vite.config.ts
+++ b/packages/itwinui-css/vite.config.ts
@@ -30,6 +30,7 @@ function generateIndex(): Plugin {
     code.replace(
       '%PUT_CONTENT_HERE%',
       `<ul>${getComponentList()
+        .filter((component) => component !== 'index')
         .map((component) => {
           return `<li><a class="iui-anchor" href="${component}.html">${component}</a></li>\n`;
         })
@@ -101,30 +102,4 @@ function getComponentList() {
   return fs
     .readdirSync(new URL('./backstop/tests', import.meta.url))
     .flatMap((file) => (file.endsWith('.html') ? [file.split('.')[0]] : []));
-}
-
-function lightningCssPlugin(): Plugin {
-  const queryWhitelist = ['direct'];
-  const matcherRegex = new RegExp(`\\.css\\??(?:${queryWhitelist.join('|')})?$`, 'i');
-  return {
-    name: 'lightning-css',
-    transform(css, id) {
-      if (!matcherRegex.test(id)) {
-        return;
-      }
-
-      try {
-        const { code } = lightningCss.transform({
-          minify: true,
-          sourceMap: false,
-          code: Buffer.from(css),
-          filename: id,
-          targets: require('./scripts/lightningCssSettings').targets,
-        });
-        return code.toString('utf8');
-      } catch {
-        return css;
-      }
-    },
-  };
 }

--- a/packages/itwinui-css/vite.config.ts
+++ b/packages/itwinui-css/vite.config.ts
@@ -6,7 +6,6 @@ import { defineConfig, type Plugin } from 'vite';
 import fs from 'fs';
 import { resolve } from 'path';
 import { minify } from 'html-minifier';
-import * as lightningCss from 'lightningcss';
 
 export default defineConfig({
   base: './',


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.
Please describe your PR here and make sure to complete all of the items below before submitting.
-->

Closes #744 <!-- Add issue number -->

* Removed `index` anchor link from the HTML demo page.
* Unrelated change: removed unused `lightningCssPlugin()` from `vite.config.ts` since after #935, lightningcss postprocessing is done in the watch script instead of a vite plugin.

## Checklist

- ~[ ]~ Add meaningful unit tests for your component (verify that all lines are covered)
- [x] Verify that all existing tests pass
- ~[ ]~ Add component features demo in Storybook (different stories)
- ~[ ]~ Approve test images for new stories
- ~[ ]~ Add screenshots of the key elements of the component
