### PR TITLE
use implicit id association in LabeledInput & LabeledTextarea

### DIFF
--- a/.changeset/witty-ties-dream.md
+++ b/.changeset/witty-ties-dream.md
@@ -1,0 +1,8 @@
+---
+'@itwin/itwinui-react': minor
+'@itwin/itwinui-css': patch
+---
+
+Changed the internal DOM structure of `LabeledInput` and `LabeledTextarea` to prefer explicit association over implicit. The `<label>` is now associated with the input using `htmlFor`/`id` and the container is a generic div.
+
+This change improves accessibility, with no API changes and no effect on visuals.

--- a/packages/itwinui-css/src/utils/input-container/input-container.scss
+++ b/packages/itwinui-css/src/utils/input-container/input-container.scss
@@ -128,6 +128,7 @@
   @include iui-input-label-styling;
   grid-area: label;
   align-self: center;
+  cursor: pointer;
 }
 
 /// Independent label outside the grid.

--- a/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
+++ b/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
 import { Input, InputProps } from '../Input/Input';
-import { StatusIconMap, useTheme, InputContainer } from '../utils';
+import { StatusIconMap, useTheme, InputContainer, useId } from '../utils';
 import '@itwin/itwinui-css/css/input.css';
 
 export type LabeledInputProps = {
@@ -61,6 +61,8 @@ export type LabeledInputProps = {
  */
 export const LabeledInput = React.forwardRef(
   (props: LabeledInputProps, ref: React.RefObject<HTMLInputElement>) => {
+    const uid = useId();
+
     const {
       className,
       disabled = false,
@@ -74,6 +76,7 @@ export const LabeledInput = React.forwardRef(
       displayStyle = 'default',
       iconDisplayStyle = displayStyle === 'default' ? 'block' : 'inline',
       required = false,
+      id = uid,
       ...rest
     } = props;
 
@@ -83,7 +86,6 @@ export const LabeledInput = React.forwardRef(
 
     return (
       <InputContainer
-        as='label'
         label={label}
         disabled={disabled}
         required={required}
@@ -94,6 +96,7 @@ export const LabeledInput = React.forwardRef(
         isIconInline={iconDisplayStyle === 'inline'}
         className={className}
         style={style}
+        inputId={id}
       >
         <Input
           disabled={disabled}
@@ -101,6 +104,7 @@ export const LabeledInput = React.forwardRef(
           style={inputStyle}
           required={required}
           ref={ref}
+          id={id}
           {...rest}
         />
       </InputContainer>

--- a/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
+++ b/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import React from 'react';
-import { StatusIconMap, useTheme, InputContainer } from '../utils';
+import { StatusIconMap, useTheme, InputContainer, useId } from '../utils';
 import { Textarea } from '../Textarea';
 import { TextareaProps } from '../Textarea/Textarea';
 import { LabeledInputProps } from '../LabeledInput';
@@ -56,6 +56,8 @@ export type LabeledTextareaProps = {
  */
 export const LabeledTextarea = React.forwardRef(
   (props: LabeledTextareaProps, ref: React.RefObject<HTMLTextAreaElement>) => {
+    const uid = useId();
+
     const {
       className,
       style,
@@ -69,6 +71,7 @@ export const LabeledTextarea = React.forwardRef(
       iconDisplayStyle = displayStyle === 'default' ? 'block' : 'inline',
       svgIcon,
       required = false,
+      id = uid,
       ...textareaProps
     } = props;
 
@@ -78,7 +81,6 @@ export const LabeledTextarea = React.forwardRef(
 
     return (
       <InputContainer
-        as='label'
         label={label}
         disabled={disabled}
         required={required}
@@ -89,12 +91,14 @@ export const LabeledTextarea = React.forwardRef(
         isIconInline={iconDisplayStyle === 'inline'}
         className={className}
         style={style}
+        inputId={id}
       >
         <Textarea
           disabled={disabled}
           className={textareaClassName}
           style={textareaStyle}
           required={required}
+          id={id}
           {...textareaProps}
           ref={ref}
         />

--- a/packages/itwinui-react/src/core/utils/components/InputContainer.tsx
+++ b/packages/itwinui-react/src/core/utils/components/InputContainer.tsx
@@ -17,6 +17,7 @@ export type InputContainerProps<T extends React.ElementType = 'div'> = {
   isLabelInline?: boolean;
   isIconInline?: boolean;
   statusMessage?: React.ReactNode;
+  inputId?: string;
 } & React.ComponentPropsWithoutRef<T>;
 
 /**
@@ -40,8 +41,11 @@ export const InputContainer = <T extends React.ElementType = 'div'>(
     className,
     style,
     statusMessage,
+    inputId,
     ...rest
   } = props;
+
+  const LabelElement = inputId && Element !== 'label' ? 'label' : 'div';
 
   return (
     <Element
@@ -61,13 +65,14 @@ export const InputContainer = <T extends React.ElementType = 'div'>(
       {...rest}
     >
       {label && (
-        <div
+        <LabelElement
           className={cx('iui-label', {
             'iui-required': required,
           })}
+          htmlFor={inputId}
         >
           {label}
-        </div>
+        </LabelElement>
       )}
       {children}
       {statusMessage ? (

--- a/packages/itwinui-react/src/core/utils/hooks/useId.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useId.ts
@@ -11,7 +11,8 @@ import { getRandomValue } from '../functions/numbers';
  * a random value as fallback for older React versions which don't include `useId`.
  */
 export const useId = () => {
-  return React.useMemo(() => `iui-${uniqueValue()}`, []);
+  const uniqueValue = useUniqueValue();
+  return React.useMemo(() => `iui-${uniqueValue}`, [uniqueValue]);
 };
 
-const uniqueValue = React.useId ?? (() => getRandomValue(10));
+const useUniqueValue = React.useId ?? (() => getRandomValue(10));

--- a/packages/itwinui-react/src/core/utils/hooks/useId.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useId.ts
@@ -7,11 +7,11 @@ import React from 'react';
 import { getRandomValue } from '../functions/numbers';
 
 /**
- * Return custom useId function as a fallback for React.useId
+ * Wrapper around React's `useId` hook, which prefixes the id with `iui-` and uses
+ * a random value as fallback for older React versions which don't include `useId`.
  */
-export const useId =
-  React.useId ??
-  (() => {
-    const [id] = React.useState(() => `iui-${getRandomValue(10)}`);
-    return id;
-  });
+export const useId = () => {
+  return React.useMemo(() => `iui-${uniqueValue()}`, []);
+};
+
+const uniqueValue = React.useId ?? (() => getRandomValue(10));


### PR DESCRIPTION
## Changes

Changed the internal DOM structure of `LabeledInput` and `LabeledTextarea` to prefer explicit association over implicit. The `<label>` is now associated with the input using `htmlFor`/`id` and the container is a generic div. To achieve this, I had to add some checks inside `InputContainer` and a prop to pass the id. I also left out `LabeledSelect` because there is no "input" in there to associate the label with; this can be addressed in a separate PR.

This change improves accessibility, with no API changes and no effect on visuals.

In the next major version, we can further improve `InputContainer` to reuse `Label` and `StatusMessage` components, and remove any duplicate CSS rules.

## Testing

Tested by going through all stories and clicking on them and inspecting the dom.

## Docs

N/A