### PR TITLE
blurred background on tooltip

### DIFF
--- a/.changeset/violet-ligers-itch.md
+++ b/.changeset/violet-ligers-itch.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Tooltip's background now has a blur filter to make text more readable.

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -17,9 +17,10 @@
   z-index: 999;
   box-shadow: var(--iui-shadow-3);
   pointer-events: none;
-  background-color: rgba(0, 0, 0, var(--iui-opacity-3));
   color: var(--iui-color-white);
   border: 1px solid rgba(255, 255, 255, var(--iui-opacity-4));
+
+  @include iui-blur($hsl: 0 0% 0%, $opacity: 3);
 }
 
 @mixin iui-tooltip-hidden {


### PR DESCRIPTION
## Changes

I was trying out something in a sandbox, when I noticed that the tooltip opacity makes it really hard to read when there is text behind the tooltip. So I'm making the background blurry.

## Testing

Looks perfectly fine in my testing on M1 Macbook and personal Windows PC.

I believe we had this 2 years ago but removed it because it was causing some blurry text (in react, not css). See #43. So I would like other Windows users to verify.

## Docs

Added changeset.