### PR TITLE
warn if root font size was overridden

### DIFF
--- a/.changeset/cuddly-cherries-build.md
+++ b/.changeset/cuddly-cherries-build.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+iTwinUI will now show a warning in development if it detects that the page overrides the root font size. For more details, see the [migration guide](https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v2-migration-guide#relative-font-size).

--- a/packages/itwinui-react/src/core/utils/hooks/useTheme.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useTheme.ts
@@ -145,7 +145,7 @@ try {
   isDev = process.env.NODE_ENV !== 'production';
 } catch {}
 
-/** Shows console warning if the page changes the font size */
+/** Shows console error if the page changes the root font size */
 const useCorrectRootFontSize = () => {
   React.useEffect(() => {
     if (isDev && !didLogWarning) {
@@ -153,7 +153,9 @@ const useCorrectRootFontSize = () => {
         getComputedStyle(document.documentElement).fontSize,
       );
       if (rootFontSize < 16) {
-        console.error('Please dont fuck with the root font size');
+        console.error(
+          'Root font size must not be overridden. \nSee https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v2-migration-guide#relative-font-size',
+        );
         didLogWarning = true;
       }
     }

--- a/packages/itwinui-react/src/core/utils/hooks/useTheme.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useTheme.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import { getDocument, getWindow } from '../functions';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 import { useIsThemeAlreadySet } from './useIsThemeAlreadySet';
@@ -53,6 +54,8 @@ export const useTheme = (
 ) => {
   const ownerDocument = themeOptions?.ownerDocument ?? getDocument();
   const isThemeAlreadySet = useIsThemeAlreadySet(ownerDocument);
+
+  useCorrectRootFontSize();
 
   useIsomorphicLayoutEffect(() => {
     if (!ownerDocument || isThemeAlreadySet.current) {
@@ -132,4 +135,27 @@ const handleTheme = (
     prefersDarkQuery?.removeEventListener?.('change', changeHandler);
     prefersHCQuery?.removeEventListener?.('change', changeHandler);
   };
+};
+
+let didLogWarning = false;
+let isDev = false;
+
+// wrapping in try-catch because process might be undefined
+try {
+  isDev = process.env.NODE_ENV !== 'production';
+} catch {}
+
+/** Shows console warning if the page changes the font size */
+const useCorrectRootFontSize = () => {
+  React.useEffect(() => {
+    if (isDev && !didLogWarning) {
+      const rootFontSize = parseInt(
+        getComputedStyle(document.documentElement).fontSize,
+      );
+      if (rootFontSize < 16) {
+        console.error('Please dont fuck with the root font size');
+        didLogWarning = true;
+      }
+    }
+  }, []);
 };


### PR DESCRIPTION
## Changes

Added new internal hook called in `useTheme` (and thus called in every component) to show a console error in development mode if the root font size was overridden. This will help avoid surprises for users who might notice that our component sizes have unexpectedly changed.

## Testing

Confirmed warning appearing by overriding root font size in dev tools.

## Docs

Added new section to migration guide: https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v2-migration-guide#relative-font-size