### PR TITLE
fix z-index issues with actionable tiles

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -225,7 +225,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   &,
   > .iui-link-action {
     width: 100%;
-    z-index: 1;
+    z-index: 0;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -278,7 +278,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   background-color: var(--iui-color-background-zebra);
   border-bottom: 1px solid var(--iui-color-border);
   margin-bottom: var(--iui-size-s);
-  isolation: isolate;
 
   > * {
     grid-area: 1 / 1 / -1 / -1;
@@ -324,6 +323,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 @mixin iui-tile-thumbnail-button($variant) {
   @include iui-button-borderless;
   @include iui-button-size(small, borderless);
+  z-index: 1;
   border-radius: 50%;
   margin-top: calc(var(--iui-size-s) * 0.5);
   margin-inline: var(--iui-size-xs);
@@ -364,10 +364,11 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   justify-content: flex-end;
   overflow: hidden;
   gap: var(--iui-size-2xs);
-  z-index: 1;
+  position: relative;
 }
 
 @mixin iui-tile-buttons {
+  z-index: 1;
   display: flex;
   flex-shrink: 0;
   user-select: none;
@@ -400,6 +401,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-more-options {
+  z-index: 1;
   grid-area: 1 / 1 / -1 / -1;
   position: absolute;
   place-self: end;


### PR DESCRIPTION
## Changes

In #959, `z-index: 1` was added on the tile-name to allow clicking on the thumbnail region to activate the action. But this broke all the other buttons on the tile, such as the quick-action/type-indicator (on the top-left/top-right of the tile) and the more-options (bottom-right).

So I've changed tile-name to have `z-index: 0`, and everything that needs to be on top of it to have `z-index: 1`. This ensures that clicking on *most* of the tile will perform the default action (such as navigation or selecting the Tile) and clicking on these specific regions will perform the contextual action (such as opening a dropdown).

## Testing

Tested working correctly by clicking/hovering on all the different parts of tiles in the html test pages (under the "Default" section) as well as storybook (the "Actionable" and "Anchor Link" stories).

## Docs

N/A. Changeset not needed because #959 is not released yet.