### PR TITLE
Use PAT for changeset workflow checkout

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ITWINUI_CHANGESETS }}
 
       - name: Use Node 16.X
         uses: actions/setup-node@v3


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Looks like #1000 didn't do it. Token might need to be used for the checkout step too. https://github.com/changesets/action/issues/187#issuecomment-1228413850

## Testing

N/A. Will need to wait for CI to run on #996.

## Docs

N/A
