### PR TITLE
fix grid positioning in safari (again)

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -136,13 +136,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
       margin-bottom: 0;
       -webkit-line-clamp: 2;
     }
-
-    .iui-tile-more-options {
-      position: absolute;
-      margin: 0;
-      bottom: var(--iui-size-s);
-      right: var(--iui-size-xs);
-    }
   }
 
   //#region Statuses
@@ -236,7 +229,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   margin-top: auto;
   margin-bottom: 0;
   color: var(--_iui-tile-body-text-color);
-  grid-row: -1;
 
   > svg,
   .iui-tile-metadata-icon {
@@ -383,13 +375,29 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-more-options {
-  grid-row: -1;
+  grid-area: 1 / 1 / -1 / -1;
+  position: absolute;
   place-self: end;
   display: grid;
   margin: 0;
 
   // visual adjustment to counteract invisible padding from borderless button
   margin-right: calc(-1 * var(--iui-size-2xs));
+
+  // safari doesn't support grid + position:absolute, so we will hardcode the values
+  @include safari-only {
+    bottom: var(--iui-size-s);
+    right: 0;
+    margin: 0;
+
+    :where(.iui-tile.iui-folder) & {
+      right: var(--iui-size-xs);
+    }
+
+    :where(.iui-tile:has(.iui-tile-buttons)) & {
+      bottom: 3.25rem;
+    }
+  }
 }
 
 @mixin iui-tile-status($status) {

--- a/packages/itwinui-css/src/utils/mixins.scss
+++ b/packages/itwinui-css/src/utils/mixins.scss
@@ -142,3 +142,9 @@
     @content;
   }
 }
+
+@mixin safari-only {
+  @supports (-apple-pay-button-style: inherit) {
+    @content;
+  }
+}


### PR DESCRIPTION
## Changes

This PR basically undoes #1132 because it was causing layout shift in Chrome/Firefox when Tile didn't have metadata.  It is now replaced with hardcoded absolute positioning specifically for safari (as a final resort after spending way too much time trying to make it work in a cross-browser way).

This is achieved by targeting safari using `@supports (-apple-pay-button-style: inherit)` which i've put in a mixin.

## Testing

Before:

https://user-images.githubusercontent.com/9084735/225394169-1582488d-9a45-4f8e-a9ba-1e7bdc6c52b5.mov

After:

https://user-images.githubusercontent.com/9084735/225395385-18c73166-fa3a-4c16-a866-32b6330087ea.mov

Additionally, I've also tried to go through and hover over every single Tile to make sure there is nothing left.

## Docs

N/A