### PR TITLE
Run CI on all PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - 'main'
   pull_request:
-    branches:
-      - 'main'
 
 jobs:
   install:


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Build/tests should run on all PRs, not just those created against `main`.

In addition to the "v1" case mentioned in https://github.com/iTwin/iTwinUI/pull/977#discussion_r1065024847, this could also be useful for:
- chained PRs (branches based on other branches based on `main`)
- backporting fixes to legacy branches

## Testing

N/A

## Docs

N/A
