### PR TITLE
use node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -42,10 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -68,10 +68,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -99,10 +99,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -188,10 +188,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -223,10 +223,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -283,10 +283,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Cache node_modules
         uses: actions/cache@v3

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           token: ${{ secrets.ITWINUI_CHANGESETS }}
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: yarn
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: "Which package to publish?"
+        description: 'Which package to publish?'
         required: true
         type: choice
         default: itwinui-css
@@ -13,7 +13,7 @@ on:
           - itwinui-variables
           - itwinui-react
       tag:
-        description: "Which npm tag to publish to?"
+        description: 'Which npm tag to publish to?'
         required: true
         type: choice
         default: latest
@@ -43,10 +43,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 18.x
           registry-url: https://registry.npmjs.org/
 
       - run: yarn install

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node 16.X
+      - name: Use Node 18.X
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - run: yarn
       - run: yarn build --filter=storybook

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Want to contribute code changes to components? Great! [Fork iTwinUI](https://doc
 
 ## How to setup
 
-To clone and build iTwinUI, you'll need [Git](https://git-scm.com), [Node 16](https://nodejs.org/en/download/), and [Yarn 1](https://classic.yarnpkg.com/en/docs/install) installed on your computer.
+To clone and build iTwinUI, you'll need [Git](https://git-scm.com), [Node 16+](https://nodejs.org/en/download/), and [Yarn 1](https://classic.yarnpkg.com/en/docs/install) installed on your computer.
 
 1. [Create a local clone](https://docs.github.com/en/get-started/quickstart/fork-a-repo#cloning-your-forked-repository) of your forked repository. You can do this from the command line or using the Github Desktop app.
 2. Go to the directory where you cloned iTwinUI. e.g. `cd iTwinUI`.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "storybook": "start-storybook -p 6006 --no-open",
-    "build": "dotenv -v NODE_OPTIONS=--openssl-legacy-provider -- build-storybook",
+    "build": "build-storybook",
     "dev": "yarn storybook --quiet",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "node scripts/run-tests.js",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -19,6 +19,7 @@
     "configs": "*",
     "cypress": "9.6.0",
     "cypress-image-diff-js": "1.18.1",
+    "dotenv-cli": "7.0.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-storybook": "^0.6.4",
@@ -32,7 +33,7 @@
   },
   "scripts": {
     "storybook": "start-storybook -p 6006 --no-open",
-    "build": "build-storybook",
+    "build": "dotenv -v NODE_OPTIONS=--openssl-legacy-provider -- build-storybook",
     "dev": "yarn storybook --quiet",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "node scripts/run-tests.js",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -33,8 +33,8 @@
   },
   "scripts": {
     "storybook": "start-storybook -p 6006 --no-open",
-    "build": "build-storybook",
-    "dev": "yarn storybook --quiet",
+    "build": "dotenv -v NODE_OPTIONS=--openssl-legacy-provider -- build-storybook",
+    "dev": "dotenv -v NODE_OPTIONS=--openssl-legacy-provider -- yarn storybook --quiet",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "node scripts/run-tests.js",
     "approve": "cypress-image-diff -u",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8058,10 +8058,30 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dotenv-cli@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-7.0.0.tgz#b24e842a4c00928ec91d051ab152cd927c66ad97"
+  integrity sha512-XfMzVdpdDTRnlcgvFLg3lSyiLXqFxS4tH7RbK5IxkC4XIUuxPyrGoDufkfLjy/dA28EILzEu+mros6h8aQmyGg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    dotenv "^16.0.0"
+    dotenv-expand "^10.0.0"
+    minimist "^1.2.6"
+
+dotenv-expand@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
+  integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
+
 dotenv-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv@^16.0.0:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
 dotenv@^8.0.0:
   version "8.6.0"


### PR DESCRIPTION
## Changes

Node 16 is no longer the active LTS version. When you go to https://nodejs.org, it prompts you to install Node 18, not 16.
![](https://user-images.githubusercontent.com/9084735/216419266-dc3c1ade-ca33-413c-b2ec-0c4eb95966c9.png)

Storybook does not work out of the box with Node 18 because it uses some old version of webpack internally. See issues: https://github.com/storybookjs/storybook/issues/20482 and https://github.com/storybookjs/storybook/issues/20209

This is possible to work around by using `NODE_OPTIONS=--openssl-legacy-provider`.

It's a bit silly that the latest stable version of storybook does not work with the latest stable version of node. Apparently this will be fixed in storybook 7, which won't be released until March this year. This workaround will avoid issues with new contributors in the meantime.

Also, node 16 users are unaffected.

## Testing

Tested locally by switching to node 18.

I've also updated our CI to use node 18 instead of node 16 and tested that CI [fails](https://github.com/iTwin/iTwinUI/actions/runs/4077564555/jobs/7026750726) when not setting NODE_OPTIONS and [passes](https://github.com/iTwin/iTwinUI/actions/runs/4077566304/jobs/7026753079) when setting it.

## Docs

Mentioned Node "16+" (previously was "16") in contributing setup instructions.