### PR TITLE
fix draggable/resizable dialogs in popup windows

### DIFF
--- a/.changeset/bright-mails-exist.md
+++ b/.changeset/bright-mails-exist.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where draggable/resizable dialogs opened in popup windows were not working correctly.

--- a/.changeset/bright-mails-exist.md
+++ b/.changeset/bright-mails-exist.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed an issue where draggable/resizable dialogs opened in popup windows were not working correctly.
+Fixed an issue in draggable/resizable dialogs opened in popup windows, where pointermove event listeners were not being removed correctly.

--- a/packages/itwinui-react/src/core/utils/components/Resizer.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Resizer.tsx
@@ -69,10 +69,10 @@ export const Resizer = (props: ResizerProps) => {
     );
 
     const resizer = event.currentTarget.dataset.iuiResizer;
+    const ownerDocument = elementRef.current.ownerDocument || document;
 
-    const originalUserSelect =
-      elementRef.current.ownerDocument.body.style.userSelect;
-    elementRef.current.ownerDocument.body.style.userSelect = 'none';
+    const originalUserSelect = ownerDocument.body.style.userSelect;
+    ownerDocument.body.style.userSelect = 'none';
 
     const onResizePointerMove = (event: PointerEvent) => {
       if (!elementRef.current) {
@@ -88,15 +88,13 @@ export const Resizer = (props: ResizerProps) => {
       const clientX = getBoundedValue(
         event.clientX,
         containerRect?.left ?? 0,
-        containerRect?.right ??
-          elementRef.current.ownerDocument.documentElement.clientWidth ??
-          0,
+        containerRect?.right ?? ownerDocument.documentElement.clientWidth ?? 0,
       );
       const clientY = getBoundedValue(
         event.clientY,
         containerRect?.top ?? 0,
         containerRect?.bottom ??
-          elementRef.current.ownerDocument.documentElement.clientHeight ??
+          ownerDocument.documentElement.clientHeight ??
           0,
       );
 
@@ -182,17 +180,13 @@ export const Resizer = (props: ResizerProps) => {
       }
     };
 
-    elementRef.current.ownerDocument.addEventListener(
-      'pointermove',
-      onResizePointerMove,
-    );
-    elementRef.current.ownerDocument.addEventListener(
+    ownerDocument.addEventListener('pointermove', onResizePointerMove);
+    ownerDocument.addEventListener(
       'pointerup',
       () => {
-        document.removeEventListener('pointermove', onResizePointerMove);
+        ownerDocument.removeEventListener('pointermove', onResizePointerMove);
         if (elementRef.current) {
-          elementRef.current.ownerDocument.body.style.userSelect =
-            originalUserSelect;
+          ownerDocument.body.style.userSelect = originalUserSelect;
           isResizing.current = false;
           onResizeEnd?.({
             width,

--- a/packages/itwinui-react/src/core/utils/hooks/useDragAndDrop.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useDragAndDrop.tsx
@@ -120,17 +120,18 @@ export const useDragAndDrop = (
       // Prevents from selecting inner content when dragging.
       elementRef.current.style.userSelect = 'none';
 
-      elementRef.current.ownerDocument.addEventListener(
-        'pointermove',
-        onPointerMove.current,
-      );
-      elementRef.current.ownerDocument.addEventListener(
+      const ownerDocument = elementRef.current.ownerDocument || document;
+      ownerDocument.addEventListener('pointermove', onPointerMove.current);
+      ownerDocument.addEventListener(
         'pointerup',
         () => {
           setTransform(
             `translate(${translateX.current}px, ${translateY.current}px)`,
           );
-          document.removeEventListener('pointermove', onPointerMove.current);
+          ownerDocument.removeEventListener(
+            'pointermove',
+            onPointerMove.current,
+          );
           if (elementRef.current) {
             elementRef.current.style.userSelect = originalUserSelect.current;
           }


### PR DESCRIPTION
## Changes

Replaced `document` with `ownerDocument` when removing the `pointermove` event listener. Hopefully fixes https://github.com/iTwin/appui/issues/236.

## Testing

Tested in playground with this code:

<details>
<summary>App.tsx</summary>
  
```tsx
import React from 'react';
import ReactDOM from 'react-dom';
import { Button, Dialog, ThemeProvider } from '@itwin/itwinui-react';

const App = () => {
  const [popout, setPopout] = React.useState<Window>();

  return (
    <>
      <Button
        onClick={() => {
          setPopout(openNewWindow());
        }}
      >
        Open popup
      </Button>
      {popout &&
        ReactDOM.createPortal(<DraggableDialog />, popout.document.body)}
    </>
  );
};

const openNewWindow = () => {
  const popout = window.open()!;
  document.head.querySelectorAll('link, style').forEach((style) => {
    popout.document.head.appendChild(style.cloneNode(true));
  });
  return popout;
};

const DraggableDialog = () => {
  const [isOpen, setIsOpen] = React.useState(true);

  return (
    <>
      <ThemeProvider>
        <Dialog
          isOpen={isOpen}
          onClose={() => setIsOpen(false)}
          closeOnEsc
          isDismissible
          isDraggable
          isResizable
        >
          <Dialog.Main>
            <Dialog.TitleBar titleText='Best dialog ever' />
            <Dialog.Content>
              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
              enim ad minim veniam, quis nostrud exercitation ullamco laboris
              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
              reprehenderit in voluptate velit esse cillum dolore eu fugiat
              nulla pariatur. Excepteur sint occaecat cupidatat non proident,
              sunt in culpa qui officia deserunt mollit anim id est laborum.
            </Dialog.Content>
          </Dialog.Main>
        </Dialog>
      </ThemeProvider>
    </>
  );
};

export default App;
```
</details>

## Docs

Added changeset.
