### PR TITLE
Skip gh-pages deploy for merge queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - gh-readonly-queue/main/*
   pull_request:
   merge_group:
 
@@ -94,6 +93,7 @@ jobs:
     name: Push static files to github pages
     needs: install
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

- Removed `gh-readonly-queue` filter from `push` trigger. This was previously added because the `merge_group` trigger was broken.
- Added extra filtering to the gh-pages deploy job, so that it will be skipped for the `merge_group` trigger. This will prevent CI from failing (see [failure](https://github.com/iTwin/iTwinUI/actions/runs/4145520173)).

## Testing

TBD

## Docs

N/A
