### PR TITLE
Remove flex centering from checkbox labels

### DIFF
--- a/.changeset/thirty-bugs-clean.md
+++ b/.changeset/thirty-bugs-clean.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed a bug where inline elements (e.g. links) were getting disrupted when using inside a checkbox label.

--- a/packages/itwinui-css/src/checkbox/checkbox.scss
+++ b/packages/itwinui-css/src/checkbox/checkbox.scss
@@ -2,59 +2,59 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import '../utils/index';
 
-@mixin iui-checkbox {
-  &-wrapper {
-    @include iui-reset;
+@mixin iui-checkbox-wrapper {
+  @include iui-reset;
+  display: flex;
+  align-items: center;
+  font-size: var(--iui-font-size-1);
+  width: fit-content;
+  user-select: none;
+  position: relative;
+  cursor: pointer;
+  color: var(--iui-color-text);
+  gap: var(--iui-size-xs);
+
+  &.iui-loading {
+    cursor: progress;
+    font-style: italic;
+    color: var(--iui-color-text-disabled);
+  }
+
+  > .iui-checkbox-label,
+  > .iui-radio-label {
     display: flex;
     align-items: center;
-    font-size: var(--iui-font-size-1);
-    width: fit-content;
-    user-select: none;
-    position: relative;
-    cursor: pointer;
-    color: var(--iui-color-text);
-    gap: var(--iui-size-xs);
 
-    &.iui-loading {
-      cursor: progress;
-      font-style: italic;
-      color: var(--iui-color-text-disabled);
-    }
-
-    > .iui-checkbox-label,
-    > .iui-radio-label {
-      display: flex;
-      align-items: center;
-
-      svg {
-        @include iui-icon-style('m');
-        vertical-align: middle;
-        fill: var(--iui-color-icon);
-      }
-    }
-
-    &.iui-disabled {
-      cursor: not-allowed;
-      color: var(--iui-color-text-disabled);
-
-      svg {
-        fill: var(--iui-color-icon-disabled);
-      }
-    }
-
-    &.iui-positive {
-      color: var(--iui-color-text-positive);
-    }
-
-    &.iui-warning {
-      color: var(--iui-color-text-warning);
-    }
-
-    &.iui-negative {
-      color: var(--iui-color-text-negative);
+    svg {
+      @include iui-icon-style('m');
+      vertical-align: middle;
+      fill: var(--iui-color-icon);
     }
   }
 
+  &.iui-disabled {
+    cursor: not-allowed;
+    color: var(--iui-color-text-disabled);
+
+    svg {
+      fill: var(--iui-color-icon-disabled);
+    }
+  }
+
+  &.iui-positive {
+    color: var(--iui-color-text-positive);
+  }
+
+  &.iui-warning {
+    color: var(--iui-color-text-warning);
+  }
+
+  &.iui-negative {
+    color: var(--iui-color-text-negative);
+  }
+}
+
+@mixin iui-checkbox {
   --_iui-checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="m6.5 12.5-4.5-4.5 1.5-1.5 3 3 6-6 1.5 1.5z" /></svg>');
   --_iui-checkbox-indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="m2.75 6.875h10.5v2.25h-10.5z" /></svg>');
   --_iui-checkbox-unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');

--- a/packages/itwinui-css/src/checkbox/checkbox.scss
+++ b/packages/itwinui-css/src/checkbox/checkbox.scss
@@ -52,6 +52,10 @@
 }
 
 @mixin iui-checkbox {
+  &-wrapper {
+    @include iui-checkbox-wrapper;
+  }
+
   --_iui-checkbox-checkmark-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="m6.5 12.5-4.5-4.5 1.5-1.5 3 3 6-6 1.5 1.5z" /></svg>');
   --_iui-checkbox-indeterminate-svg: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="m2.75 6.875h10.5v2.25h-10.5z" /></svg>');
   --_iui-checkbox-unchecked-svg: url('data:image/svg+xml;utf8,<svg viewBox="0 0 16 16"></svg>');

--- a/packages/itwinui-css/src/checkbox/checkbox.scss
+++ b/packages/itwinui-css/src/checkbox/checkbox.scss
@@ -22,9 +22,6 @@
 
   > .iui-checkbox-label,
   > .iui-radio-label {
-    display: flex;
-    align-items: center;
-
     svg {
       @include iui-icon-style('m');
       vertical-align: middle;


### PR DESCRIPTION
## Changes

Flex centering is not necessary on checkbox labels. It breaks inline elements, especially at narrow widths, so I've removed it.

Fixes #845

## Testing

All existing tests should pass.

Also manually tested this code from the linked issue description:
```html
<label class="iui-checkbox-wrapper">
  <input class="iui-checkbox" type="checkbox" />
  <span class="iui-checkbox-label">I agree to the <a href="#" class="iui-anchor">terms of service</a>.</span>
</label>
```
It wraps correctly.
<img src="https://user-images.githubusercontent.com/9084735/218862540-f942fbed-4355-440b-a080-5002755033a5.png" width="50%">


## Docs

Changeset added.