### PR TITLE
Update combobox to not crash

### DIFF
--- a/.changeset/heavy-ligers-marry.md
+++ b/.changeset/heavy-ligers-marry.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`ComboBox` will not crash when user provided value is not in Options list.

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -913,3 +913,15 @@ it('should handle keyboard navigation when multiple is enabled', async () => {
   await userEvent.tab();
   expect(document.querySelector('.iui-menu')).not.toBeVisible();
 });
+
+it('should not crash when provided value in not in options when multiple enabled', async () => {
+  const mockOnChange = jest.fn();
+  const options = [0, 1, 2].map((value) => ({ value, label: `Item ${value}` }));
+
+  const { container } = render(
+    <ComboBox options={options} onChange={mockOnChange} multiple value={[3]} />,
+  );
+
+  const input = container.querySelector('.iui-input') as HTMLInputElement;
+  expect(input).toHaveValue('');
+});

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -230,9 +230,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
           (option) => option.value === value,
         );
         if (indexToAdd > -1) {
-          indexArray.push(
-            options.findIndex((option) => option.value === value),
-          );
+          indexArray.push(indexToAdd);
         }
       });
       return indexArray;

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -226,7 +226,14 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     if (isMultipleEnabled(valueProp, multiple)) {
       const indexArray: number[] = [];
       valueProp?.forEach((value) => {
-        indexArray.push(options.findIndex((option) => option.value === value));
+        const indexToAdd = options.findIndex(
+          (option) => option.value === value,
+        );
+        if (indexToAdd > -1) {
+          indexArray.push(
+            options.findIndex((option) => option.value === value),
+          );
+        }
       });
       return indexArray;
     } else {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

Solves #1115 

## Changes

Updated `getSelectedIndexes` to check if user provided index is valid (exists in options).

## Testing

To test this copy-paste user provided example and run our test app.
Added unit test for this case.

## Docs

N/A
