### PR TITLE
fix Table header misalignment in firefox

### DIFF
--- a/.changeset/afraid-zoos-double.md
+++ b/.changeset/afraid-zoos-double.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue in Firefox where the right edge of the `Table` header was misaligned with the table body.

--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -15,7 +15,8 @@
   overflow: hidden;
   // Fix for Firefox columns misalignment
   @supports not (overflow: overlay) {
-    overflow-y: scroll;
+    scrollbar-gutter: stable;
+    background-color: var(--iui-color-background);
   }
   display: flex;
   flex-shrink: 0;


### PR DESCRIPTION
## Changes

Noticed an issue where the Table header was misaligned with Table body in firefox. We actually already had a workaround for Firefox in place, but it was only partially working because it was occupying invisible space. So I've updated it to have a background-color.

## Testing

Before this change, this is how it looks in Firefox:

![image](https://user-images.githubusercontent.com/9084735/224161587-5febde96-6127-45a2-a5f0-53cb95ddfdc2.png)

After this change, this is how it looks in Firefox:
![image](https://user-images.githubusercontent.com/9084735/224161277-2f568090-8940-4792-a7dc-e7bbc48c3c2c.png)


## Docs

Added changeset.
