### PR TITLE
fix z-index issues with actionable tiles (again)

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -225,7 +225,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   &,
   > .iui-link-action {
     width: 100%;
-    z-index: 0;
+    z-index: 1;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -323,7 +323,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 @mixin iui-tile-thumbnail-button($variant) {
   @include iui-button-borderless;
   @include iui-button-size(small, borderless);
-  z-index: 1;
+  z-index: 2;
   border-radius: 50%;
   margin-top: calc(var(--iui-size-s) * 0.5);
   margin-inline: var(--iui-size-xs);
@@ -368,7 +368,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-buttons {
-  z-index: 1;
+  z-index: 2;
   display: flex;
   flex-shrink: 0;
   user-select: none;
@@ -401,7 +401,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-more-options {
-  z-index: 1;
+  z-index: 2;
   grid-area: 1 / 1 / -1 / -1;
   position: absolute;
   place-self: end;


### PR DESCRIPTION
## Changes

#1141 was only working on firefox, so this change makes it work on chrome too.

## Testing

same as #1141 but made sure to click on thumbnail area in chrome and safari too.

Before:

https://user-images.githubusercontent.com/9084735/226354345-48920c2d-ec5e-4c93-beb6-192a1ea3e413.mov

After:

https://user-images.githubusercontent.com/9084735/226354490-76c2ec04-e27b-400e-b9a3-251a7f0b22aa.mov

(results might vary by operating system)

## Docs

N/A