### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,6 +369,7 @@ To enable us to quickly review and accept your pull requests, always create one 
 - Tests added for all new code.
   - All existing and new tests should pass.
 - Stories added to demonstrate new features.
+- If your changes are user-facing, then add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) by running `yarn changeset`.
 
 Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that the name of your pull request follows the [Conventional Commits spec](https://www.conventionalcommits.org/), and that you have a proper description with screenshots and a [closing keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,10 +369,8 @@ To enable us to quickly review and accept your pull requests, always create one 
 - Tests added for all new code.
   - All existing and new tests should pass.
 - Stories added to demonstrate new features.
-- If your changes are user-facing, then add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) by running `yarn changeset`.
+- [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) using `yarn changeset`, if changes are user-facing.
 
-Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
-
-If your pull request changes an existing component, we ask that the description distinctly lists all visual changes that have occurred. These notes are used by the Visual Design team to update specifications and images within documentation.
+Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure your pull request has a proper description and a [linked issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
 Your pull request will be reviewed by one or more maintainers who might leave some comments/suggestions to help improve the quality and consistency of your code. Once approved, your changes will be accepted into the repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ Need a feature or found a bug? Please create an [issue](https://github.com/iTwin
 
 Have a question or suggestion? Please create a [discussion](https://github.com/iTwin/iTwinUI/discussions).
 
-Want to contribute by creating a pull request? Great! [Fork iTwinUI](https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository) to get started.
+If you're only contributing changes to the **iTwinUI documentation website**, you can ignore this guide, as it's geared towards technical contributions to component code.
+
+Want to contribute code changes to components? Great! [Fork iTwinUI](https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository) to get started.
 
 ---
 
@@ -60,6 +62,8 @@ e.g. to build all workspaces together, run the following command from the root:
 yarn build
 ```
 
+If you only need to run this task for a specific workspace, you can specify turborepo's `--filter` argument. For example, if you only want to build itwinui-react, you could run `yarn build --filter=itwinui-react`. Note that this will automatically run `build` for any dependencies (e.g. `itwinui-css` and `itwinui-variables`). You can see the pipeline in the `turbo.json` file.
+
 #### Development environment
 
 To start the development server for all workspaces, run the following command from the root.
@@ -76,8 +80,6 @@ By default, a portal will be opened containing links to all the different dev se
   - astro playground: `http://localhost:1703`
   - storybook: `http://localhost:6006` (storybook default)
   - html test pages: `http://localhost:5173` (vite default)
-
-If you only need to run this task for a specific workspace, you can specify turborepo's `--filter` argument. For example, if you only want to start storybook, you could run `yarn dev --filter=storybook`.
 
 ### Running bespoke commands
 
@@ -104,68 +106,9 @@ This is why it's recommended to use the turbo `--filter` syntax whenever possibl
 yarn build --filter=storybook
 ```
 
-### Adding a new component (CSS)
-
-If you'd like to get your component added to iTwinUI, follow these guidelines.
-
-We provide a script that can automatically create all the necessary files for you. Simply run `yarn createComponent [component-name]` (e.g. `yarn createComponent my-component`).
-
-- Add all your component styles in `src/[component-name]/[component-name].scss` file.
-  - Break variables and mixins into separate files where possible.
-  - Use existing Sass variables for spacing (margin, padding, sizing, etc).
-- Define classes for your mixin in `src/[component-name]/classes.scss` file.
-  - _Running the `createComponent` command will do this for you._
-- Make sure your component index and classes are imported in `src/all.scss`.
-  - _Running the `createComponent` command will also do this for you but you need to manually sort the imports alphabetically._
-- Write tests for your new component in `backstop/tests/[component-name].html` and `backstop/scenarios/[component-name].js`. See [Testing](#Testing) section below.
-- After running `yarn build` you can open minified html in browser to check up, how your component looks like from `backstop/minified`.
-
-### Visual testing (CSS)
-
-#### How to run tests:
-
-For running tests you will need [Docker](https://www.docker.com/products/docker-desktop). It helps to avoid cross-platform rendering differences.
-
-- Make sure Docker is running.
-
-- To run tests for a specific component, use this command:
-
-  `yarn test --filter=[component_name]` (e.g. `yarn test --filter=side-navigation`)
-
-- To approve test images, run `yarn approve:css`.
-
-- To delete old/unused tests images, run `yarn clean:images`.
-
-#### How to write tests:
-
-- Write the html in `backstop/tests/[component-name].html` displaying the elements you wish to test and their all possible states, using the built CSS in `lib/css/`.
-
-- Write the test cases in `backstop/scenarios/[component-name].js` and ensure it exports scenarios list (see `backstop/scenarios/alert.js` for example).
-  - Use `scenario` function from `scenarioHelper.js` to create a scenario where the first argument is test case name and the second one is options.
-    ```js
-    const { scenario } = require('../scenarioHelper');
-    module.exports = [scenario('basic')];
-    ```
-  - For actions like click, hover use according functions from `scenarioHelper.js` and pass them as scenario options `actions` property.
-    ```js
-    const { scenario, hover } = require('../scenarioHelper');
-    module.exports = [scenario('hover', { actions: [hover('.element-selector')] })];
-    ```
-  - If you want to select only specific part of the test elements, pass `selectors` property to the options.
-    ```js
-    const { scenario } = require('../scenarioHelper');
-    module.exports = [scenario('selected part', { selectors: ['.selected-part-selector'] })];
-    ```
-  - If you want to hide some elements because they might be moving e.g. spinner, pass `hideSelectors` property to the options.
-    ```js
-    const { scenario } = require('../scenarioHelper');
-    module.exports = [scenario('hide part', { hideSelectors: ['.hide-selector'] })];
-    ```
-  - More information about options can be found in [BackstopJS GitHub](https://github.com/garris/BackstopJS#advanced-scenarios).
-
 ---
 
-### Creating components (React)
+### Creating components
 
 Before developing, please read our [style guide](./STYLEGUIDE.md).
 
@@ -178,6 +121,18 @@ It ensures all needed imports are added and files are created.
 > Note: Every component needs to use `useTheme()` hook to ensure styling (theming) works fine. The `createComponent` script mentioned above adds it automatically.
 
 For a component named `Alert`, the `createComponent` script will add/modify the following files:
+
+- packages/itwinui-css/src/**alert/alert.scss**: framework-agnostic component styles
+- packages/itwinui-css/src/**alert/classes.scss**: all user-facing class names/attributes
+- packages/itwinui-css/backstop/tests/**alert.html**: html test cases for component css
+- packages/itwinui-css/backstop/scenarios/**alert.js**: visual test scenarios for html
+- packages/itwinui-react/src/core/**Alert/Alert.tsx**: react component
+- packages/itwinui-react/src/core/**Alert/Alert.test.tsx**: unit tests for react component
+- packages/itwinui-react/src/core/**Alert/index.ts**: barrel file for component exports
+- packages/itwinui-react/src/core/**index.ts**: barrel file containing all public exports
+- apps/storybook/src/**Alert.stories.tsx**: common demo states and examples ("stories")
+- apps/storybook/src/**Alert.test.tsx**: cypress visual tests for stories
+- apps/websites/src/pages/docs/**alert.mdx**: documentation page for the component
 
 <details>
 <summary>Directory structure</summary>
@@ -215,54 +170,19 @@ apps/storybook
 |   + - src
 |       |
 |       + - > Alert.stories.tsx
-|.      + - > Alert.test.ts
+|       + - > Alert.test.ts
+|
+apps/website
+|   |
+|   + - src
+|       |
+|       + - pages
+|           |
+|           + - docs
+|               + -> alert.mdx
 ```
 
 </details>
-
-packages/itwinui-css/src/**alert/alert.scss**
-  - Contains the framework-agnostic styling for the component
-
-packages/itwinui-css/backstop/tests/**alert.html**
-  - Contains all the test cases and demonstrations for the framework-agnostic css.
-
-packages/itwinui-css/backstop/scenarios/**alert.js**
-  - Contains the visual test scenarios for the html.
-
-packages/itwinui-react/src/core/**Alert/Alert.tsx**
-
-- Implements the React component and exports it, both named and by default.
-
-packages/itwinui-react/src/core/**Alert/Alert.test.tsx**
-
-- Contains all test cases for the component.
-
-packages/itwinui-react/src/core/**Alert/index.ts**
-
-```jsx
-export { Alert } from './Alert';
-export type { AlertProps } from './Alert';
-export default './Alert';
-```
-
-packages/itwinui-react/src/core/**index.ts**
-
-```jsx
----
-export { Alert } from './Alert';
-export type { AlertProps } from './Alert';
----
-```
-
-> Note: The script will add the exports to index.ts but you will need to manually sort them alphabetically.
-
-apps/storybook/src/**Alert.stories.tsx**
-
-- Contains common demo states and examples for the component.
-
-apps/storybook/src/**Alert.test.tsx**
-
-- Contains the Cypress test for the component.
 
 ### Importing icons
 
@@ -274,15 +194,6 @@ apps/storybook/src/**Alert.test.tsx**
 e.g.
 ```tsx
 import { SvgClose, SvgInfoCircular } from '../utils';
-```
-
-#### In other modules:
-
-* Import it from `@itwin/itwinui-icons-react`
-
-e.g.
-```tsx
-import { SvgChevronRightDouble, SvgFolder } from '@itwin/itwinui-icons-react';
 ```
 
 ### Documentation
@@ -356,6 +267,47 @@ it('should be visible', () => {
   getByText('some text');
 });
 ```
+
+### Visual testing (CSS)
+
+We reuse our html test pages for visual tests by taking screenshots of parts of the page using [BackstopJS](https://github.com/garris/BackstopJS).
+
+#### How to run tests:
+
+For running tests you will need [Docker](https://www.docker.com/products/docker-desktop). It helps to avoid cross-platform rendering differences.
+
+- Make sure Docker is running.
+- To run tests for a specific component, use this command:
+  `yarn workspace itwinui-css test --filter=[component_name]` (e.g. `yarn workspace itwinui-css test --filter=side-navigation`)
+- To approve test images, run `yarn approve:css`.
+- To delete old/unused tests images, run `yarn clean:images`.
+
+#### How to write tests:
+
+- Write the html in `packages/itwinui-css/backstop/tests/[component-name].html` displaying the elements you wish to test and their all possible states.
+
+- Write the test cases in `backstop/scenarios/[component-name].js` and ensure it exports scenarios list (see `backstop/scenarios/alert.js` for example).
+  - Use `scenario` function from `scenarioHelper.js` to create a scenario where the first argument is test case name and the second one is options.
+    ```js
+    const { scenario } = require('../scenarioHelper');
+    module.exports = [scenario('basic')];
+    ```
+  - For actions like click, hover use according functions from `scenarioHelper.js` and pass them as scenario options `actions` property.
+    ```js
+    const { scenario, hover } = require('../scenarioHelper');
+    module.exports = [scenario('hover', { actions: [hover('.element-selector')] })];
+    ```
+  - If you want to select only specific part of the test elements, pass `selectors` property to the options.
+    ```js
+    const { scenario } = require('../scenarioHelper');
+    module.exports = [scenario('selected part', { selectors: ['.selected-part-selector'] })];
+    ```
+  - If you want to hide some elements because they might be moving e.g. spinner, pass `hideSelectors` property to the options.
+    ```js
+    const { scenario } = require('../scenarioHelper');
+    module.exports = [scenario('hide part', { hideSelectors: ['.hide-selector'] })];
+    ```
+  - More information about options can be found in [BackstopJS GitHub](https://github.com/garris/BackstopJS#advanced-scenarios).
 
 ### Visual testing (React)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,7 +369,7 @@ To enable us to quickly review and accept your pull requests, always create one 
 - Tests added for all new code.
   - All existing and new tests should pass.
 - Stories added to demonstrate new features.
-- [Changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) using `yarn changeset`, if changes are user-facing.
+- Added [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) using `yarn changeset`, if changes are user-facing.
 
 Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure your pull request has a proper description and a [linked issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,7 +371,7 @@ To enable us to quickly review and accept your pull requests, always create one 
 - Stories added to demonstrate new features.
 - If your changes are user-facing, then add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) by running `yarn changeset`.
 
-Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork). Make sure that the name of your pull request follows the [Conventional Commits spec](https://www.conventionalcommits.org/), and that you have a proper description with screenshots and a [closing keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests).
+Verify that your changes are ready, then [create a pull request from your fork](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).
 
 If your pull request changes an existing component, we ask that the description distinctly lists all visual changes that have occurred. These notes are used by the Visual Design team to update specifications and images within documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ For a component named `Alert`, the `createComponent` script will add/modify the 
 - packages/itwinui-react/src/core/**index.ts**: barrel file containing all public exports
 - apps/storybook/src/**Alert.stories.tsx**: common demo states and examples ("stories")
 - apps/storybook/src/**Alert.test.tsx**: cypress visual tests for stories
-- apps/websites/src/pages/docs/**alert.mdx**: documentation page for the component
+- apps/website/src/pages/docs/**alert.mdx**: documentation page for the component
 
 <details>
 <summary>Directory structure</summary>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Updates to contributing guide:
- added prominent note that the guide can be ignored for docs-only contributions
- made the "Adding components" sections smaller, combining the css/react sections.
  - this is because we are not that often adding new components.
- moved the "Visual testing (CSS)" down.
- updated some commands and paths.
- added note about changesets and removed note about conventional commits
- removed note about "Visual Design team" and "specifications". not relevant anymore

## Testing

N/A

## Docs

N/A
