### PR TITLE
DropdownButton: Add dropdownMenuProps

### DIFF
--- a/.changeset/kind-zoos-boil.md
+++ b/.changeset/kind-zoos-boil.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`DropdownButton` now exposes `dropdownMenuProps` to allow control over all popover props, such as `placement`.

--- a/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
+++ b/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.test.tsx
@@ -106,3 +106,14 @@ it('should render borderless button correctly', () => {
   expect(button).toBeTruthy();
   expect(button).toHaveAttribute('data-iui-variant', 'borderless');
 });
+
+it('should allow changing placement', async () => {
+  const { container } = renderComponent({
+    dropdownMenuProps: { placement: 'bottom-end' },
+  });
+  const button = container.querySelector('.iui-button') as HTMLElement;
+  await userEvent.click(button);
+
+  const popover = document.querySelector('.iui-popover');
+  expect(popover).toHaveAttribute('data-placement', 'bottom-end');
+});

--- a/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -30,7 +30,7 @@ export type DropdownButtonProps = {
   /**
    * Props for the `DropdownMenu` which extends `PopoverProps`.
    */
-  dropdownMenuProps?: Omit<DropdownMenuProps, 'menuItems'>;
+  dropdownMenuProps?: Omit<DropdownMenuProps, 'menuItems' | 'children'>;
 } & Omit<ButtonProps, 'onClick' | 'styleType' | 'endIcon'>;
 
 /**

--- a/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { Button, ButtonProps } from '../Button';
-import { DropdownMenu } from '../../DropdownMenu';
+import { DropdownMenu, DropdownMenuProps } from '../../DropdownMenu';
 import {
   SvgCaretDownSmall,
   SvgCaretUpSmall,
@@ -27,6 +27,10 @@ export type DropdownButtonProps = {
    * @default 'default'
    */
   styleType?: 'default' | 'borderless';
+  /**
+   * Props for the `DropdownMenu` which extends `PopoverProps`.
+   */
+  dropdownMenuProps?: Omit<DropdownMenuProps, 'menuItems'>;
 } & Omit<ButtonProps, 'onClick' | 'styleType' | 'endIcon'>;
 
 /**
@@ -40,7 +44,15 @@ export type DropdownButtonProps = {
  */
 export const DropdownButton = React.forwardRef(
   (props: DropdownButtonProps, ref: React.RefObject<HTMLButtonElement>) => {
-    const { menuItems, className, size, styleType, children, ...rest } = props;
+    const {
+      menuItems,
+      className,
+      size,
+      styleType,
+      children,
+      dropdownMenuProps,
+      ...rest
+    } = props;
 
     useTheme();
 
@@ -60,9 +72,16 @@ export const DropdownButton = React.forwardRef(
     return (
       <DropdownMenu
         menuItems={menuItems}
-        style={{ minWidth: menuWidth }}
-        onShow={() => setIsMenuOpen(true)}
-        onHide={() => setIsMenuOpen(false)}
+        {...dropdownMenuProps}
+        onShow={(i) => {
+          setIsMenuOpen(true);
+          dropdownMenuProps?.onShow?.(i);
+        }}
+        onHide={(i) => {
+          setIsMenuOpen(false);
+          dropdownMenuProps?.onHide?.(i);
+        }}
+        style={{ minWidth: menuWidth, ...dropdownMenuProps?.style }}
       >
         <Button
           className={cx('iui-button-dropdown', className)}

--- a/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
@@ -28,7 +28,7 @@ export type DropdownMenuProps = {
    * Child element to wrap dropdown with.
    */
   children: React.ReactNode;
-} & PopoverProps &
+} & Omit<PopoverProps, 'content'> &
   Omit<CommonProps, 'title'>;
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Added `dropdownMenuProps` to give user full control over the `DropdownMenu` which wraps the button. Closes #1028.

We are going to get rid of `tippy.js` so this prop will be removed in the next major release, but it's pretty useful to have right now.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Basic unit test added. Didn't add visual test. This doesn't need extensive testing because it is not really a new feature, it's just propagating the props.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

Changeset added.