### PR TITLE
Retry css tests if timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,13 @@ jobs:
             playgrounds/*/node_modules
           key: modules-${{ hashFiles('yarn.lock') }}
 
-      - run: yarn test --filter=@itwin/itwinui-css
+      - name: yarn test --filter=itwinui-css
+        uses: nick-fields/retry@2
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          retry_on: timeout
+          command: yarn test --filter=itwinui-css
 
       - name: Publish test results artifact
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,7 +242,7 @@ jobs:
           key: modules-${{ hashFiles('yarn.lock') }}
 
       - name: yarn test --filter=itwinui-css
-        uses: nick-fields/retry@2
+        uses: nick-fields/retry@v2
         with:
           timeout_minutes: 15
           max_attempts: 2


### PR DESCRIPTION
## Changes

Our css tests often time out and keep running indefinitely.
![](https://user-images.githubusercontent.com/9084735/219115039-aae8c022-2d24-471d-8010-7f53dd6aa181.png)

So I'm now using [`nick-fields/retry`](https://github.com/nick-fields/retry) to retry if tests are still running after 15 mins.

## Testing

CI should pass in this PR. In general, we'll have to observe how this behaves after it's merged.

## Docs

N/A