### PR TITLE
feat: Links to github on doc website open a new tab

### DIFF
--- a/apps/website/src/components/EditPageLink.astro
+++ b/apps/website/src/components/EditPageLink.astro
@@ -18,7 +18,8 @@ if (page === 'components') {
 const repoUrl = 'https://github.com/iTwin/iTwinUI';
 const githubEditUrl = `${repoUrl}/edit/main/apps/website/src/pages/docs/${fileName}`;
 ---
-<a href={githubEditUrl} {...rest}>
+
+<a href={githubEditUrl} target='_blank' {...rest}>
   <EditIcon aria-hidden='true' />Edit this page on GitHub
 </a>
 

--- a/apps/website/src/components/FeedbackLink.astro
+++ b/apps/website/src/components/FeedbackLink.astro
@@ -7,7 +7,8 @@ let { page, ...rest } = Astro.props;
 const repoUrl = 'https://github.com/iTwin/iTwinUI';
 const githubFeedbackUrl = `${repoUrl}/discussions/new?category=documentation&title=Feedback%20on%20%60${page}%60&body=Replace%20this%20text%20with%20your%20feedback%20on%20the%20%60${page}%60%20page.`;
 ---
-<a href={githubFeedbackUrl} {...rest}>
+
+<a href={githubFeedbackUrl} target='_blank' {...rest}>
   <ChatIcon aria-hidden='true' />Provide feedback on GitHub
 </a>
 


### PR DESCRIPTION
## Changes
Added `target='_blank' to force the links to open a new tab. This will benefit UXers that are updating the doc pages so that they can reference the current page easily, as the preview on Github is not very good.

## Testing
I clicked the links and they opened new tabs.

## Docs
N/A
