### PR TITLE
Specify type='button' on paginator buttons

### DIFF
--- a/.changeset/nice-toys-collect.md
+++ b/.changeset/nice-toys-collect.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where TablePaginator buttons were causing postbacks when used inside a form.

--- a/packages/itwinui-react/src/core/Table/TablePaginator.test.tsx
+++ b/packages/itwinui-react/src/core/Table/TablePaginator.test.tsx
@@ -38,6 +38,7 @@ it('should render in its most basic form', () => {
   const pages = container.querySelectorAll('.iui-table-paginator-page-button');
   expect(pages).toHaveLength(20);
   expect(pages[0]).toHaveAttribute('data-iui-active', 'true');
+  expect(pages[0]).toHaveAttribute('type', 'button');
 
   const previousPageButton = screen.getByLabelText(
     'Previous page',

--- a/packages/itwinui-react/src/core/Table/TablePaginator.tsx
+++ b/packages/itwinui-react/src/core/Table/TablePaginator.tsx
@@ -172,6 +172,7 @@ export const TablePaginator = (props: TablePaginatorProps) => {
     (index: number, tabIndex = index === focusedIndex ? 0 : -1) => (
       <button
         key={index}
+        type='button'
         className={cx('iui-table-paginator-page-button', {
           'iui-table-paginator-page-button-small': buttonSize === 'small',
         })}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Specify type='button' to prevent postbacks when pager is used in forms.
Fixes issue #1053 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->
Copy/pasted sample from https://codesandbox.io/s/paging-page-refresh-w0bpoh?file=/App.tsx in vite playground to verify pager buttons no longer postback.

## Docs

N/A