### PR TITLE
improve website typography

### DIFF
--- a/apps/website/src/components/Placeholder.astro
+++ b/apps/website/src/components/Placeholder.astro
@@ -28,6 +28,10 @@ const storyUrl = `https://itwin.github.io/iTwinUI/react/?path=/story/${component
     border: solid 1px var(--color-highlight-2);
     border-radius: var(--border-radius-1);
 
+    p {
+      color: var(--color-text);
+    }
+
     svg {
       color: var(--color-highlight-2);
       height: var(--space-8);

--- a/apps/website/src/pages/_global.astro
+++ b/apps/website/src/pages/_global.astro
@@ -65,8 +65,25 @@ const { content = {} } = Astro.props;
         line-height: 1.2;
       }
 
+      :where(h1) {
+        font-size: var(--type-4);
+      }
+
+      :where(h2) {
+        font-size: var(--type-3);
+      }
+
+      :where(h3) {
+        font-size: var(--type-2);
+      }
+
       :where(code, pre) {
         font-family: var(--font-mono);
+      }
+
+      :where(ul:not(.content-wrapper *)) {
+        list-style: none;
+        padding: 0;
       }
 
       @media (pointer: fine) and (hover: hover) {

--- a/apps/website/src/pages/docs/_layout.astro
+++ b/apps/website/src/pages/docs/_layout.astro
@@ -206,26 +206,11 @@ const currentPage = new URL(Astro.request.url).pathname;
         }
 
         &:global(:not(:first-child)) {
-          margin-top: 1rem;
+          margin-block-start: 1.1em;
         }
       }
 
-      :global(
-          :where(
-              :not(
-                  a,
-                  h1,
-                  h2,
-                  h3,
-                  h4,
-                  .demo-iui-wrapper,
-                  .demo-iui-wrapper *,
-                  table,
-                  table *,
-                  [data-iui-theme] *
-                )
-            )
-        ) {
+      :global(:where(p, ul, ol):where(:not(.demo-iui-wrapper *))) {
         color: var(--color-subtext);
         font-size: var(--type-1);
       }


### PR DESCRIPTION
## Changes

- Increased the spacing between sections by using a slightly larger value and by using `em` instead of `rem`.
- Fixed the colors so that heading text looks brighter than paragraph text.
- Updated the heading font size to use the fluid typography scale that we already have in place.

All of these changes help address https://github.com/iTwin/iTwinUI/issues/941#issuecomment-1500391356

## Testing

Tested locally.

## Docs

N/A