### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,34 @@
 <!--
 Thank you for your contribution to iTwinUI.
-Please describe your PR here and make sure to complete all of the items below before submitting.
+
+If you are only making changes to the docs site using the "Edit page on GitHub" link,
+then you can ignore most of this template.
 -->
 
-Closes # <!-- Add issue number -->
+Closes #<!-- Add issue number -->
 
-## Checklist
+## Changes
 
-- [ ] Add meaningful unit tests for your component (verify that all lines are covered)
-- [ ] Verify that all existing tests pass
-- [ ] Add component features demo in Storybook (different stories)
-- [ ] Approve test images for new stories
-- [ ] Add screenshots of the key elements of the component
+<!--
+What kind of code changes does this PR include?
+Mention anything that could be helpful for reviewers and include screenshots for visual changes.
+-->
+
+## Testing
+
+<!--
+How did you test your changes?
+If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
+storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).
+
+If not applicable, you can write "N/A".
+-->
+
+## Docs
+
+<!--
+If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
+Make sure to include a changeset (`yarn changeset`).
+
+If not applicable, you can write "N/A".
+-->


### PR DESCRIPTION
## Changes

Trying something new. Instead of a boring checklist which gets ignored in all PRs, I've separated the PR template into three sections (much like this very PR description) and added somewhat helpful comments to each. Got this idea from the astro repo (take a look at some of their [merged PRs](https://github.com/withastro/astro/pulls?q=is%3Apr+is%3Aclosed+) for examples). And if one of the sections does not apply to a PR, then we can write "N/A".

## Testing

N/A

## Docs

N/A