### PR TITLE
update Tile order so name comes first

### DIFF
--- a/.changeset/odd-trees-return.md
+++ b/.changeset/odd-trees-return.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-css': patch
+---
+
+The DOM order of Tile content has changed so that the name comes before the thumbnail region. This improves accessibility without affecting visuals.

--- a/packages/itwinui-css/backstop/tests/tile.html
+++ b/packages/itwinui-css/backstop/tests/tile.html
@@ -125,6 +125,14 @@
         class="iui-tile iui-new"
         id="test-tile-1"
       >
+        <div class="iui-tile-name">
+          <svg-new
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-new>
+          <span class="iui-tile-name-label">Super long tile name that will truncate</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <button
             aria-label="Type indicator"
@@ -178,13 +186,6 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <svg-new
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-new>
-            <span class="iui-tile-name-label">Super long tile name that will truncate</span>
-          </div>
           <div class="iui-tile-description">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
@@ -253,6 +254,10 @@
         class="iui-tile"
         id="test-tile-2"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Title</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -291,9 +296,6 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Title</span>
-          </div>
           <div class="iui-tile-description">
             This tile uses a DIV with a background image & only has 1 button.
           </div>
@@ -339,6 +341,10 @@
         tabindex="0"
         id="test-tile-4"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Tile name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <button
             aria-label="Info"
@@ -367,9 +373,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Tile name</span>
-          </div>
+
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -411,6 +415,10 @@
         tabindex="0"
         id="test-tile-5"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Tile name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -436,9 +444,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Tile name</span>
-          </div>
+
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -479,6 +485,14 @@
         class="iui-tile iui-actionable iui-selected"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <svg-checkmark
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-checkmark>
+          <span class="iui-tile-name-label">Tile name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -504,13 +518,7 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <svg-checkmark
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-checkmark>
-            <span class="iui-tile-name-label">Tile name</span>
-          </div>
+
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -555,6 +563,10 @@
         class="iui-tile iui-actionable"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Terry Rivers</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <x-avatar
             type="2"
@@ -565,9 +577,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Terry Rivers</span>
-          </div>
+
           <div class="iui-tile-description">CEO</div>
 
           <div class="iui-tile-more-options">
@@ -591,6 +601,14 @@
         class="iui-tile iui-actionable iui-selected"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <svg-checkmark
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-checkmark>
+          <span class="iui-tile-name-label">Terry Rivers</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <x-avatar
             type="2"
@@ -601,13 +619,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <svg-checkmark
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-checkmark>
-            <span class="iui-tile-name-label">Terry Rivers</span>
-          </div>
+
           <div class="iui-tile-description">CEO</div>
 
           <div class="iui-tile-more-options">
@@ -668,6 +680,7 @@
           <div class="iui-tile-name">
             <span class="iui-tile-name-label">Bentley Systems Headquarters</span>
           </div>
+
           <div class="iui-tile-description">
             <div class="iui-tile-description">
               685 Stockton Drive, Exton, PA 19341
@@ -705,6 +718,10 @@
 
       <!-- With thumbnail -->
       <div class="iui-tile">
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Bentley Systems Headquarters</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -736,9 +753,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Bentley Systems Headquarters</span>
-          </div>
+
           <div class="iui-tile-description">
             <div class="iui-tile-description">
               685 Stockton Drive, Exton, PA 19341
@@ -783,6 +798,10 @@
         class="iui-tile iui-actionable"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Video name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <button
             aria-label="Favorite"
@@ -811,9 +830,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Video name</span>
-          </div>
+
           <div class="iui-tile-description">
             Are you ready to be inspired by some of the world’s most impressive
             infrastructure projects? We have highlighted a few of the most
@@ -849,6 +866,10 @@
         class="iui-tile iui-actionable"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Video name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -878,9 +899,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Video name</span>
-          </div>
+
           <div class="iui-tile-description">
             Are you ready to be inspired by some of the world’s most impressive
             infrastructure projects? We have highlighted a few of the most
@@ -917,6 +936,14 @@
         tabindex="0"
         id="test-tile-3"
       >
+        <div class="iui-tile-name">
+          <svg-checkmark
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-checkmark>
+          <span class="iui-tile-name-label">Video name</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
           <button
@@ -946,13 +973,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <svg-checkmark
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-checkmark>
-            <span class="iui-tile-name-label">Video name</span>
-          </div>
+
           <div class="iui-tile-description">
             Are you ready to be inspired by some of the world’s most impressive
             infrastructure projects? We have highlighted a few of the most
@@ -1146,6 +1167,14 @@
         class="iui-tile iui-actionable iui-positive"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <svg-status-success
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-status-success>
+          <span class="iui-tile-name-label">charlie.pdf</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <svg-filetype-pdf
             class="iui-thumbnail-icon"
@@ -1154,13 +1183,6 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <svg-status-success
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-status-success>
-            <span class="iui-tile-name-label">charlie.pdf</span>
-          </div>
 
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
@@ -1202,6 +1224,15 @@
         class="iui-tile iui-actionable iui-warning"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <svg-filetype-image aria-hidden="true"></svg-filetype-image>
+          <svg-status-warning
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-status-warning>
+          <span class="iui-tile-name-label">delta.jpg</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <svg-filetype-image
             class="iui-thumbnail-icon"
@@ -1210,14 +1241,6 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <svg-filetype-image aria-hidden="true"></svg-filetype-image>
-            <svg-status-warning
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-status-warning>
-            <span class="iui-tile-name-label">delta.jpg</span>
-          </div>
 
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
@@ -1259,6 +1282,15 @@
         class="iui-tile iui-actionable iui-negative"
         tabindex="0"
       >
+        <div class="iui-tile-name">
+          <svg-status-error
+            class="iui-tile-status-icon"
+            aria-hidden="true"
+          ></svg-status-error>
+          <span
+            class="iui-tile-name-label">MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <svg-filetype-vector
             class="iui-thumbnail-icon"
@@ -1267,14 +1299,7 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <svg-status-error
-              class="iui-tile-status-icon"
-              aria-hidden="true"
-            ></svg-status-error>
-            <span
-              class="iui-tile-name-label">MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg</span>
-          </div>
+
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -1310,6 +1335,31 @@
       </div>
 
       <div class="iui-tile iui-loading">
+        <div class="iui-tile-name">
+          <div class="iui-progress-indicator-radial iui-determinate iui-tile-status-icon">
+            <svg
+              class="iui-radial"
+              viewBox="0 0 40 40"
+              aria-hidden="true"
+            >
+              <circle
+                class="iui-track"
+                cx="20"
+                cy="20"
+                r="15.91549"
+              ></circle>
+              <circle
+                class="iui-fill"
+                cx="20"
+                cy="20"
+                r="15.91549"
+                style="stroke-dashoffset: 20"
+              ></circle>
+            </svg>
+          </div>
+          <span class="iui-tile-name-label">alpha.dgn</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <svg-filetype-imodel
             class="iui-thumbnail-icon"
@@ -1318,30 +1368,7 @@
         </div>
 
         <div class="iui-tile-content ">
-          <div class="iui-tile-name">
-            <div class="iui-progress-indicator-radial iui-determinate iui-tile-status-icon">
-              <svg
-                class="iui-radial"
-                viewBox="0 0 40 40"
-                aria-hidden="true"
-              >
-                <circle
-                  class="iui-track"
-                  cx="20"
-                  cy="20"
-                  r="15.91549"
-                ></circle>
-                <circle
-                  class="iui-fill"
-                  cx="20"
-                  cy="20"
-                  r="15.91549"
-                  style="stroke-dashoffset: 20"
-                ></circle>
-              </svg>
-            </div>
-            <span class="iui-tile-name-label">alpha.dgn</span>
-          </div>
+
           <div class="iui-tile-more-options">
             <button
               aria-label="More options"
@@ -1363,8 +1390,12 @@
         class="iui-tile"
         aria-disabled="true"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Disabled</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
-          <div class="iui-tile-status-icon iui-table iui-thumbnail-icon">
+          <div class="iui-thumbnail-icon">
             <svg-filetype-video
               class="iui-thumbnail-icon"
               aria-hidden="true"
@@ -1373,9 +1404,7 @@
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Disabled</span>
-          </div>
+
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -1414,14 +1443,15 @@
         class="iui-tile"
         aria-disabled="true"
       >
+        <div class="iui-tile-name">
+          <span class="iui-tile-name-label">Disabled</span>
+        </div>
+
         <div class="iui-tile-thumbnail">
           <div class="iui-tile-thumbnail-picture demo-photo"></div>
         </div>
 
         <div class="iui-tile-content">
-          <div class="iui-tile-name">
-            <span class="iui-tile-name-label">Disabled</span>
-          </div>
           <div class="iui-tile-description">
             Bentley Systems, Incorporated, is an American-based software
             development company that develops, manufactures, licenses, sells and
@@ -1637,7 +1667,7 @@
         aria-disabled="true"
       >
         <div class="iui-tile-thumbnail">
-          <div class="iui-tile-status-icon iui-table iui-thumbnail-icon">
+          <div class="iui-thumbnail-icon">
             <svg-folder
               class="iui-thumbnail-icon"
               aria-hidden="true"

--- a/packages/itwinui-css/src/tile/classes.scss
+++ b/packages/itwinui-css/src/tile/classes.scss
@@ -46,6 +46,26 @@
   @include iui-tile-content;
 }
 
+.iui-tile-name {
+  @include iui-tile-name;
+}
+
+.iui-tile-name-label {
+  @include iui-tile-name-label;
+}
+
+.iui-tile-description {
+  @include iui-tile-description;
+}
+
+.iui-tile-metadata {
+  @include iui-tile-metadata;
+}
+
+.iui-tile-status-icon {
+  @include iui-tile-status-icon;
+}
+
 .iui-tile-more-options {
   @include iui-tile-more-options;
 }

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -29,7 +29,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   }
 
   &:where(:not(.iui-folder)) {
-    > :where(:first-child) {
+    > :where(.iui-tile-thumbnail) {
       border-top-left-radius: inherit;
       border-top-right-radius: inherit;
     }

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -118,10 +118,16 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
       flex: 1;
       border-bottom: none;
       border-right: 1px solid var(--iui-color-border);
+      margin: 0;
     }
 
     .iui-tile-content {
       flex: 2;
+      padding: var(--iui-size-s);
+
+      > * {
+        padding: 0;
+      }
     }
 
     .iui-tile-description {
@@ -164,7 +170,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-content {
-  padding: var(--iui-size-s);
+  padding-bottom: var(--iui-size-s);
   display: grid;
   grid-template-rows: auto 1fr auto;
   flex-grow: 2;
@@ -172,6 +178,8 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 
   > * {
     max-width: 100%;
+    margin-bottom: calc(var(--iui-size-s) * 0.5);
+    padding-inline: var(--iui-size-s);
   }
 }
 
@@ -181,9 +189,10 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   align-items: center;
   font-size: var(--iui-font-size-2);
   user-select: all;
-  margin-bottom: calc(var(--iui-size-s) * 0.5);
   color: var(--_iui-tile-title-text-color);
   overflow: hidden;
+  padding-inline: var(--iui-size-s);
+  margin-bottom: calc(var(--iui-size-s) * 0.5);
 }
 
 @mixin iui-tile-status-icon {
@@ -217,6 +226,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   display: flex;
   align-items: center;
   margin-top: auto;
+  margin-bottom: 0;
   color: var(--_iui-tile-body-text-color);
 
   > svg,
@@ -234,6 +244,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-thumbnail {
+  order: -1;
   box-sizing: content-box;
   height: calc(var(--iui-size-s) * 13);
   flex-shrink: 0;
@@ -241,6 +252,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   display: grid;
   background-color: var(--iui-color-background-zebra);
   border-bottom: 1px solid var(--iui-color-border);
+  margin-bottom: var(--iui-size-s);
 
   > * {
     grid-area: 1 / 1 / -1 / -1;
@@ -365,6 +377,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   grid-area: 1 / 1 / -1 / -1;
   place-self: end;
   position: absolute;
+  margin: 0;
 
   // visual adjustment to counteract invisible padding from borderless button
   margin-right: calc(-1 * var(--iui-size-2xs));

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -173,63 +173,63 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   > * {
     max-width: 100%;
   }
+}
 
-  .iui-tile-name {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    font-size: var(--iui-font-size-2);
-    user-select: all;
-    margin-bottom: calc(var(--iui-size-s) * 0.5);
-    color: var(--_iui-tile-title-text-color);
-    overflow: hidden;
-  }
+@mixin iui-tile-name {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  font-size: var(--iui-font-size-2);
+  user-select: all;
+  margin-bottom: calc(var(--iui-size-s) * 0.5);
+  color: var(--_iui-tile-title-text-color);
+  overflow: hidden;
+}
 
-  .iui-tile-status-icon {
+@mixin iui-tile-status-icon {
+  @include iui-icon-style('m');
+  margin-right: var(--iui-size-xs);
+  fill: var(--_iui-tile-status-icon-fill);
+}
+
+@mixin iui-tile-name-label {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+@mixin iui-tile-description {
+  margin-bottom: var(--iui-size-s);
+  font-size: var(--iui-font-size-1);
+  height: 100%;
+  max-height: calc(var(--iui-size-s) * 6);
+  @include iui-line-clamp(3);
+  color: var(--_iui-tile-body-text-color);
+}
+
+@mixin iui-tile-metadata {
+  font-size: var(--iui-font-size-0);
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: var(--iui-size-l);
+  width: 100%;
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  color: var(--_iui-tile-body-text-color);
+
+  > svg,
+  .iui-tile-metadata-icon {
     @include iui-icon-style('m');
+    fill: var(--iui-color-icon-muted);
     margin-right: var(--iui-size-xs);
-    fill: var(--_iui-tile-status-icon-fill);
   }
 
-  .iui-tile-name-label {
-    overflow: hidden;
+  > * {
     white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
-  .iui-tile-description {
-    margin-bottom: var(--iui-size-s);
-    font-size: var(--iui-font-size-1);
-    height: 100%;
-    max-height: calc(var(--iui-size-s) * 6);
-    @include iui-line-clamp(3);
-    color: var(--_iui-tile-body-text-color);
-  }
-
-  .iui-tile-metadata {
-    font-size: var(--iui-font-size-0);
-    flex-shrink: 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    height: var(--iui-size-l);
-    width: 100%;
-    display: flex;
-    align-items: center;
-    margin-top: auto;
-    color: var(--_iui-tile-body-text-color);
-
-    > svg,
-    .iui-tile-metadata-icon {
-      @include iui-icon-style('m');
-      fill: var(--iui-color-icon-muted);
-      margin-right: var(--iui-size-xs);
-    }
-
-    > * {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
   }
 }
 

--- a/packages/itwinui-react/src/core/Tile/Tile.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.tsx
@@ -166,6 +166,19 @@ export const Tile = (props: TileProps) => {
   const showMenu = React.useCallback(() => setIsMenuVisible(true), []);
   const hideMenu = React.useCallback(() => setIsMenuVisible(false), []);
 
+  const tileName = (
+    <div className='iui-tile-name'>
+      <TitleIcon
+        isLoading={isLoading}
+        isSelected={isSelected}
+        isNew={isNew}
+        status={status}
+      />
+
+      <span className='iui-tile-name-label'>{name}</span>
+    </div>
+  );
+
   return (
     <div
       className={cx(
@@ -184,6 +197,8 @@ export const Tile = (props: TileProps) => {
       tabIndex={isActionable && !isDisabled ? 0 : undefined}
       {...rest}
     >
+      {variant !== 'folder' ? tileName : null}
+
       {thumbnail && (
         <div className='iui-tile-thumbnail'>
           {typeof thumbnail === 'string' ? (
@@ -222,16 +237,7 @@ export const Tile = (props: TileProps) => {
       )}
 
       <div className='iui-tile-content'>
-        <div className='iui-tile-name'>
-          <TitleIcon
-            isLoading={isLoading}
-            isSelected={isSelected}
-            isNew={isNew}
-            status={status}
-          />
-
-          <span className='iui-tile-name-label'>{name}</span>
-        </div>
+        {variant === 'folder' ? tileName : null}
 
         {description != undefined && (
           <div className='iui-tile-description'>{description}</div>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Before this change, when using arrow key navigation in screenreaders, all the content in the thumbnail area would be announced before the name of the Tile. This is not ideal.

So now, `iui-tile-name` will now be the first thing inside tile (in the DOM) with no changes to visuals. This is done using flex `order`.

I left the folder tile unchanged because it was getting complicated and it's less important - there isn't much stuff there in the thumbnail area.

## Testing

No new tests needed. Existing tests all pass because there are no visual changes.

## Docs

Added changeset.