### PR TITLE
remove manual tooltip state from slider

### DIFF
--- a/.changeset/lazy-buses-cross.md
+++ b/.changeset/lazy-buses-cross.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where Slider's tooltip was still visible after unmounting the component.

--- a/packages/itwinui-react/src/core/Slider/Slider.test.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.test.tsx
@@ -5,6 +5,7 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { Slider } from './Slider';
+import userEvent from '@testing-library/user-event';
 
 const createBoundingClientRect = (
   left: number,
@@ -477,44 +478,30 @@ it('should not process keystrokes when slider is disabled', () => {
   expect(thumb.getAttribute('aria-valuenow')).toEqual('50');
 });
 
-it('should show tooltip on thumb hover', () => {
+it('should show tooltip on thumb hover', async () => {
   const { container } = render(<Slider values={defaultSingleValue} />);
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
   expect(document.querySelector('.iui-tooltip')).toBeFalsy();
 
-  act(() => {
-    fireEvent.mouseEnter(thumb);
-  });
+  await userEvent.hover(thumb);
   expect(document.querySelector('.iui-tooltip')?.textContent).toBe('50');
-
-  const tippy = document.querySelector('[data-tippy-root]') as HTMLElement;
-  act(() => {
-    fireEvent.mouseLeave(thumb);
-  });
-  expect(tippy).not.toBeVisible();
+  expect(document.querySelector('[data-tippy-root]')).toBeVisible();
 });
 
-it('should show tooltip on thumb focus', () => {
+it('should show tooltip on thumb focus', async () => {
   const { container } = render(<Slider values={defaultSingleValue} />);
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
   expect(document.querySelector('.iui-tooltip')).toBeFalsy();
 
-  act(() => {
-    thumb.focus();
-  });
+  await userEvent.tab();
   expect(
     (document.querySelector('.iui-tooltip') as HTMLDivElement).textContent,
   ).toBe('50');
-
-  const tippy = document.querySelector('[data-tippy-root]') as HTMLElement;
-  act(() => {
-    thumb.blur();
-  });
-  expect(tippy).not.toBeVisible();
+  expect(document.querySelector('[data-tippy-root]')).toBeVisible();
 });
 
 it('should apply thumb props', () => {

--- a/packages/itwinui-react/src/core/Slider/Thumb.tsx
+++ b/packages/itwinui-react/src/core/Slider/Thumb.tsx
@@ -129,8 +129,6 @@ export const Thumb = (props: ThumbProps) => {
     !disabled && onThumbActivated(index);
   }, [disabled, index, onThumbActivated]);
 
-  const [hasFocus, setHasFocus] = React.useState(false);
-  const [isHovered, setIsHovered] = React.useState(false);
   const adjustedValue = React.useMemo(() => {
     if (value < sliderMin) {
       return sliderMin;
@@ -150,8 +148,10 @@ export const Thumb = (props: ThumbProps) => {
 
   return (
     <Tooltip
-      visible={isActive || hasFocus || isHovered}
       placement='top'
+      trigger={
+        tooltipProps?.visible == null ? 'mouseenter click focus' : undefined
+      }
       {...tooltipProps}
     >
       <div
@@ -178,10 +178,6 @@ export const Thumb = (props: ThumbProps) => {
         onPointerDown={handlePointerDownOnThumb}
         onKeyDown={(event) => handleOnKeyboardEvent(event, false)}
         onKeyUp={(event) => handleOnKeyboardEvent(event, true)}
-        onFocus={() => setHasFocus(true)}
-        onBlur={() => setHasFocus(false)}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
       />
     </Tooltip>
   );


### PR DESCRIPTION
## Changes

There is no need to manually maintain tooltip state because tippy already has a way of handling this. Hopefully should fix https://github.com/iTwin/iTwinUI/discussions/1122

## Testing

Tested in existing stories.

Updated unit test to use userEvent.

also tested in iTwin.js sandbox: see https://github.com/iTwin/iTwinUI/discussions/1122#discussioncomment-5326566

## Docs

Added changeset.