### PR TITLE
chore(Avatar): Show `<img>` in JSDocs as a codeblock

### DIFF
--- a/packages/itwinui-react/src/core/Avatar/Avatar.tsx
+++ b/packages/itwinui-react/src/core/Avatar/Avatar.tsx
@@ -35,7 +35,7 @@ export type AvatarProps = {
    */
   abbreviation?: string;
   /**
-   * User image to be displayed. MUST be an <img> element!
+   * User image to be displayed. MUST be an `<img>` element!
    */
   image?: JSX.Element;
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

* When going through `Avatar.tsx`, I noticed that the JSDocs for the `image` props was rendering the `<img>` element. So this is a small fix to render it as a codeblock.
* I also searched other similar places using the regex `\*.*<[a-z]+` and found none.

#### Old
<img width="300px" src="https://user-images.githubusercontent.com/45748283/211416262-db090e76-82f6-4765-b652-203e40ee6333.png" />

#### New
<img width="300px" src="https://user-images.githubusercontent.com/45748283/211416227-d0afdc61-6391-4d88-a565-11de462e4ff2.png" />

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A