### PR TITLE
fix site url for seo

### DIFF
--- a/apps/website/astro.config.ts
+++ b/apps/website/astro.config.ts
@@ -15,6 +15,7 @@ const isDev = process.env.NODE_ENV === 'development';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://itwinui.bentley.com',
   integrations: [react(), mdx(), sitemap()],
   markdown: {
     syntaxHighlight: 'prism',

--- a/apps/website/src/components/HeadSEO.astro
+++ b/apps/website/src/components/HeadSEO.astro
@@ -8,8 +8,7 @@ const contentDescription =
   content.description ||
   `An open-source design system for building consistent, accessible experiences.`;
 
-const canonicalUrl = 'https://www.itwinui.com';
-const deployUrl = import.meta.env.DEPLOY_PRIME_URL || Astro.request.url;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <title>{contentTitle}</title>
@@ -24,7 +23,7 @@ const deployUrl = import.meta.env.DEPLOY_PRIME_URL || Astro.request.url;
 <meta property='og:type' content='article' />
 <meta property='og:url' content={canonicalUrl} />
 <meta property='og:locale' content={content.ogLocale ?? 'en-us'} />
-<meta property='og:image' content={new URL('og-image.png', deployUrl)} />
+<meta property='og:image' content={new URL('/og-image.png', Astro.url)} />
 <meta property='og:image:alt' content='iTwinUI logo' />
 <meta property='og:site_name' content={contentTitle} />
 
@@ -32,4 +31,4 @@ const deployUrl = import.meta.env.DEPLOY_PRIME_URL || Astro.request.url;
 <meta name='twitter:card' content='summary_large_image' />
 <meta name='twitter:title' content={contentTitle} />
 <meta name='twitter:description' content={contentDescription} />
-<meta name='twitter:image' content={new URL('twitter-image.png', deployUrl)} />
+<meta name='twitter:image' content={new URL('/twitter-image.png', Astro.url)} />


### PR DESCRIPTION
## Changes

Astro requires the [`site`](https://docs.astro.build/en/reference/configuration-reference/#site) property to be specified in config to generate correct sitemaps. This property is then also used to generate canonical urls for SEO.

## Testing

Tested correct urls showing up in build output. (Previously it was not even generating sitemap and was using localhost in some of the meta tags)

## Docs

N/A