### PR TITLE
fix sb cli conflicting with `storybook` workspace

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -28,14 +28,14 @@
     "react-dom": "^18.0.0",
     "react-table": "^7.1.0",
     "serve": "^14.0.1",
-    "storybook": "~7.0.2",
+    "sb": "~7.0.2",
     "storybook-dark-mode": "^3.0.0",
     "typescript": "^4.6.3",
     "vite": "^4.1.1"
   },
   "scripts": {
-    "build": "dotenv -v NODE_OPTIONS=\"--max-old-space-size=4096\" storybook build",
-    "dev": "storybook dev -p 6006 --no-open --quiet",
+    "build": "dotenv -v NODE_OPTIONS=\"--max-old-space-size=4096\" sb build",
+    "dev": "sb dev -p 6006 --no-open --quiet",
     "lint": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "test": "node scripts/run-tests.js",
     "approve": "cypress-image-diff -u",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16417,6 +16417,13 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
+sb@~7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/sb/-/sb-7.0.2.tgz#d80f76cadbabe5c87279cf24ebeb499974b048df"
+  integrity sha512-cbAKBg62x8IrzyF/yFYSKrNXKbTwSCPN8RKBcKiv+dxFwKBHqa2NBsgFyMNKOY1/pwddvvTBshemv67VAJLWUg==
+  dependencies:
+    "@storybook/cli" "7.0.2"
+
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -17017,13 +17024,6 @@ storybook-dark-mode@^3.0.0:
     "@storybook/theming" "^7.0.0"
     fast-deep-equal "^3.1.3"
     memoizerific "^1.11.3"
-
-storybook@~7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.0.2.tgz#b12f4214cb0b0307d944d5d820b8855f89396159"
-  integrity sha512-/XBLhT9Vb14yNBcA9rlW15y+C6IsCA3kx5PKvK9kL10sKCi8invcY94UfCSisXe8HqsO3u6peumo2xpYucKMjw==
-  dependencies:
-    "@storybook/cli" "7.0.2"
 
 stream-shift@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Changes

In #1188, a new `storybook` dependency was added, and `changesets` was getting confused by it (https://github.com/iTwin/iTwinUI/pull/1196#discussion_r1161773600). So I've replaced this dependency with `sb`.

Both of these packages are aliases to `@storybook/cli` and work identically.

## Testing

Tested running storybook.

## Docs

N/A