### PR TITLE
fix changesets format

### DIFF
--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -1,0 +1,56 @@
+/** @type {import('@changesets/types').ChangelogFunctions} */
+module.exports = {
+  getReleaseLine: async ({ commit, summary }, type, options) => {
+    checkOptionsRepo(options);
+
+    const [firstLine, ...futureLines] = summary
+      .split('\n')
+      .map((l) => l.trimEnd());
+
+    const prOrCommit = await (async () => {
+      try {
+        return await fetch(
+          `https://api.github.com/repos/${options.repo}/commits/${commit}/pulls`,
+        )
+          .then((r) => r.json())
+          .then(
+            ([{ number }]) =>
+              `[#${number}](https://github.com/${options.repo}/pull/${number}): `,
+          );
+      } catch {
+        return `${commit}: ` || '';
+      }
+    })();
+
+    let returnVal = `- ${prOrCommit}${firstLine}`;
+
+    if (futureLines.length > 0) {
+      returnVal += `\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
+    }
+
+    return returnVal;
+  },
+  getDependencyReleaseLine: async (
+    changesets,
+    dependenciesUpdated,
+    options,
+  ) => {
+    checkOptionsRepo(options);
+
+    if (dependenciesUpdated.length === 0) return '';
+
+    const updatedDependenciesList = dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+    );
+
+    return ['- Updated dependencies:', ...updatedDependenciesList].join('\n');
+  },
+};
+
+function checkOptionsRepo(options) {
+  if (!options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
+    );
+  }
+}

--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -22,7 +22,7 @@ module.exports = {
               `[#${number}](https://github.com/${options.repo}/pull/${number}): `,
           );
       } catch {
-        return `${commit}: ` || '';
+        return commit ? `${commit}: ` : '';
       }
     })();
 

--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -1,7 +1,11 @@
 /** @type {import('@changesets/types').ChangelogFunctions} */
 module.exports = {
   getReleaseLine: async ({ commit, summary }, type, options) => {
-    checkOptionsRepo(options);
+    if (!options.repo) {
+      throw new Error(
+        'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog-github.mjs", { "repo": "org/repo" }]',
+      );
+    }
 
     const [firstLine, ...futureLines] = summary
       .split('\n')
@@ -30,13 +34,7 @@ module.exports = {
 
     return returnVal;
   },
-  getDependencyReleaseLine: async (
-    changesets,
-    dependenciesUpdated,
-    options,
-  ) => {
-    checkOptionsRepo(options);
-
+  getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
     if (dependenciesUpdated.length === 0) return '';
 
     const updatedDependenciesList = dependenciesUpdated.map(
@@ -46,11 +44,3 @@ module.exports = {
     return ['- Updated dependencies:', ...updatedDependenciesList].join('\n');
   },
 };
-
-function checkOptionsRepo(options) {
-  if (!options.repo) {
-    throw new Error(
-      'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog-github.mjs", { "repo": "org/repo" }]',
-    );
-  }
-}

--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -11,23 +11,23 @@ module.exports = {
       .split('\n')
       .map((l) => l.trimEnd());
 
+    // make API call to find PR number associated with the commit
     const prOrCommit = await (async () => {
       try {
-        return await fetch(
+        const [{ number }] = await fetch(
           `https://api.github.com/repos/${options.repo}/commits/${commit}/pulls`,
-        )
-          .then((r) => r.json())
-          .then(
-            ([{ number }]) =>
-              `[#${number}](https://github.com/${options.repo}/pull/${number}): `,
-          );
+        ).then((r) => r.json());
+
+        return `[#${number}](https://github.com/${options.repo}/pull/${number})`;
       } catch {
-        return commit ? `${commit}: ` : '';
+        // fallback to commit sha if API call fails for some reason
+        return commit;
       }
     })();
 
-    let returnVal = `- ${prOrCommit}${firstLine}`;
+    let returnVal = `- ${prOrCommit}: ${firstLine}`;
 
+    // indent everything so it's aligned with the first line
     if (futureLines.length > 0) {
       returnVal += `\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
     }

--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -50,7 +50,7 @@ module.exports = {
 function checkOptionsRepo(options) {
   if (!options.repo) {
     throw new Error(
-      'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]',
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog-github.mjs", { "repo": "org/repo" }]',
     );
   }
 }

--- a/.changeset/changelog-github.cjs
+++ b/.changeset/changelog-github.cjs
@@ -1,3 +1,5 @@
+// see https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md
+
 /** @type {import('@changesets/types').ChangelogFunctions} */
 module.exports = {
   getReleaseLine: async ({ commit, summary }, type, options) => {
@@ -34,6 +36,7 @@ module.exports = {
 
     return returnVal;
   },
+
   getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
     if (dependenciesUpdated.length === 0) return '';
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["./changelog-github.cjs", { "repo": "iTwin/iTwinUI" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Changes

Updated changesets config to use a custom script instead of [`@changesets/changelog-git`](https://github.com/changesets/changesets/blob/main/packages/changelog-git/src/index.ts).

Two main changes:
- will show PR number instead of commit number
- hopefully will not show duplicate entries for updated dependencies
 
## Testing

Tested by running `yarn changeset version` before today's release.

## Docs

N/A
