### PR TITLE
doc(Avatar): Added avatar group with tooltip example

### DIFF
--- a/apps/website/src/examples/Avatar.groupoverflowtooltip.tsx
+++ b/apps/website/src/examples/Avatar.groupoverflowtooltip.tsx
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import { AvatarGroup, Avatar, getUserColor, Tooltip } from '@itwin/itwinui-react';
+
+export default () => {
+  const userNames = [
+    'Terry Rivers',
+    'Robin Mercer',
+    'Morgan Vera',
+    'Ashley Miles',
+    'Jean Mullins',
+    'Charlie Mayfield',
+    'Peyton Pennington',
+    'Justice Harrington',
+    'Alex Gonzales',
+    'Jordan Baker',
+  ];
+
+  /**
+   * Ref is set on the last avatar for tooltip positioning.
+   */
+  const avatarRef = React.useRef<HTMLDivElement>(null);
+
+  const maxIcons = 3;
+  const arrayLength = maxIcons;
+  const usersSubArray = userNames.slice(arrayLength);
+  const tooltipContent = usersSubArray.join(`\n`) as string;
+
+  return (
+    <>
+      <AvatarGroup iconSize='x-large' maxIcons={maxIcons} countIconProps={{ ref: avatarRef }}>
+        {userNames.map((name, index) => (
+          <Avatar
+            key={`${name}-${index}`}
+            abbreviation={name
+              .split(' ')
+              .map((token) => token[0])
+              .join('')}
+            backgroundColor={getUserColor(name)}
+            title={name}
+          />
+        ))}
+      </AvatarGroup>
+      <Tooltip
+        reference={avatarRef}
+        content={tooltipContent}
+        placement='right'
+        style={{ whiteSpace: 'pre' }}
+      />
+    </>
+  );
+};

--- a/apps/website/src/examples/index.tsx
+++ b/apps/website/src/examples/index.tsx
@@ -14,6 +14,7 @@ export { default as AvatarMainExample } from './Avatar.main';
 export { default as AvatarGroupExample } from './Avatar.group';
 export { default as AvatarGroupAnimatedExample } from './Avatar.groupanimated';
 export { default as AvatarGroupOverflowExample } from './Avatar.groupoverflow';
+export { default as AvatarGroupOverflowTooltipExample } from './Avatar.groupoverflowtooltip';
 export { default as AvatarGroupStackedExample } from './Avatar.groupstacked';
 export { default as AvatarIconExample } from './Avatar.icon';
 export { default as AvatarInitialsExample } from './Avatar.initials';

--- a/apps/website/src/pages/docs/avatar.mdx
+++ b/apps/website/src/pages/docs/avatar.mdx
@@ -99,13 +99,15 @@ You can also have the stacked group animate to unstacked on hover. When doing th
 
 ### Overflow
 
-By default a maximum of five avatars will be shown within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
+It is strongly suggested that you display a maximum of five avatars within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
 
 <LiveExample src='Avatar.groupoverflow.tsx'>
   <AllExamples.AvatarGroupOverflowExample client:load />
 </LiveExample>
 
 Additionally, you could display a [tooltip](tooltip) on hover, a [dialog](dialog) on click, or perhaps a [dropdown menu](dropdownmenu) of the hidden users. Implementation of these options depends on the purpose of the page and the use case.
+
+The example below displays a tooltip of all hidden avatars. It also uses the property `maxIcons` to limit the number of visible avatars to three.
 
 <LiveExample src='Avatar.groupoverflowtooltip.tsx'>
   <AllExamples.AvatarGroupOverflowTooltipExample client:load />

--- a/apps/website/src/pages/docs/avatar.mdx
+++ b/apps/website/src/pages/docs/avatar.mdx
@@ -99,10 +99,16 @@ You can also have the stacked group animate to unstacked on hover. When doing th
 
 ### Overflow
 
-A maximum of six avatars can be shown within a group. Additional avatars are hidden; however, the number of hidden items should be displayed in the last avatar circle as shown below. Additionally, you could display a [tooltip](tooltip) on hover, a [dialog](dialog) on click, or perhaps a [dropdown menu](dropdownmenu) of the hidden users. Implementation of these options depends on the purpose of the page and the use case.
+By default a maximum of six avatars will be shown within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
 
 <LiveExample src='Avatar.groupoverflow.tsx'>
   <AllExamples.AvatarGroupOverflowExample client:load />
+</LiveExample>
+
+Additionally, you could display a [tooltip](tooltip) on hover, a [dialog](dialog) on click, or perhaps a [dropdown menu](dropdownmenu) of the hidden users. Implementation of these options depends on the purpose of the page and the use case.
+
+<LiveExample src='Avatar.groupoverflowtooltip.tsx'>
+  <AllExamples.AvatarGroupOverflowTooltipExample client:load />
 </LiveExample>
 
 ## Props

--- a/apps/website/src/pages/docs/avatar.mdx
+++ b/apps/website/src/pages/docs/avatar.mdx
@@ -99,7 +99,7 @@ You can also have the stacked group animate to unstacked on hover. When doing th
 
 ### Overflow
 
-It is strongly suggested that you display a maximum of five avatars within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
+By default a maximum of five avatars will be shown within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
 
 <LiveExample src='Avatar.groupoverflow.tsx'>
   <AllExamples.AvatarGroupOverflowExample client:load />

--- a/apps/website/src/pages/docs/avatar.mdx
+++ b/apps/website/src/pages/docs/avatar.mdx
@@ -99,7 +99,7 @@ You can also have the stacked group animate to unstacked on hover. When doing th
 
 ### Overflow
 
-By default a maximum of six avatars will be shown within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
+By default a maximum of five avatars will be shown within a group. Additional avatars are hidden; however, the number of hidden items will be displayed in the last avatar circle as shown below.
 
 <LiveExample src='Avatar.groupoverflow.tsx'>
   <AllExamples.AvatarGroupOverflowExample client:load />


### PR DESCRIPTION
## Changes

I added the storybook example for avatar group with tooltip to the website. I also edited some of the text to reflect the addition, and corrected the statement that the maximum amount of avatars is six.

![image](https://user-images.githubusercontent.com/37936169/225951503-4ba2f687-620f-4f8a-a4e0-aecacd8af543.png)

## Testing

I made sure the website example worked as intended.

## Docs

N/A
