### PR TITLE
fix(Dialog): Making it visible

### DIFF
--- a/.changeset/lovely-dingos-attack.md
+++ b/.changeset/lovely-dingos-attack.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Reverted animation class change that broke Dialog.

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
@@ -168,6 +168,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
           {
             'iui-dialog-default': styleType === 'default',
             'iui-dialog-full-page': styleType === 'fullPage',
+            'iui-dialog-visible': isOpen,
             'iui-dialog-draggable': isDraggable,
           },
           className,
@@ -207,7 +208,6 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
         classNames={{
           enter: 'iui-dialog-animation-enter',
           enterActive: 'iui-dialog-animation-enter-active',
-          enterDone: 'iui-dialog-visible',
         }}
         timeout={{ exit: 600 }}
         // Focuses dialog when opened


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Added back old visibility class handling because new one broke stuff.

## Testing

Tested in vite app, docs website and storybook.

## Docs

N/A just undoing bug we introduced.
