### PR TITLE
increase checkbox touch target size

### DIFF
--- a/.changeset/sour-garlics-lay.md
+++ b/.changeset/sour-garlics-lay.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Adjusted Checkbox so that its clickable target area is 24pxx24px by default (increased from 16x16) and 32x32 when used in a Table selection column.

--- a/packages/itwinui-css/src/checkbox/checkbox.scss
+++ b/packages/itwinui-css/src/checkbox/checkbox.scss
@@ -76,6 +76,13 @@
   outline: solid 1px var(--_iui-checkbox-border-color);
   outline-offset: -1px;
 
+  // increase tap target size to 24x24 by default and allow adjusting through CSS var
+  &::before {
+    content: '';
+    position: absolute;
+    inset: calc((var(--iui-checkbox-target-size, 24px) - 16px) / -2);
+  }
+
   &::after {
     content: '';
     position: absolute;

--- a/packages/itwinui-css/src/table/table.scss
+++ b/packages/itwinui-css/src/table/table.scss
@@ -384,6 +384,9 @@
     justify-content: center;
     align-items: center;
     flex-basis: calc(var(--iui-size-l) * 2);
+
+    // make the checkbox bigger (32x32) to prevent accidentally clicking on the row
+    --iui-checkbox-target-size: 32px;
   }
 
   &.iui-table-cell-sticky {


### PR DESCRIPTION
## Changes

Used `::before` element with negative inset to increase checkbox to 24x24 by default. Can be adjusted using the CSS variable `--iui-checkbox-target-size`.

In table, I'm using this variable to make it 32x32. This will prevent accidentally clicking on the row instead of the checkbox.

No visual changes.

## Testing

Tested in demo pages / storybook.

![](https://user-images.githubusercontent.com/9084735/236009350-fab3737e-89e4-42fc-96ab-2569bae67b8e.png)
![](https://user-images.githubusercontent.com/9084735/236009554-045685b9-944b-4024-9db4-19fd3225d7e9.png)
![](https://user-images.githubusercontent.com/9084735/236009712-01665ee2-144f-4596-bcbc-70e9ebebca7b.png)

See branch preview: https://itwin.github.io/iTwinUI/1245/react/?path=/story/core-table--selectable-multi

## Docs

N/A