### PR TITLE
fix css import missing in LabeledSelect

### DIFF
--- a/.changeset/lovely-pianos-fry.md
+++ b/.changeset/lovely-pianos-fry.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue with missing css in LabeledSelect.

--- a/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
+++ b/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
@@ -5,10 +5,10 @@
 import React from 'react';
 
 import { Select } from '../Select';
-import { SelectProps } from '../Select/Select';
+import type { SelectProps } from '../Select/Select';
 import { StatusIconMap, useTheme, InputContainer } from '../utils';
-import { LabeledInputProps } from '../LabeledInput';
-import '@itwin/itwinui-css/css/select.css';
+import type { LabeledInputProps } from '../LabeledInput';
+import '@itwin/itwinui-css/css/input.css';
 
 export type LabeledSelectProps<T> = {
   /**

--- a/packages/itwinui-react/src/core/utils/components/InputContainer.tsx
+++ b/packages/itwinui-react/src/core/utils/components/InputContainer.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import cx from 'classnames';
+import '@itwin/itwinui-css/css/utils.css';
 
 export type InputContainerProps<T extends React.ElementType = 'div'> = {
   as?: T;


### PR DESCRIPTION
## Changes

`input.css` was missing so i changed to it from `select.css` (which is already imported through `Select.tsx`). Fixes #1194

## Testing

Hard to test because can't repro. But the user was able to work around it with a manual import so the this fix _should_ work.

## Docs

N/A