### PR TITLE
CI: do not error when publishing test results fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,6 +244,7 @@ jobs:
 
       - name: Publish test results artifact
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v2.2.3
         with:
           name: 'backstop_test_results'
@@ -263,6 +264,7 @@ jobs:
 
       - name: Post test results link under Checks
         if: github.ref != 'refs/heads/main' && always()
+        continue-on-error: true
         uses: actions/github-script@v6
         with:
           script: |
@@ -304,6 +306,7 @@ jobs:
 
       - name: Publish test results artifact
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v3.0.0
         with:
           name: 'cypress-visual-screenshots'


### PR DESCRIPTION
## Changes

Currently if "optional" steps fail (such as uploading test results to github-pages or posting a link to it) for any reason, then it fails the whole step, which is not ideal. The failure often happens due to issues with permissions (e.g. bot user or external contributor).

This PR will make them not be marked as failures (big prominent ❌).

When the actual tests fail, they will still be marked as failures (❌).

## Testing

N/A. Will need to wait and see how CI behaves..

## Docs

N/A
