### PR TITLE
website: Example hotfixes

### DIFF
--- a/apps/website/src/components/LeftSidebar.astro
+++ b/apps/website/src/components/LeftSidebar.astro
@@ -62,6 +62,7 @@ import LeftSidebarContent from './LeftSidebarContent.astro';
   }
 
   aside {
+    height: 100%;
     max-width: 80%;
     background-color: var(--color-background-2);
     border-right: 1px solid var(--color-line-2);

--- a/apps/website/src/examples/Alert.sticky.tsx
+++ b/apps/website/src/examples/Alert.sticky.tsx
@@ -7,7 +7,7 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <>
+    <div>
       <Alert
         isSticky
         onClose={() => console.log('CLOSED')}
@@ -17,6 +17,6 @@ export default () => {
         This is a sticky alert
       </Alert>
       <p>Page content.</p>
-    </>
+    </div>
   );
 };

--- a/apps/website/src/examples/Blockquote.main.tsx
+++ b/apps/website/src/examples/Blockquote.main.tsx
@@ -7,7 +7,7 @@ import { Blockquote } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <div style={{ width: '80%' }}>
+    <div style={{ padding: '0 48px' }}>
       <Blockquote
         cite={'https://www.bentley.com/en'}
         footer={

--- a/apps/website/src/examples/DropdownMenu.main.tsx
+++ b/apps/website/src/examples/DropdownMenu.main.tsx
@@ -45,7 +45,17 @@ export default () => {
     </MenuItem>,
   ];
   return (
-    <div style={{ height: '70%', width: '50%', display: 'flex', alignItems: 'flex-start' }}>
+    <div
+      style={{
+        height: '70%',
+        width: '50%',
+        display: 'flex',
+        alignItems: 'flex-start',
+        position: 'absolute',
+        left: '38%',
+        top: '18%',
+      }}
+    >
       <ButtonGroup>
         <IconButton disabled>
           <SvgPlaceholder />

--- a/apps/website/src/examples/Keyboard.main.tsx
+++ b/apps/website/src/examples/Keyboard.main.tsx
@@ -6,5 +6,11 @@ import * as React from 'react';
 import { Kbd, KbdKeys } from '@itwin/itwinui-react';
 
 export default () => {
-  return <Kbd>{KbdKeys.Enter}</Kbd>;
+  return (
+    <div style={{ display: 'flex', gap: '12px' }}>
+      <Kbd>{KbdKeys.Enter}</Kbd>
+      <Kbd>{KbdKeys.Command}</Kbd>
+      <Kbd>{KbdKeys.Down}</Kbd>
+    </div>
+  );
 };

--- a/apps/website/src/examples/NonIdealState.main.tsx
+++ b/apps/website/src/examples/NonIdealState.main.tsx
@@ -11,19 +11,7 @@ export default () => {
     <NonIdealState
       svg={<Svg404 />}
       heading='Page not found'
-      description={
-        <>
-          We can not find the iModel that you are looking for or it does not exist.
-          <br />
-          Visit the iModel HUB or contact our support team.
-        </>
-      }
-      actions={
-        <>
-          <Button styleType={'high-visibility'}>Retry</Button>
-          <Button>Contact us</Button>
-        </>
-      }
+      description={<>We can not find the iModel that you are looking for or it does not exist.</>}
     />
   );
 };

--- a/apps/website/src/examples/ProgressLinear.main.tsx
+++ b/apps/website/src/examples/ProgressLinear.main.tsx
@@ -7,7 +7,7 @@ import { ProgressLinear } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <div style={{ width: '80%' }}>
+    <div style={{ width: '200px' }}>
       <ProgressLinear indeterminate />
     </div>
   );

--- a/apps/website/src/examples/RadioTile.main.tsx
+++ b/apps/website/src/examples/RadioTile.main.tsx
@@ -8,7 +8,7 @@ import { SvgNetwork, SvgWindows } from '@itwin/itwinui-icons-react';
 
 export default () => {
   return (
-    <RadioTileGroup>
+    <RadioTileGroup style={{ width: '350px' }}>
       <RadioTile
         label='Web'
         description='Dimensions in px'

--- a/apps/website/src/examples/Slider.main.tsx
+++ b/apps/website/src/examples/Slider.main.tsx
@@ -7,7 +7,7 @@ import { Slider } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <div style={{ width: '80%' }}>
+    <div style={{ width: '300px' }}>
       <Slider values={[50]} min={0} max={100} />
     </div>
   );

--- a/apps/website/src/examples/Surface.main.tsx
+++ b/apps/website/src/examples/Surface.main.tsx
@@ -10,7 +10,6 @@ export default () => {
     <Surface
       elevation={4}
       style={{
-        width: '50%',
         height: '50%',
         display: 'flex',
         justifyContent: 'center',

--- a/apps/website/src/examples/Table.main.tsx
+++ b/apps/website/src/examples/Table.main.tsx
@@ -51,6 +51,7 @@ export default () => {
         id: 'product',
         Header: 'Product',
         accessor: 'product',
+        width: '40%',
       },
       {
         id: 'price',
@@ -59,11 +60,6 @@ export default () => {
         Cell: (props: CellProps<TableStoryDataType>) => {
           return <>${props.value}</>;
         },
-      },
-      {
-        id: 'quantity',
-        Header: 'Quantity',
-        accessor: 'quantity',
       },
       {
         id: 'rating',
@@ -88,7 +84,7 @@ export default () => {
   }, []);
 
   return (
-    <div style={{ width: '90%' }}>
+    <div style={{ width: '300px' }}>
       <Table
         columns={columns}
         emptyTableContent='No data.'

--- a/apps/website/src/examples/Tabs.main.tsx
+++ b/apps/website/src/examples/Tabs.main.tsx
@@ -18,7 +18,7 @@ export default () => {
     }
   };
   return (
-    <div style={{ width: '70%' }}>
+    <div style={{ padding: '0 48px' }}>
       <Tabs
         orientation='horizontal'
         labels={[

--- a/apps/website/src/examples/Tree.main.tsx
+++ b/apps/website/src/examples/Tree.main.tsx
@@ -67,6 +67,7 @@ export default () => {
 
   return (
     <Tree<StoryData>
+      style={{ width: '260px' }}
       data={data}
       getNode={getNode}
       nodeRenderer={React.useCallback(

--- a/apps/website/src/pages/docs/alert.mdx
+++ b/apps/website/src/pages/docs/alert.mdx
@@ -25,7 +25,7 @@ An alert is an element that notifies the user of something important that is not
 
 ## Appearance
 
-An alert must have a foreground status color. The alert message must be concise, we recommend no more than 256 characters. If you feel the need to explain in further detail, you may use an optional hyperlink at the end of the alert message to explain more on a new page. You may also include an optional close icon (close icon is required for sticky alerts). The following types of alerts are permissible:
+The alert message must be concise, we recommend no more than 256 characters. If you feel the need to explain in further detail, you may use an optional hyperlink at the end of the alert message to explain more on a new page. You may also include an optional close icon (close icon is required for sticky alerts).
 
 ### Informational
 

--- a/apps/website/src/pages/docs/carousel.mdx
+++ b/apps/website/src/pages/docs/carousel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carousel
-description:
+description: A slideshow component for cycling through elements.
 layout: ./_layout.astro
 propsPath: '@itwin/itwinui-react/esm/core/Carousel/Carousel.d.ts'
 exampleCodeFile1: Carousel.main.tsx
@@ -15,12 +15,13 @@ import LiveExample from '~/components/LiveExample.astro';
 
 <LiveExample src={frontmatter.exampleCodeFile1} />
 
-## Appearance
+The Carousel component consists of a set of slides, normally displayed one at a time. A navigation section is
+located below the slides, consisting of "dots" and "previous"/"next" buttons, used for changing slides.
 
-## Usage
+The currently shown slide can also be changed using the left/right arrow keys or by dragging on a touch device.
+
+This component uses a composition approach so it should be used with the provided subcomponents.
 
 ## Props
 
-<PropsTable path={frontmatter.propsPath} />
-
-## Related resources
+To be defined.

--- a/apps/website/src/pages/docs/combobox.mdx
+++ b/apps/website/src/pages/docs/combobox.mdx
@@ -15,6 +15,10 @@ import LiveExample from '~/components/LiveExample.astro';
 
 <LiveExample src={frontmatter.exampleCodeFile1} />
 
+ComboBox component that allows typing a value to filter the options in dropdown list.
+
+Values can be selected either using mouse clicks or using the Enter key.
+
 ## Props
 
 <PropsTable path={frontmatter.propsPath} />

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -149,7 +149,7 @@ const currentPage = new URL(Astro.request.url).pathname;
         </li>
         <li class='library-item'>
           <h3>
-            <a href='/https://itwin.github.io/iTwinUI-icons/'>Icons</a>
+            <a href='https://itwin.github.io/iTwinUI-icons/'>Icons</a>
           </h3>
           <p>
             Hundreds of flexible, flat-styled icons in SVG format, allowing for infinite scalability


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

- Added some fixes to examples (styling, width, padding)
- Fixes `Icons` link in home page

We need to re-think LiveExamples to not include inline styles.

## Testing

Open pages and check how it looks.

## Docs

N/A
