### PR TITLE
fix VirtualScroll minHeight update for react 17

### DIFF
--- a/.changeset/clever-moons-clap.md
+++ b/.changeset/clever-moons-clap.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in ComboBox where the height of empty state content was not getting updated when using `enableVirtualization`.

--- a/packages/itwinui-react/src/core/utils/components/VirtualScroll.tsx
+++ b/packages/itwinui-react/src/core/utils/components/VirtualScroll.tsx
@@ -3,11 +3,15 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
   mergeRefs,
   useResizeObserver,
   useIsomorphicLayoutEffect,
 } from '../hooks';
+
+const unstable_batchedUpdates =
+  ReactDOM.unstable_batchedUpdates ?? ((cb: () => void) => void cb());
 
 const getScrollableParent = (
   element: HTMLElement | null,
@@ -224,9 +228,10 @@ export const useVirtualization = (props: VirtualScrollProps) => {
       if (height > 0) {
         setIsMounted(true);
       }
-      setScrollContainerHeight(height);
-
-      updateChildHeight();
+      unstable_batchedUpdates(() => {
+        setScrollContainerHeight(height);
+        updateChildHeight();
+      });
     },
     [updateChildHeight],
   );


### PR DESCRIPTION
## Changes

React 18 automatically batches all updates, but React 17 doesn't. We can opt into this by using `unstable_batchedUpdates`, which fixes #1050.

Yes, this is an "unstable" API, but it will be around for the forseeable future and I've added a noop fallback just in case. See https://github.com/reactwg/react-18/discussions/21

## Testing

Tested by manually replicating this sandbox in vite playground: https://codesandbox.io/s/itwinui-react-example-forked-qk7dyt?file=/src/index.tsx

## Docs

Added changeset.
