### PR TITLE
website: Change code sample box

### DIFF
--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -29,36 +29,33 @@ if (code.includes('Copyright (c) Bentley Systems')) {
 }
 ---
 
-<div class='demo-box'>
-  <ThemeProvider
-    className='demo-iui-wrapper'
-    theme='dark'
-    themeOptions={{ applyBackground: false }}
-  >
-    <slot />
-  </ThemeProvider>
-  <OpenInCodesandbox class='sandbox-link' code={code} />
+<div class='demo-wrapper'>
+  <div class='demo-box'>
+    <ThemeProvider
+      className='demo-iui-wrapper'
+      theme='dark'
+      themeOptions={{ applyBackground: false }}
+    >
+      <slot />
+    </ThemeProvider>
+    <OpenInCodesandbox class='sandbox-link' code={code} />
+  </div>
+  <demo-code>
+    <details>
+      <summary>Code sample</summary>
+      <Code code={code} lang='tsx' theme={nightOwl} />
+    </details>
+    <button data-copied='false'><span class='visually-hidden'>Copy to clipboard</span></button>
+  </demo-code>
 </div>
-<demo-code>
-  {truncate && <button aria-expanded='false'>Toggle full code</button>}
-  <button data-copied='false'><span class='visually-hidden'>Copy to clipboard</span></button>
-  <Code code={code} lang='tsx' theme={nightOwl} />
-</demo-code>
 
 <script>
   customElements.define(
     'demo-code',
     class extends HTMLElement {
       connectedCallback() {
-        const expandButton = this.querySelector('button[aria-expanded]') as HTMLElement;
         const copyButton = this.querySelector('button[data-copied]') as HTMLElement;
         const code = this.querySelector('pre');
-
-        expandButton?.addEventListener('click', () => {
-          const shouldExpand = expandButton.getAttribute('aria-expanded') === 'false';
-          expandButton.setAttribute('aria-expanded', String(shouldExpand));
-          code.inert = !shouldExpand;
-        });
 
         copyButton?.addEventListener('click', async () => {
           try {
@@ -79,6 +76,11 @@ if (code.includes('Copyright (c) Bentley Systems')) {
 </script>
 
 <style lang='scss'>
+  .demo-wrapper {
+    background: var(--color-sandbox-gradient);
+    border-radius: var(--border-radius-1);
+  }
+
   .demo-box {
     position: relative;
     min-height: 300px;
@@ -86,9 +88,8 @@ if (code.includes('Copyright (c) Bentley Systems')) {
     display: grid;
     justify-items: center;
     padding: 1rem;
-    background: var(--color-sandbox-gradient);
     isolation: isolate;
-    border-radius: var(--border-radius-1);
+    border-radius: inherit;
   }
 
   .demo-iui-wrapper {
@@ -111,61 +112,43 @@ if (code.includes('Copyright (c) Bentley Systems')) {
     isolation: isolate;
     position: relative;
     display: grid;
-    border-radius: var(--border-radius-1);
-    outline: 1px solid var(--color-line-2);
-    outline-offset: 1px;
 
-    > :global(pre) {
-      padding: 1rem;
-      font-size: var(--type--1);
-      border-radius: var(--border-radius-1);
-    }
+    > details {
+      border-radius: 0 0 var(--border-radius-1) var(--border-radius-1);
+      border-top: 1px solid var(--color-line-2);
 
-    > :global([aria-expanded='false'] ~ pre) {
-      max-height: 200px;
-      overflow: hidden !important;
+      > summary {
+        padding: 1rem;
+        cursor: pointer;
+        user-select: none;
+        color: var(--color-subtext);
+        border-radius: inherit;
 
-      &::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        background: linear-gradient(to bottom, transparent, var(--color-background-2));
+        &:hover {
+          background-color: var(--color-active);
+          color: var(--color-text);
+        }
       }
-    }
 
-    > :global([aria-expanded='true'] ~ pre) {
-      padding-block-end: 2.5rem;
+      > :global(pre) {
+        padding: 1rem;
+        font-size: var(--type--1);
+        background-color: transparent !important;
+      }
     }
 
     button {
       font: inherit;
       cursor: pointer;
-      background: var(--color-background-1);
-      padding: 0.5rem 1.25rem;
+      background: transparent;
+      color: var(--color-text);
       position: absolute;
-      border: 1px solid;
-      border-radius: var(--border-radius-1);
-      z-index: 2;
+      border: 1px solid transparent;
+      border-radius: 999px;
       transition: color 0.2s, border-color 0.2s;
-    }
-
-    button[aria-expanded] {
-      bottom: 1rem;
-      left: 50%;
-      transform: translateX(-50%);
-
-      &:not(:hover, :focus-visible) {
-        color: var(--color-text);
-        border-color: var(--color-line-1);
-      }
-    }
-
-    button[data-copied] {
-      top: 0.5rem;
-      right: 0.5rem;
-      padding: 0.5rem;
-      border-color: var(--color-line-2);
+      top: 0.75rem;
+      right: 0.25rem;
+      padding: calc(0.5rem - 1px);
       display: grid;
       place-items: center;
 
@@ -185,7 +168,7 @@ if (code.includes('Copyright (c) Bentley Systems')) {
       }
 
       &:hover {
-        border-color: currentColor;
+        background-color: hsla(0deg, 0%, 0%, 0.2);
       }
     }
 


### PR DESCRIPTION
## Changes

While working on #961 some pages have many demos.  With the current implementation the code samples take up a good amount of vertical space even when collapsed.  The idea behind this was to reduce the vertical space used when collapsed, reduce the visual noise when collapsed (the code samples, because they're colorful, draw my attention).

- Use `<details>` to show / hide the code snippet under demos on the documentation website.
- Styled the copy button to match the Open in Codesandbox button directly above it.

## Testing

N/A

## Docs

N/A