### PR TITLE
add `isDateDisabled` prop and styling

### DIFF
--- a/apps/storybook/src/DatePicker.stories.tsx
+++ b/apps/storybook/src/DatePicker.stories.tsx
@@ -320,3 +320,65 @@ Range.args = {
   startDate: new Date(2022, 6, 13, 14, 55, 22),
   endDate: new Date(2022, 6, 27, 14, 55, 22),
 };
+
+export const SomeDatesDisabled: Story<DatePickerProps> = (args) => {
+  const {
+    setFocus = true,
+    localizedNames,
+    startDate = new Date(2022, 6, 13, 14, 55, 22),
+    endDate = new Date(2022, 6, 27, 14, 55, 22),
+    ...rest
+  } = args;
+  const [opened, setOpened] = React.useState(false);
+  const [currentStartDate, setCurrentStartDate] = React.useState(startDate);
+  const [currentEndDate, setCurrentEndDate] = React.useState(endDate);
+
+  // only allow selecting dates in July
+  const isDateDisabled = (date: Date) => {
+    return date.getMonth() !== 6;
+  };
+
+  const onChange = (startDate: Date, endDate?: Date) => {
+    setCurrentStartDate(startDate);
+    endDate && setCurrentEndDate(endDate);
+  };
+
+  // sync with story controls
+  React.useEffect(() => {
+    setCurrentStartDate(new Date(startDate));
+    setCurrentEndDate(new Date(endDate));
+  }, [startDate, endDate]);
+
+  return (
+    <>
+      <IconButton onClick={() => setOpened(!opened)} id='picker-button'>
+        <SvgCalendar />
+      </IconButton>
+      <span style={{ marginLeft: 16 }}>
+        Start Date: {currentStartDate.toLocaleDateString()}
+      </span>
+      <span style={{ marginLeft: 16 }}>
+        End Date: {currentEndDate.toLocaleDateString()}
+      </span>
+      {opened && (
+        <div style={{ marginTop: 4 }}>
+          <DatePicker
+            {...rest}
+            enableRangeSelect
+            startDate={currentStartDate}
+            endDate={currentEndDate}
+            onChange={onChange}
+            localizedNames={localizedNames}
+            setFocus={setFocus}
+            isDateDisabled={isDateDisabled}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+SomeDatesDisabled.args = {
+  startDate: new Date(2022, 6, 13, 14, 55, 22),
+  endDate: new Date(2022, 6, 27, 14, 55, 22),
+};

--- a/packages/itwinui-css/src/date-picker/date-picker.scss
+++ b/packages/itwinui-css/src/date-picker/date-picker.scss
@@ -143,6 +143,17 @@ $iui-date-picker-today-circle-size: 32px;
   &-today {
     @include iui-calendar-day-today-base;
   }
+
+  &[aria-disabled='true'] {
+    color: var(--iui-color-text-muted);
+    background-color: transparent;
+    font-weight: var(--iui-font-weight-normal);
+    cursor: not-allowed;
+
+    @media (forced-colors: active) {
+      color: GrayText;
+    }
+  }
 }
 
 @mixin iui-calendar-day-selected {

--- a/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
+++ b/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
@@ -202,6 +202,11 @@ export type DatePickerProps = {
    * @default false
    */
   showYearSelection?: boolean;
+  /**
+   * Will disable dates for which this function returns true.
+   * Disabled dates cannot be selected.
+   */
+  isDateDisabled?: (date: Date) => boolean;
 } & DateRangePickerProps &
   Omit<TimePickerProps, 'date' | 'onChange' | 'setFocusHour'>;
 
@@ -234,6 +239,7 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
     enableRangeSelect = false,
     startDate,
     endDate,
+    isDateDisabled,
     ...rest
   } = props;
 
@@ -488,7 +494,9 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
       case 'Enter':
       case ' ':
       case 'Spacebar':
-        onDayClick(focusedDay);
+        if (!isDateDisabled?.(focusedDay)) {
+          onDayClick(focusedDay);
+        }
         event.preventDefault();
         break;
     }
@@ -595,13 +603,15 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
               >
                 {weekDays.map((weekDay, dayIndex) => {
                   const dateValue = weekDay.getDate();
+                  const isDisabled = isDateDisabled?.(weekDay);
                   return (
                     <div
                       key={`day-${displayedMonthIndex}-${dayIndex}`}
                       className={getDayClass(weekDay)}
-                      onClick={() => onDayClick(weekDay)}
+                      onClick={() => !isDisabled && onDayClick(weekDay)}
                       role='option'
                       tabIndex={isSameDay(weekDay, focusedDay) ? 0 : -1}
+                      aria-disabled={isDisabled ? 'true' : undefined}
                       ref={(element) =>
                         isSameDay(weekDay, focusedDay) &&
                         needFocus.current &&


### PR DESCRIPTION
## Changes

- Added muted text styling for `aria-disabled` and removed extra hover interactions.
- Added `isDateDisabled` prop which takes a function which must return a boolean. If true, the date will have `aria-disabled='true'` and will also disable click/<kbd>Enter</kbd> handlers.

## Testing

Briefly tested in storybook.

Currently working on more extensive testing.

## Docs

TBD