### PR TITLE
fix(Toast): Allow toast message to break

### DIFF
--- a/.changeset/weak-carrots-cheat.md
+++ b/.changeset/weak-carrots-cheat.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Allows toast messages to break when words are long.

--- a/packages/itwinui-css/src/toast/toast.scss
+++ b/packages/itwinui-css/src/toast/toast.scss
@@ -41,6 +41,8 @@
     font-weight: var(--iui-font-weight-normal);
     font-style: normal;
     color: var(--iui-color-text);
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 
   &-anchor {


### PR DESCRIPTION
## Changes
Added css that allows toast messages to break rather than overflow as in this example: https://stackblitz.com/edit/react-ts-tyyqu4?file=App.tsx

Before: 
![image](https://user-images.githubusercontent.com/37936169/228608299-c123fb43-a7a7-485f-9681-77ab4bd0af56.png)
After: 
![image](https://user-images.githubusercontent.com/37936169/228608447-9841e17a-6e1c-48ce-863f-d0e4eb1ade78.png)

## Testing

Tested that long words and short words behave as expected in the toast. The long words should break if necessary but short words should not unecessarily.

## Docs
Added changeset
