### PR TITLE
Run CI on pushes to gh-merge queue branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - main
+      - gh-readonly-queue/main/*
   pull_request:
   merge_group:
 


### PR DESCRIPTION
## Changes

`merge_group` alone does not currently work so added `gh-readonly-queue/main/*` branch filtering. Based on [community suggestion](https://github.com/orgs/community/discussions/46757#discussioncomment-4908280).

## Testing

N/A

## Docs

N/A
