### PR TITLE
Revert "Use PAT for changeset workflow checkout"

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ITWINUI_CHANGESETS }}
 
       - name: Use Node 16.X
         uses: actions/setup-node@v3


### PR DESCRIPTION
Reverts #1001 because it is not working and the changeset workflow fails entirely 😔. Will need to figure something else out.