### PR TITLE
Keyboard: Add color

### DIFF
--- a/.changeset/plenty-cats-report.md
+++ b/.changeset/plenty-cats-report.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Added `color` declaration to `iui-keyboard`.

--- a/packages/itwinui-css/src/keyboard/keyboard.scss
+++ b/packages/itwinui-css/src/keyboard/keyboard.scss
@@ -19,6 +19,7 @@
   border: 1px solid var(--iui-color-border);
   box-shadow: 0 1px 1px var(--iui-color-border), 0 1px 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;
   transition: box-shadow var(--iui-duration-1) ease-out;
+  color: var(--iui-color-text);
 
   &:hover {
     box-shadow: 0 0 0 var(--iui-color-border), 0 0 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Added color declaration to Keyboard key because it does not get default one when rendered in a Tooltip.

## Testing

N/A

## Docs

N/A
