### PR TITLE
fix(Alert): Allow alert message to break

### DIFF
--- a/.changeset/nasty-news-dress.md
+++ b/.changeset/nasty-news-dress.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Allows alert messages to break when words are long.

--- a/packages/itwinui-css/src/alert/alert.scss
+++ b/packages/itwinui-css/src/alert/alert.scss
@@ -36,6 +36,8 @@
 
 @mixin iui-alert-message {
   margin: var(--iui-size-s) var(--iui-size-m);
+  word-break: normal;
+  overflow-wrap: anywhere;
 }
 
 @mixin iui-alert-link {


### PR DESCRIPTION
## Changes
Added css that allows alert messages to break rather than overflow as mentioned in the similar PR for toast: https://github.com/iTwin/iTwinUI/pull/1169

Before: 
![image](https://user-images.githubusercontent.com/37936169/228659201-e05a3061-0c9b-438e-917c-de7ef7069db6.png)
After: 
![image](https://user-images.githubusercontent.com/37936169/228659249-5e031b65-adeb-4120-900a-d879096dfc6a.png)

## Testing
Tested that long words and short words behave as expected in the alert. The long words should break if necessary but short words should not unecessarily.

## Docs
Added changeset
