### PR TITLE
Use PAT for changeset workflow checkout (again)

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -34,3 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ITWINUI_CHANGESETS }}
           NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ITWINUI_CHANGESETS }}
 
       - name: Use Node 16.X
         uses: actions/setup-node@v3


### PR DESCRIPTION
Reverts #1009. In other words, reintroduces #1001.

### Explanation

Recently, I made two changes: #1000 and #1001.

After merging #1000, I noticed that it didn't fix the issue. It was updating the release PR (#996) but not running the build and tests. So I created #1001.

After merging #1001, I noticed that the changeset workflows were failing, so #996 was not being updated anymore.

So I reverted #1001 in #1009 but it didn't change anything.

Then I guessed that the token was bad, so I asked @FlyersPh9 to reauthorize SSO. After that, I re-ran the workflows at two different points and found that #1001 does work correctly! Tests automatically run.

![](https://user-images.githubusercontent.com/9084735/213020133-fe77e774-91b2-4812-9336-71e380d4f396.png)

But it's using the wrong username (because @FlyersPh9 created the PAT), so to fix that I'm trying to see if setting the committer name/email manually works. [`0831c9e`](https://github.com/iTwin/iTwinUI/pull/1012/commits/0831c9e127cf46b8c412ceed67e32174077eccea)
