### PR TITLE
fix grid positioning in safari

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -136,6 +136,13 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
       margin-bottom: 0;
       -webkit-line-clamp: 2;
     }
+
+    .iui-tile-more-options {
+      position: absolute;
+      margin: 0;
+      bottom: var(--iui-size-s);
+      right: var(--iui-size-xs);
+    }
   }
 
   //#region Statuses
@@ -177,6 +184,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   min-width: 0;
 
   > * {
+    grid-column: 1;
     max-width: 100%;
     margin-bottom: calc(var(--iui-size-s) * 0.5);
     padding-inline: var(--iui-size-s);
@@ -228,6 +236,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   margin-top: auto;
   margin-bottom: 0;
   color: var(--_iui-tile-body-text-color);
+  grid-row: -1;
 
   > svg,
   .iui-tile-metadata-icon {
@@ -298,10 +307,10 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 @mixin iui-tile-thumbnail-button($variant) {
   @include iui-button-borderless;
   @include iui-button-size(small, borderless);
-  position: absolute;
   border-radius: 50%;
   margin-top: calc(var(--iui-size-s) * 0.5);
   margin-inline: var(--iui-size-xs);
+  place-self: start;
 
   @if $variant == quick-action {
     justify-self: end;
@@ -374,9 +383,9 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-more-options {
-  grid-area: 1 / 1 / -1 / -1;
+  grid-row: -1;
   place-self: end;
-  position: absolute;
+  display: grid;
   margin: 0;
 
   // visual adjustment to counteract invisible padding from borderless button


### PR DESCRIPTION
## Changes

In #1117, we introduced css grid. This looked fine in chrome/firefox but was breaking in safari. Affected elements: thumbnail buttons and more-options button.

After investigating, I found the cause to be the use of `position: absolute` together with grid. These were left behind because we don't want the "overlaying" parts to occupy space. I was able to easily remove it from thumbnail buttons, but removing it from more-options was causing layout shift (because it now occupies space) so I had to get a bit creative.

The more-options button now uses `grid-row: -1` together with the metadata (both are considered "last row") and also uses `display: grid` to get rid of any excess line height. And for folder tiles, this is not enough for (there is no metadata region there) so I've removed it from the grid and reverted back to `position: absolute`.

## Testing

Tested successfully in Safari.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/9084735/225048176-38a9e557-9a73-4747-b488-3236af805279.png) | ![image](https://user-images.githubusercontent.com/9084735/225048088-d0275115-ba0d-4211-a47d-df0438edbe8b.png) |

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/9084735/225049485-9123f4b9-08ea-4258-a9e7-e6e30b78619a.png) | ![image](https://user-images.githubusercontent.com/9084735/225049567-f43173c2-2c0a-4e81-8d91-69bc4842db4e.png) |

No visual changes in Chrome/Firefox.

## Docs

N/A. No changeset needed because #1117 is not released yet.