### PR TITLE
Tile: Move `position: relative` from content to root

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -15,6 +15,7 @@
   flex-direction: column;
   width: calc(var(--iui-size-3xl) * 3);
   backface-visibility: hidden;
+  position: relative;
 
   &:where(:not(.iui-folder)) {
     > :where(:first-child) {
@@ -144,7 +145,6 @@
 
 @mixin iui-tile-content {
   padding: var(--iui-size-s) var(--iui-size-s);
-  position: relative;
   display: flex;
   flex-direction: column;
   flex-grow: 2;


### PR DESCRIPTION
## Changes

This should improve the sandbox in https://github.com/iTwin/iTwinUI/issues/985#issuecomment-1379477077 where `<a>` is placed inside the Tile `name` with the pseudo-content trick for accessible cards. In that sandbox, if a `thumbnail` is used in the Tile, then it is not clickable.

That trick uses `position: absolute` which mean it looks upwards for a `position: relative`, which *should* be the Tile itself.

I checked, and the more-options button is the only element inside tile-content that uses `position: absolute`. Since it is anchored to the bottom right of the tile (which is the same as the bottom right of the tile-content), it should remain unaffected in the regular case. But looks like it breaks when there are buttons at the bottom of the tile. _Will need to rethink the approach here. Maybe needs another wrapper._

## Testing

Pending

## Docs

Undocumented until we add an official API (#840).
