### PR TITLE
fix watchScss script

### DIFF
--- a/packages/itwinui-css/scripts/watchScss.mjs
+++ b/packages/itwinui-css/scripts/watchScss.mjs
@@ -23,11 +23,11 @@ const components = (await fs.promises.readdir(srcDir, { withFileTypes: true }))
 const inputsAndOutputsList = [
   ['src/all.scss', 'css/all.css'],
   ['src/global.scss', 'css/global.css'],
-  ...components.map((name) => [`src/${name}/classes.scss`, `css/${name}.css`]),
+  ...components.map((name) => [`src/${name}/${name}.scss`, `css/${name}.css`]),
 ];
 
 // sass cli expects this format (https://sass-lang.com/documentation/cli/dart-sass)
-// src/all.scss:css/all.css src/alert/classes.scss:css/alert.css
+// src/all.scss:css/all.css src/alert/alert.scss:css/alert.css
 const spaceSeparatedInputsAndOutputs = inputsAndOutputsList.map(([scss, css]) => `${scss}:${css}`).join(' ');
 
 spawn(`yarn sass --watch ${spaceSeparatedInputsAndOutputs}`, {


### PR DESCRIPTION
leftover from #1251. The files are now `{component}.scss`, not `classes.scss`.

tested working correctly by starting dev server and modifying scss files.