### PR TITLE
fix combobox disabled items behavior

### DIFF
--- a/.changeset/lovely-dodos-sit.md
+++ b/.changeset/lovely-dodos-sit.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in ComboBox where disabled items didn't have a proper focus outline and were still selectable with keyboard.

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -57,20 +57,6 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
     background-color: var(--iui-color-background-hover);
   }
 
-  &:where(:focus-visible, .iui-focused, [data-iui-focused='true'], :has(.iui-link-action:focus-visible)) {
-    outline: $iui-active-outline;
-    outline-offset: -1px;
-    z-index: 2;
-  }
-
-  @supports not selector(:has(+ *)) {
-    &:where(:focus-within) {
-      outline: $iui-active-outline;
-      outline-offset: -1px;
-      z-index: 2;
-    }
-  }
-
   &:where(.iui-large, [data-iui-size='large']) {
     min-block-size: var(--iui-component-height-large);
   }
@@ -95,18 +81,6 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
     z-index: 1;
     --_iui-list-item-icon-fill: currentColor;
     --_iui-list-item-description-color: var(--iui-color-text-accent);
-
-    &:where(:focus-visible, .iui-focused, [data-iui-focused='true'], :has(.iui-link-action:focus-visible)) {
-      outline-width: var(--iui-size-3xs);
-      outline-offset: -2px;
-    }
-
-    @supports not selector(:has(+ *)) {
-      &:where(:focus-within) {
-        outline-width: var(--iui-size-3xs);
-        outline-offset: -2px;
-      }
-    }
   }
 
   &:where(.iui-disabled, [data-iui-disabled='true']) {
@@ -117,6 +91,30 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
     color: var(--iui-color-text-disabled);
     --_iui-list-item-icon-fill: var(--iui-color-icon-disabled);
     --_iui-list-item-description-color: var(--iui-color-text-disabled);
+  }
+
+  &:where(:focus-visible, .iui-focused, [data-iui-focused='true'], :has(.iui-link-action:focus-visible)) {
+    outline: $iui-active-outline;
+    outline-offset: -1px;
+    z-index: 2;
+
+    &:where(.iui-active, [data-iui-active='true']) {
+      outline-width: var(--iui-size-3xs);
+      outline-offset: -2px;
+    }
+  }
+
+  @supports not selector(:has(+ *)) {
+    &:where(:focus-within) {
+      outline: $iui-active-outline;
+      outline-offset: -1px;
+      z-index: 2;
+
+      &:where(.iui-active, [data-iui-active='true']) {
+        outline-width: var(--iui-size-3xs);
+        outline-offset: -2px;
+      }
+    }
   }
 }
 

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -926,7 +926,7 @@ it('should not crash when provided value in not in options when multiple enabled
   expect(input).toHaveValue('');
 });
 
-it.only('should not select disabled items', async () => {
+it('should not select disabled items', async () => {
   const id = 'test-component';
   const onChange = jest.fn();
   const { container } = renderComponent({

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -926,7 +926,7 @@ it('should not crash when provided value in not in options when multiple enabled
   expect(input).toHaveValue('');
 });
 
-it('should not select disabled items', async () => {
+it.only('should not select disabled items', async () => {
   const id = 'test-component';
   const onChange = jest.fn();
   const { container } = renderComponent({
@@ -946,9 +946,9 @@ it('should not select disabled items', async () => {
   expect(onChange).not.toHaveBeenCalled();
   expect(document.querySelector('.iui-menu')).toBeVisible();
   expect(input).toHaveValue('');
+  expect(input).toHaveFocus();
 
   // focus first disabled item, then press Enter
-  await userEvent.tab();
   const disabled1Id = `${id}-option-A-disabled-item`;
   await userEvent.keyboard('{ArrowDown}');
   await userEvent.keyboard('{ArrowDown}');
@@ -967,7 +967,6 @@ it('should not select disabled items', async () => {
   expect(input).toHaveValue('An');
 
   // and with keyboard
-  await userEvent.tab();
   const disabled2Id = `${id}-option-Another-disabled-item`;
   await userEvent.keyboard('{ArrowDown}');
   await userEvent.keyboard('{ArrowDown}');

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -494,7 +494,7 @@ it('should work with custom itemRenderer', async () => {
   expect(document.querySelector('.iui-menu')).not.toBeVisible();
   expect(input).toHaveValue('Item 1'); // the actual value of input doesn't change
 
-  await userEvent.tab({ shift: true }); // reopen menu
+  await userEvent.keyboard('{Enter}'); // reopen menu
 
   expect(
     document.querySelector(

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -398,6 +398,10 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
 
   const onClickHandler = React.useCallback(
     (__originalIndex: number) => {
+      if (optionsRef.current[__originalIndex]?.disabled) {
+        return;
+      }
+
       if (isMultipleEnabled(selected, multiple)) {
         const actionType = isMenuItemSelected(__originalIndex)
           ? 'removed'
@@ -417,6 +421,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
       multiple,
       onChangeHandler,
       selected,
+      optionsRef,
     ],
   );
 

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -398,6 +398,8 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
 
   const onClickHandler = React.useCallback(
     (__originalIndex: number) => {
+      inputRef.current?.focus({ preventScroll: true }); // return focus to input
+
       if (optionsRef.current[__originalIndex]?.disabled) {
         return;
       }

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -19,6 +19,7 @@ export const ComboBoxInput = React.forwardRef(
     const {
       onKeyDown: onKeyDownProp,
       onFocus: onFocusProp,
+      onClick: onClickProp,
       selectTags,
       ...rest
     } = props;
@@ -94,7 +95,9 @@ export const ComboBoxInput = React.forwardRef(
                 menuRef.current?.querySelector('[data-iui-index]');
               nextIndex = Number(nextElement?.getAttribute('data-iui-index'));
 
-              return dispatch({ type: 'focus', value: nextIndex });
+              if (nextElement) {
+                return dispatch({ type: 'focus', value: nextIndex });
+              }
             } while (nextIndex !== focusedIndexRef.current);
             break;
           }
@@ -137,7 +140,9 @@ export const ComboBoxInput = React.forwardRef(
                 menuRef.current?.querySelector('[data-iui-index]:last-of-type');
               prevIndex = Number(prevElement?.getAttribute('data-iui-index'));
 
-              return dispatch({ type: 'focus', value: prevIndex });
+              if (prevElement) {
+                return dispatch({ type: 'focus', value: prevIndex });
+              }
             } while (prevIndex !== focusedIndexRef.current);
             break;
           }
@@ -181,6 +186,20 @@ export const ComboBoxInput = React.forwardRef(
       [dispatch, onFocusProp],
     );
 
+    const handleClick = React.useCallback(
+      (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+        onClickProp?.(e);
+        if (e.isDefaultPrevented()) {
+          return;
+        }
+
+        if (!isOpen) {
+          dispatch({ type: 'open' });
+        }
+      },
+      [dispatch, isOpen, onClickProp],
+    );
+
     const [tagContainerWidthRef, tagContainerWidth] = useContainerWidth();
 
     return (
@@ -188,6 +207,7 @@ export const ComboBoxInput = React.forwardRef(
         <Input
           ref={refs}
           onKeyDown={handleKeyDown}
+          onClick={handleClick}
           onFocus={handleFocus}
           aria-activedescendant={
             isOpen && focusedIndex != undefined && focusedIndex > -1

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -148,16 +148,8 @@ export const ComboBoxInput = React.forwardRef(
           case 'Enter': {
             event.preventDefault();
             if (isOpen) {
-              if (multiple) {
-                // Keep menu open when multiselect is enabled and user selects an item
-                if (focusedIndexRef.current > -1) {
-                  onClickHandler?.(focusedIndexRef.current);
-                } else {
-                  dispatch({ type: 'close' });
-                }
-              } else {
+              if (focusedIndexRef.current > -1) {
                 onClickHandler?.(focusedIndexRef.current);
-                dispatch({ type: 'close' });
               }
             } else {
               dispatch({ type: 'open' });
@@ -179,7 +171,6 @@ export const ComboBoxInput = React.forwardRef(
         enableVirtualization,
         isOpen,
         menuRef,
-        multiple,
         onClickHandler,
         onKeyDownProp,
         optionsExtraInfoRef,

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -94,9 +94,7 @@ export const ComboBoxInput = React.forwardRef(
                 menuRef.current?.querySelector('[data-iui-index]');
               nextIndex = Number(nextElement?.getAttribute('data-iui-index'));
 
-              if (nextElement?.ariaDisabled !== 'true') {
-                return dispatch({ type: 'focus', value: nextIndex });
-              }
+              return dispatch({ type: 'focus', value: nextIndex });
             } while (nextIndex !== focusedIndexRef.current);
             break;
           }
@@ -139,9 +137,7 @@ export const ComboBoxInput = React.forwardRef(
                 menuRef.current?.querySelector('[data-iui-index]:last-of-type');
               prevIndex = Number(prevElement?.getAttribute('data-iui-index'));
 
-              if (prevElement?.ariaDisabled !== 'true') {
-                return dispatch({ type: 'focus', value: prevIndex });
-              }
+              return dispatch({ type: 'focus', value: prevIndex });
             } while (prevIndex !== focusedIndexRef.current);
             break;
           }

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
@@ -55,7 +55,7 @@ export const ComboBoxMenuItem = React.memo(
           ref={refs}
           onClick={() => !disabled && onClick?.(value)}
           role={role}
-          tabIndex={disabled || role === 'presentation' ? undefined : -1}
+          tabIndex={role === 'presentation' ? undefined : -1}
           aria-selected={isSelected}
           aria-disabled={disabled}
           data-iui-index={index}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
@@ -53,7 +53,7 @@ export const ComboBoxMenuItem = React.memo(
             className,
           )}
           ref={refs}
-          onClick={() => !disabled && onClick?.(value)}
+          onClick={() => onClick?.(value)}
           role={role}
           tabIndex={role === 'presentation' ? undefined : -1}
           aria-selected={isSelected}


### PR DESCRIPTION
## Changes

- Adjusted css so that disabled items have proper focus outline
- Adjusted react code so that onClickHandler will early return if the item is disabled

Both of these changes ensure that disabled items can be predictably focused but not selected. Fixes #1201 

## Testing

Tested in storybook and also in playground, both with previous version (which doesn't have ListItem changes) and with new code.

https://user-images.githubusercontent.com/9084735/231842528-de7bf044-0c21-407f-a672-16e6b05b6692.mov


## Docs

N/A