### PR TITLE
Add missing `forwardRef` in Icon

### DIFF
--- a/packages/itwinui-react/src/core/utils/components/Icon.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Icon.tsx
@@ -65,17 +65,20 @@ const getSizeValue = (size: string) => {
  *   <SvgStatusError />
  * </Icon>
  */
-export const Icon = (props: IconProps) => {
-  const { size = 'medium', fill = 'default', className, ...rest } = props;
+export const Icon = React.forwardRef(
+  (props: IconProps, ref: React.RefObject<HTMLSpanElement>) => {
+    const { size = 'medium', fill = 'default', className, ...rest } = props;
 
-  return (
-    <span
-      className={cx('iui-svg-icon', className)}
-      data-iui-icon-size={getSizeValue(size)}
-      data-iui-icon-color={fill}
-      {...rest}
-    />
-  );
-};
+    return (
+      <span
+        className={cx('iui-svg-icon', className)}
+        data-iui-icon-size={getSizeValue(size)}
+        data-iui-icon-color={fill}
+        ref={ref}
+        {...rest}
+      />
+    );
+  },
+);
 
 export default Icon;


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

forwardRef was missed in original PR. It is useful for DOM manipulation and adding things like tooltips.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Not needed, it is standard in many components.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

No changeset needed because Icon is not released yet.