### PR TITLE
remove default tooltip role from popover

### DIFF
--- a/.changeset/cuddly-moons-invite.md
+++ b/.changeset/cuddly-moons-invite.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Removed incorrect `role=tooltip` from Popover, DropdownMenu, Select and ComboBox.

--- a/packages/itwinui-react/src/core/utils/components/Popover.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Popover.tsx
@@ -67,7 +67,7 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     arrow: false,
     duration: 0,
     interactive: true,
-    role: undefined,
+    role: '',
     offset: [0, 0],
     maxWidth: '',
     zIndex: 99999,


### PR DESCRIPTION
## Changes

Noticed that popovers were incorrectly getting `role='tooltip'` which is what Tippy.js defaults to, so removed it. Role must be manually specified for each case.

## Testing

Tested by inspecting the DOM.

## Docs

N/A