### PR TITLE
website: Link to components in home page demo

### DIFF
--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -46,37 +46,39 @@ const currentPage = new URL(Astro.request.url).pathname;
       <div class='demo-carousel-list move-on-visible' data-move-on-visible-direction='up'>
         <div class='demo-wrapper'>
           <div class='demo-box'><AlertDemo client:load /></div>
-          <h3>Alert</h3>
+          <a href='/docs/alert' class='component-link'>Alert</a>
           <p>A small box to quickly grab user attention and communicate a brief message.</p>
         </div>
 
         <div class='demo-wrapper'>
           <div class='demo-box'><DialogDemo client:load /></div>
-          <h3>Dialog</h3>
+          <a href='/docs/dialog' class='component-link'>Dialog</a>
           <p>Provides the foundation for building modals and modeless dialogs.</p>
         </div>
 
         <div class='demo-wrapper'>
           <div class='demo-box'><FieldsetDemo client:load /></div>
-          <h3>Fieldset</h3>
+          <a href='/docs/fieldset' class='component-link'>Fieldset</a>
           <p>A fieldset is a container grouping interactive components together.</p>
         </div>
 
         <div class='demo-wrapper'>
           <div class='demo-box'><SliderDemo client:load /></div>
-          <h3>Slider</h3>
+          <a href='/docs/slider' class='component-link'>Slider</a>
           <p>Sliders let users make selections from a range of values.</p>
         </div>
 
         <div class='demo-wrapper'>
           <div class='demo-box'><ComboBoxDemo client:load /></div>
-          <h3>ComboBox</h3>
+          <a href='/docs/combobox' class='component-link'>ComboBox</a>
           <p>Allows typing a value to filter and choose from the options in dropdown list.</p>
         </div>
         <div class='demo-wrapper'>
           <div class='demo-box demo-box-muted'>
             <li class='discover-more'>
-              <h3><a href={'/docs/components'}>Discover more components <RightArrowIcon /></a></h3>
+              <a href={'/docs/components'} class='component-link'
+                >Discover more components <RightArrowIcon />
+              </a>
             </li>
           </div>
         </div>
@@ -215,6 +217,10 @@ const currentPage = new URL(Astro.request.url).pathname;
     a {
       text-decoration: none;
       color: unset;
+
+      &:hover {
+        text-decoration: underline;
+      }
     }
     .header {
       grid-area: header;
@@ -383,7 +389,8 @@ const currentPage = new URL(Astro.request.url).pathname;
       text-align: center;
       padding-bottom: var(--space-4);
     }
-    h3 {
+    h3,
+    .component-link {
       font-size: var(--type-2);
       text-align: left;
     }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Users complain that home page demos are not clickable. Added simple link on component name to route users to component docs.
[underline only on hover to indicate that it's clickable]
<img width="388" alt="image" src="https://user-images.githubusercontent.com/83585998/230363498-39424e62-4aab-482e-92f8-320c7f2c5cb6.png">


## Testing

N/A
## Docs

N/A
