### PR TITLE
revert v1 styles for psuedo elements too

### DIFF
--- a/.changeset/wet-eyes-drop.md
+++ b/.changeset/wet-eyes-drop.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where pseudo elements inside a v2 boundary were not reverting v1 styles.

--- a/packages/itwinui-css/src/global.scss
+++ b/packages/itwinui-css/src/global.scss
@@ -5,7 +5,11 @@
 // reset anything that may have been set by v1
 :where(.iui-body, [class*='iui-theme-']) :where(.iui-root, [data-iui-theme]) {
   :where([class*='iui-']:not(.iui-root)) {
-    all: revert;
+    &,
+    &::before,
+    &::after {
+      all: revert;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

After #1245, a user reported some unexpected visible borders around checkboxes.

![](https://user-images.githubusercontent.com/9084735/236882948-29b5f32d-238a-4dcd-a87f-0f26eb27103c.png)

The border comes from v1 styles which were not being correctly targeted in the place where we globally revert all v1 styles, so I explicitly added selectors for `::before`/`::after` in that rule.

## Testing

Tested with this code:
```jsx
import { Global } from '@emotion/react';
import { Checkbox, ThemeProvider } from '@itwin/itwinui-react';

export default () => {
  return (
    <div className='iui-body'>
      <Global
        styles={`
          @layer test {
            .iui-checkbox::before {
              border: 1px solid hotpink;
            }
          }
        `}
      />
      <ThemeProvider theme='dark'>
        <Checkbox label='Hello' />
      </ThemeProvider>
    </div>
  );
};
```

Without this change:
![pink outline](https://user-images.githubusercontent.com/9084735/236883364-1d3bb02a-1a95-42a2-87cd-57da622fc9c9.png)


With this change:
![no visible outline](https://user-images.githubusercontent.com/9084735/236883319-6d2aa88d-a4b7-4d4d-9ae2-dd2fa2f33acc.png)


## Docs

N/A