### PR TITLE
website: Add related components section

### DIFF
--- a/apps/website/src/components/RelatedComponents.astro
+++ b/apps/website/src/components/RelatedComponents.astro
@@ -1,0 +1,71 @@
+---
+import Card from './Card.astro';
+
+export type Props = {
+  components: { title: string; url: string }[];
+};
+
+const { components } = Astro.props;
+---
+
+<ul>
+  {
+    components.map((page) => (
+      <li class='card'>
+        <h3>
+          <a href={page.url}>{page.title}</a>
+        </h3>
+      </li>
+    ))
+  }
+</ul>
+
+<style lang='scss'>
+  ul {
+    --_iui-grid-item-min-width: 200px;
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(min(100%, var(--_iui-grid-item-min-width)), 1fr)
+    );
+    gap: var(--space-5);
+    margin-top: var(--space-5);
+    padding: 0;
+  }
+
+  .card {
+    position: relative;
+    display: flex;
+    flex: 1 0 20%;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    border-radius: var(--border-radius-1);
+    box-shadow: 0 0 1px var(--color-highlight-1), 0 0 10px var(--color-highlight-2);
+    transition: box-shadow var(--transition-speed) ease;
+
+    &:where(:hover, :focus-within) {
+      box-shadow: 0 0 10px var(--color-highlight-1), 0 0 20px var(--color-highlight-2);
+    }
+  }
+
+  a {
+    color: var(--color-text);
+    text-decoration: none;
+
+    &:where(:focus) {
+      outline: none;
+      text-decoration: none;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+    }
+  }
+
+  h3 {
+    font-size: var(--type-0);
+  }
+</style>

--- a/apps/website/src/components/RelatedComponents.astro
+++ b/apps/website/src/components/RelatedComponents.astro
@@ -60,8 +60,4 @@ const { components, ...rest } = Astro.props;
       inset: 0;
     }
   }
-
-  h3 {
-    font-size: var(--type-0);
-  }
 </style>

--- a/apps/website/src/components/RelatedComponents.astro
+++ b/apps/website/src/components/RelatedComponents.astro
@@ -1,20 +1,16 @@
 ---
-import Card from './Card.astro';
-
 export type Props = {
   components: { title: string; url: string }[];
 };
 
-const { components } = Astro.props;
+const { components, ...rest } = Astro.props;
 ---
 
-<ul>
+<ul {...rest}>
   {
     components.map((page) => (
       <li class='card'>
-        <h3>
-          <a href={page.url}>{page.title}</a>
-        </h3>
+        <a href={page.url}>{page.title}</a>
       </li>
     ))
   }

--- a/apps/website/src/pages/docs/buttongroup.mdx
+++ b/apps/website/src/pages/docs/buttongroup.mdx
@@ -10,6 +10,7 @@ group: buttons
 import PropsTable from '~/components/PropsTable.astro';
 import LiveExample from '~/components/LiveExample.astro';
 import Placeholder from '~/components/Placeholder.astro';
+import RelatedComponents from '~/components/RelatedComponents.astro';
 import * as AllExamples from '~/examples';
 
 <p>{frontmatter.description}</p>
@@ -61,3 +62,13 @@ You can combine [inputs](input) with buttons in a button group.
 ## Props
 
 To be defined
+
+## Related components
+
+<RelatedComponents
+  components={[
+    { title: 'Button', url: 'button' },
+    { title: 'Dropdown menu', url: 'dropdownmenu' },
+    { title: 'Input', url: 'input' },
+  ]}
+/>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Added component to show related components cards list. Currently added only to ButtonGroup.

![image](https://user-images.githubusercontent.com/83585998/230092477-84981317-1901-4792-bda3-806e63133d17.png)

## Testing

Visual testing, also voiceOver testing.

## Docs

N/A
