### PR TITLE
enable provenance for npm publish

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -5,12 +5,17 @@ on:
     branches:
       - main
 
+env:
+  NPM_CONFIG_PROVENANCE: true
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
     name: Release
     if: github.repository == 'iTwin/iTwinUI'
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Changes

This change will (hopefully) add provenance info to our npmjs.com page, linking back to our github repo/commits. Basically like a "verified" badge to prove that our github repo is actually where the package was published from.

See https://github.blog/2023-04-19-introducing-npm-package-provenance/

## Testing

TBD. Will need to wait for next release to see if it actually works.

## Docs

N/A