### PR TITLE
Fix broken links on html demo pages

### DIFF
--- a/packages/itwinui-css/backstop/tests/header.html
+++ b/packages/itwinui-css/backstop/tests/header.html
@@ -100,7 +100,7 @@
                   >
                     <img
                       class="iui-header-breadcrumb-button-icon"
-                      src="../assets/image-test.jpg"
+                      src="./assets/image-test.jpg"
                       draggable="false"
                     />
                     <span class="iui-header-breadcrumb-button-text">
@@ -439,7 +439,7 @@
                   >
                     <img
                       class="iui-header-breadcrumb-button-icon"
-                      src="../assets/image-test.jpg"
+                      src="./assets/image-test.jpg"
                       draggable="false"
                     />
                     <span class="iui-header-breadcrumb-button-text">
@@ -741,7 +741,7 @@
                     >
                       <img
                         class="iui-header-breadcrumb-button-icon"
-                        src="../assets/image-test.jpg"
+                        src="./assets/image-test.jpg"
                         draggable="false"
                       />
                       <span class="iui-header-breadcrumb-button-text">
@@ -1133,7 +1133,7 @@
                 >
                   <img
                     class="iui-header-breadcrumb-button-icon"
-                    src="../assets/image-test.jpg"
+                    src="./assets/image-test.jpg"
                     draggable="false"
                   />
                   <span class="iui-header-breadcrumb-button-text">

--- a/packages/itwinui-css/backstop/tests/menu.html
+++ b/packages/itwinui-css/backstop/tests/menu.html
@@ -696,7 +696,7 @@
                 >
                   <img
                     class="iui-header-breadcrumb-button-icon"
-                    src="../assets/image-test.jpg"
+                    src="./assets/image-test.jpg"
                     draggable="false"
                   />
                   <span class="iui-header-breadcrumb-button-text">
@@ -846,7 +846,7 @@
                 >
                   <img
                     class="iui-header-breadcrumb-button-icon"
-                    src="../assets/image-test.jpg"
+                    src="./assets/image-test.jpg"
                     draggable="false"
                   />
                   <span class="iui-header-breadcrumb-button-text">


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

I noticed that some images for [`header.html`](https://itwin.github.io/iTwinUI/css/header.html) were showing as broken. This happened only on the deployed version but not on the localhost version, not sure why. This PR makes small fixes to the image path.

![image](https://user-images.githubusercontent.com/45748283/212987452-ebb59769-956a-4931-87b1-732edeebaea6.png)

I also searched for `../assets/` and found two occurrences in `menu.html`. Corrected the path there too.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

I verified that the images show correctly in the deploy preview for the PR.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A