### PR TITLE
fix(Table): Fixed reordering column behavior when columns are hidden

### DIFF
--- a/.changeset/brave-dragons-sparkle.md
+++ b/.changeset/brave-dragons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed bug which gave an unexpected column order once columns were hidden, reordered, and then shown

--- a/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
+++ b/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
@@ -98,7 +98,7 @@ const defaultGetDragAndDropProps =
       event.preventDefault();
       setOnDragColumnStyle(event);
 
-      const columnIds = instance.flatHeaders.map((x) => x.id);
+      const columnIds = instance.allColumns.map((x) => x.id);
       const srcIndex = instance.state.columnReorderStartIndex;
       const dstIndex = columnIds.findIndex((x) => x === header.id);
 


### PR DESCRIPTION
## Changes

Fixed a bug which gave users an unexpected column order when columns were hidden, reordered, and then shown
Fixes #892 

## Testing
Before:
![ColumnManagerBeforeReorderSolution](https://user-images.githubusercontent.com/78564221/218874161-e35c6064-c57d-4587-824d-8fb9d9e7a472.gif)

After:
![ColumnManagerReorderSolution](https://user-images.githubusercontent.com/78564221/218874187-f6ed455c-64db-4aa0-9376-035ff7b3202a.gif)

## Docs

N/A
