### PR TITLE
Table horizontal scroll after resizing

### DIFF
--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -24,10 +24,10 @@
 }
 
 @mixin iui-table-header {
-  display: flex;
+  // display: flex;
   user-select: none;
   min-width: 100%;
-  flex-shrink: 0;
+  // flex-shrink: 0;
   font-weight: var(--iui-font-weight-semibold);
   border-bottom: 1px solid var(--iui-color-border);
 
@@ -319,6 +319,7 @@
 @mixin iui-table-body {
   overflow-y: scroll;
   overflow: overlay;
+  // overflow-x: hidden;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -385,12 +386,12 @@
     flex-basis: calc(var(--iui-size-l) * 2);
   }
 
-  &.iui-table-cell-sticky {
-    position: sticky;
-    z-index: 1;
-    left: var(--iui-table-sticky-left, initial);
-    right: var(--iui-table-sticky-right, initial);
-  }
+  // &.iui-table-cell-sticky {
+  //   position: sticky;
+  //   z-index: 1;
+  //   left: var(--iui-table-sticky-left, initial);
+  //   right: var(--iui-table-sticky-right, initial);
+  // }
 
   &:not(.iui-slot):last-child {
     padding-right: var(--iui-size-m);

--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -386,12 +386,12 @@
     flex-basis: calc(var(--iui-size-l) * 2);
   }
 
-  // &.iui-table-cell-sticky {
-  //   position: sticky;
-  //   z-index: 1;
-  //   left: var(--iui-table-sticky-left, initial);
-  //   right: var(--iui-table-sticky-right, initial);
-  // }
+  &.iui-table-cell-sticky {
+    position: sticky;
+    z-index: 1;
+    left: var(--iui-table-sticky-left, initial);
+    right: var(--iui-table-sticky-right, initial);
+  }
 
   &:not(.iui-slot):last-child {
     padding-right: var(--iui-size-m);


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
The addition of `display: flex` for `iui-table-header`  in #621 is what is causing the regression in issue #895 (when resizing column -> resizing table -> resizing column again, instead of shrinking, the table shows horizontal scroll instead, which..we don't want?). So I commented out `display: flex` which fixes the issue. HOWEVER that breaks some of the other tables (like horizontal scroll one). So I think the right way would be to target when it is a resizable table and remove `display: flex` out of `iui-table-header` (how can I achieve this?). But then what if users want a resizable column and horizontal scroll within a table? So... do we want to change this at all? And if we do, what would be the best way to do it?

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->
Visual testing on Storybook

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->
