### PR TITLE
add `as` prop to HeaderLogo

### DIFF
--- a/.changeset/loud-hats-perform.md
+++ b/.changeset/loud-hats-perform.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+HeaderLogo now supports `as` prop to allow rendering as a link. It will default to a `button` if `onClick` is passed, and `div` if not.

--- a/packages/itwinui-react/src/core/Header/HeaderLogo.test.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderLogo.test.tsx
@@ -57,7 +57,7 @@ it('renders with as prop correctly', () => {
       hello
     </HeaderLogo>,
   );
-  const link = container.querySelector('h1');
+  const link = container.querySelector('a');
   expect(link).toHaveClass('iui-header-brand');
   expect(link).toHaveAttribute('href', 'https://www.example.com/');
   link?.click();

--- a/packages/itwinui-react/src/core/Header/HeaderLogo.test.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderLogo.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { SvgMore as SvgPlaceholder } from '../utils';
 
 import HeaderLogo from './HeaderLogo';
@@ -13,9 +13,9 @@ it('renders default correctly', () => {
     <HeaderLogo logo={<SvgPlaceholder />}>Application</HeaderLogo>,
   );
 
-  const root = container.querySelector('.iui-header-brand') as HTMLDivElement;
+  const root = container.querySelector('div') as HTMLDivElement;
   expect(root).toBeTruthy();
-  expect(root.getAttribute('role')).toBeNull();
+  expect(root).toHaveClass('iui-header-brand');
 
   const {
     container: { firstChild: placeholderIcon },
@@ -38,34 +38,30 @@ it('renders with onClick correctly', () => {
     </HeaderLogo>,
   );
 
-  const root = container.querySelector('.iui-header-brand') as HTMLDivElement;
-  expect(root).toBeTruthy();
-  expect(root.getAttribute('role')).toBe('button');
+  const root = container.querySelector('button') as HTMLButtonElement;
+  expect(root).toHaveClass('iui-header-brand');
   root.click();
 
   expect(onClickMock).toHaveBeenCalled();
 });
 
-it('handles keypress with onClick correctly', () => {
+it('renders with as prop correctly', () => {
   const onClickMock = jest.fn();
   const { container } = render(
-    <HeaderLogo logo={<SvgPlaceholder />} onClick={onClickMock}>
-      Application
+    <HeaderLogo
+      as='a'
+      logo={<SvgPlaceholder />}
+      href='https://www.example.com/'
+      onClick={onClickMock}
+    >
+      hello
     </HeaderLogo>,
   );
-
-  const root = container.querySelector('.iui-header-brand') as HTMLDivElement;
-  expect(root).toBeTruthy();
-  expect(root.getAttribute('role')).toBe('button');
-
-  fireEvent.keyDown(root, { key: 'Enter' });
-  expect(onClickMock).toHaveBeenCalledTimes(1);
-
-  fireEvent.keyDown(root, { key: ' ' });
-  expect(onClickMock).toHaveBeenCalledTimes(2);
-
-  fireEvent.keyDown(root, { key: 'a' });
-  expect(onClickMock).toHaveBeenCalledTimes(2);
+  const link = container.querySelector('h1');
+  expect(link).toHaveClass('iui-header-brand');
+  expect(link).toHaveAttribute('href', 'https://www.example.com/');
+  link?.click();
+  expect(onClickMock).toHaveBeenCalled();
 });
 
 it('renders with no children correctly', () => {

--- a/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
@@ -6,7 +6,7 @@
 import cx from 'classnames';
 import React from 'react';
 
-import { useTheme, CommonProps } from '../utils';
+import { useTheme, PolymorphicForwardRefComponent } from '../utils';
 import '@itwin/itwinui-css/css/header.css';
 
 export type HeaderLogoProps = {
@@ -16,14 +16,10 @@ export type HeaderLogoProps = {
   logo: JSX.Element;
   /**
    * Click event handler.
-   * Will update the Logo to have mouse and keyboard interaction if provided.
+   * If passed, the component will be rendered as a `<button>` rather than `<div>`.
    */
-  onClick?: () => void;
-  /**
-   * Expects the app name, is put on the right of the logo.
-   */
-  children?: React.ReactNode;
-} & CommonProps;
+  onClick?: (e: unknown) => void;
+};
 
 /**
  * Header Title section
@@ -33,25 +29,25 @@ export type HeaderLogoProps = {
  * <HeaderLogo logo={<img src='image.png' />} />
  * <HeaderLogo logo={<img src='data:image/png;base64,...' />}>Downloaded Image</HeaderLogo>
  */
-export const HeaderLogo = (props: HeaderLogoProps) => {
-  const { className, children, logo, onClick, ...rest } = props;
-  const keyDownHandler = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      onClick &&
-      (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar')
-    ) {
-      e.preventDefault();
-      onClick();
-    }
-  };
+export const HeaderLogo = React.forwardRef((props, ref) => {
+  const {
+    className,
+    children,
+    logo,
+    onClick,
+    as: Element = !!onClick ? 'button' : 'div',
+    ...rest
+  } = props;
+
   useTheme();
+
   return (
-    <div
+    <Element
       className={cx('iui-header-brand', className)}
-      role={onClick && 'button'}
-      tabIndex={onClick && 0}
-      onKeyDown={keyDownHandler}
       onClick={onClick}
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TS complains here but it's ok; it is an implementation detail
+      // @ts-ignore
+      ref={ref}
       {...rest}
     >
       {React.isValidElement<{ className: string }>(logo)
@@ -60,8 +56,8 @@ export const HeaderLogo = (props: HeaderLogoProps) => {
           })
         : undefined}
       {children && <span className='iui-header-brand-label'>{children}</span>}
-    </div>
+    </Element>
   );
-};
+}) as PolymorphicForwardRefComponent<'div', HeaderLogoProps>;
 
 export default HeaderLogo;

--- a/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
@@ -6,10 +6,14 @@
 import cx from 'classnames';
 import React from 'react';
 
-import { useTheme, PolymorphicForwardRefComponent } from '../utils';
+import { useTheme } from '../utils';
+import type {
+  PolymorphicForwardRefComponent,
+  PolymorphicComponentProps,
+} from '../utils';
 import '@itwin/itwinui-css/css/header.css';
 
-export type HeaderLogoProps = {
+type HeaderLogoOwnProps = {
   /**
    * Logo shown before the main content.
    */
@@ -20,6 +24,11 @@ export type HeaderLogoProps = {
    */
   onClick?: (e: unknown) => void;
 };
+
+export type HeaderLogoProps = PolymorphicComponentProps<
+  'div',
+  HeaderLogoOwnProps
+>;
 
 /**
  * Header Title section
@@ -58,6 +67,6 @@ export const HeaderLogo = React.forwardRef((props, ref) => {
       {children && <span className='iui-header-brand-label'>{children}</span>}
     </Element>
   );
-}) as PolymorphicForwardRefComponent<'div', HeaderLogoProps>;
+}) as PolymorphicForwardRefComponent<'div', HeaderLogoOwnProps>;
 
 export default HeaderLogo;


### PR DESCRIPTION
## Changes

Closes #920

`as` prop will allow rendering the HeaderLogo as a link, with correct hover states. Also removed some extra code that is not necessary - previously we were always rendering a `<div>` and doing extra work to turn it into button when `onClick` was passed.

The `as` prop will now default to `div` when no `onClick` passed, and `button` when one is passed.

## Testing

Updated existing unit tests and added new unit test for `as` prop.

Also inspected dom in stories/playground and it was rendering the correct element.

## Docs

Added changeset.
