### PR TITLE
SearchBox documentation

### DIFF
--- a/apps/website/src/examples/SearchBox.basic.tsx
+++ b/apps/website/src/examples/SearchBox.basic.tsx
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import { SearchBox, Flex } from '@itwin/itwinui-react';
+
+export default () => {
+  return (
+    <Flex style={{ width: '70%' }}>
+      <SearchBox
+        aria-label='Search input'
+        inputProps={{
+          placeholder: 'Search...',
+        }}
+      />
+    </Flex>
+  );
+};

--- a/apps/website/src/examples/Searchbox.custom.tsx
+++ b/apps/website/src/examples/Searchbox.custom.tsx
@@ -4,13 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { SearchBox, Divider, Flex } from '@itwin/itwinui-react';
-import { SvgCaretUpSmall, SvgCaretDownSmall, SvgCloseSmall } from '@itwin/itwinui-icons-react';
+import { SvgCaretUpSmall, SvgCaretDownSmall, SvgAirplane } from '@itwin/itwinui-icons-react';
 
 export default () => {
   return (
     <Flex style={{ width: '70%' }} justifyContent='center' flexDirection='column'>
       <SearchBox expandable>
-        <SearchBox.CollapsedState />
+        <SearchBox.CollapsedState>
+          <SearchBox.ExpandButton>
+            <SvgAirplane />
+          </SearchBox.ExpandButton>
+        </SearchBox.CollapsedState>
         <SearchBox.ExpandedState>
           <SearchBox.Input placeholder='Expandable search with custom interactions' />
           <SearchBox.Button label='Previous result'>

--- a/apps/website/src/examples/Searchbox.custom.tsx
+++ b/apps/website/src/examples/Searchbox.custom.tsx
@@ -3,43 +3,25 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { SearchBox, Text, Divider, Flex } from '@itwin/itwinui-react';
+import { SearchBox, Divider, Flex } from '@itwin/itwinui-react';
 import { SvgCaretUpSmall, SvgCaretDownSmall, SvgCloseSmall } from '@itwin/itwinui-icons-react';
 
 export default () => {
   return (
     <Flex style={{ width: '70%' }} justifyContent='center' flexDirection='column'>
       <SearchBox expandable>
-        <SearchBox.Input placeholder='Expandable search with custom interactions' />
-        <SearchBox.Button label='Previous result'>
-          <SvgCaretUpSmall />
-        </SearchBox.Button>
-        <SearchBox.Button label='Next result'>
-          <SvgCaretDownSmall />
-        </SearchBox.Button>
-        <Divider orientation='vertical' />
-        <SearchBox.CollapseButton label='Close search' />
-      </SearchBox>
-      <SearchBox>
-        <SearchBox.Input placeholder='Basic search with custom interactions' />
-        <Text
-          isMuted
-          variant='body'
-          as='p'
-          style={{ paddingRight: 'var(--iui-size-s)', alignSelf: 'center' }}
-        >
-          0/3
-        </Text>
-        <Divider orientation='vertical' />
-        <SearchBox.Button label='Previous result'>
-          <SvgCaretUpSmall />
-        </SearchBox.Button>
-        <SearchBox.Button label='Next result'>
-          <SvgCaretDownSmall />
-        </SearchBox.Button>
-        <SearchBox.Button label='Clear search'>
-          <SvgCloseSmall />
-        </SearchBox.Button>
+        <SearchBox.CollapsedState />
+        <SearchBox.ExpandedState>
+          <SearchBox.Input placeholder='Expandable search with custom interactions' />
+          <SearchBox.Button label='Previous result'>
+            <SvgCaretUpSmall />
+          </SearchBox.Button>
+          <SearchBox.Button label='Next result'>
+            <SvgCaretDownSmall />
+          </SearchBox.Button>
+          <Divider orientation='vertical' />
+          <SearchBox.CollapseButton label='Close search' />
+        </SearchBox.ExpandedState>
       </SearchBox>
     </Flex>
   );

--- a/apps/website/src/examples/Searchbox.customopen.tsx
+++ b/apps/website/src/examples/Searchbox.customopen.tsx
@@ -3,29 +3,32 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { SearchBox, Divider, Flex } from '@itwin/itwinui-react';
-import { SvgCaretUpSmall, SvgCaretDownSmall, SvgAirplane } from '@itwin/itwinui-icons-react';
+import { SearchBox, Divider, Flex, Text } from '@itwin/itwinui-react';
+import { SvgCaretUpSmall, SvgCaretDownSmall, SvgCloseSmall } from '@itwin/itwinui-icons-react';
 
 export default () => {
   return (
-    <Flex style={{ width: '70%' }} justifyContent='center' flexDirection='column'>
-      <SearchBox
-        expandable
-        collapsedState={
-          <SearchBox.ExpandButton>
-            <SvgAirplane />
-          </SearchBox.ExpandButton>
-        }
-      >
-        <SearchBox.Input placeholder='Expandable search with custom open icon' />
+    <Flex style={{ width: '70%' }} justifyContent='center'>
+      <SearchBox>
+        <SearchBox.Input placeholder='Basic search with custom interactions' />
+        <Text
+          isMuted
+          variant='body'
+          as='p'
+          style={{ paddingRight: 'var(--iui-size-s)', alignSelf: 'center' }}
+        >
+          0/3
+        </Text>
+        <Divider orientation='vertical' />
         <SearchBox.Button label='Previous result'>
           <SvgCaretUpSmall />
         </SearchBox.Button>
         <SearchBox.Button label='Next result'>
           <SvgCaretDownSmall />
         </SearchBox.Button>
-        <Divider orientation='vertical' />
-        <SearchBox.CollapseButton label='Close search' />
+        <SearchBox.Button label='Clear search'>
+          <SvgCloseSmall />
+        </SearchBox.Button>
       </SearchBox>
     </Flex>
   );

--- a/apps/website/src/examples/Searchbox.expandable.tsx
+++ b/apps/website/src/examples/Searchbox.expandable.tsx
@@ -8,11 +8,7 @@ import { SearchBox, Flex } from '@itwin/itwinui-react';
 export default () => {
   return (
     <Flex style={{ width: '70%' }} justifyContent='center'>
-      <SearchBox
-        expandable
-        aria-label='Search input'
-        inputProps={{ placeholder: 'Expandable search...' }}
-      />
+      <SearchBox expandable inputProps={{ placeholder: 'Expandable search...' }} />
     </Flex>
   );
 };

--- a/apps/website/src/examples/Searchbox.main.tsx
+++ b/apps/website/src/examples/Searchbox.main.tsx
@@ -4,32 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { SearchBox, Flex } from '@itwin/itwinui-react';
-import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 
 export default () => {
-  const [inputValue, setInputValue] = React.useState<string>('');
   return (
     <Flex style={{ width: '70%' }}>
-      <SearchBox aria-label='Search input'>
-        <SearchBox.Icon />
-        <SearchBox.Input
-          placeholder='Try typing...'
-          value={inputValue}
-          onChange={(e) => {
-            setInputValue(e.target.value);
-          }}
-        />
-        {inputValue !== '' ? (
-          <SearchBox.Button
-            label='Clear'
-            onClick={() => {
-              setInputValue('');
-            }}
-          >
-            <SvgCloseSmall />
-          </SearchBox.Button>
-        ) : null}
-      </SearchBox>
+      <SearchBox inputProps={{ placeholder: 'SearchBox component' }} />
     </Flex>
   );
 };

--- a/apps/website/src/examples/Searchbox.main.tsx
+++ b/apps/website/src/examples/Searchbox.main.tsx
@@ -4,11 +4,32 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { SearchBox, Flex } from '@itwin/itwinui-react';
+import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 
 export default () => {
+  const [inputValue, setInputValue] = React.useState<string>('');
   return (
     <Flex style={{ width: '70%' }}>
-      <SearchBox aria-label='Search input' inputProps={{ placeholder: 'Search...' }} />
+      <SearchBox aria-label='Search input'>
+        <SearchBox.Icon />
+        <SearchBox.Input
+          placeholder='Try typing...'
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+          }}
+        />
+        {inputValue !== '' ? (
+          <SearchBox.Button
+            label='Clear'
+            onClick={() => {
+              setInputValue('');
+            }}
+          >
+            <SvgCloseSmall />
+          </SearchBox.Button>
+        ) : null}
+      </SearchBox>
     </Flex>
   );
 };

--- a/apps/website/src/examples/Searchbox.size.tsx
+++ b/apps/website/src/examples/Searchbox.size.tsx
@@ -9,6 +9,7 @@ export default () => {
   return (
     <Flex style={{ width: '70%' }} flexDirection='column'>
       <SearchBox size='small' inputProps={{ placeholder: 'Small search...' }} />
+      <SearchBox inputProps={{ placeholder: 'Default search...' }} />
       <SearchBox size='large' inputProps={{ placeholder: 'Large search...' }} />
     </Flex>
   );

--- a/apps/website/src/examples/index.tsx
+++ b/apps/website/src/examples/index.tsx
@@ -156,12 +156,12 @@ export { default as RadioStatusesExample } from './Radio.statuses';
 export { default as RadioTileMainExample } from './RadioTile.main';
 export { default as RadioTileColorExample } from './RadioTile.color';
 
-export { default as SearchboxMainExample } from './Searchbox.main';
-export { default as SearchboxSizeExample } from './Searchbox.size';
-export { default as SearchboxExpandableExample } from './Searchbox.expandable';
-export { default as SearchboxStatusExample } from './Searchbox.status';
-export { default as SearchboxCustomExample } from './Searchbox.custom';
-export { default as SearchboxCustomOpenExample } from './Searchbox.customopen';
+export { default as SearchBoxMainExample } from './SearchBox.main';
+export { default as SearchBoxSizeExample } from './SearchBox.size';
+export { default as SearchBoxExpandableExample } from './SearchBox.expandable';
+export { default as SearchBoxStatusExample } from './SearchBox.status';
+export { default as SearchBoxCustomExample } from './SearchBox.custom';
+export { default as SearchBoxCustomOpenExample } from './SearchBox.customopen';
 
 export { default as SelectMainExample } from './Select.main';
 

--- a/apps/website/src/examples/index.tsx
+++ b/apps/website/src/examples/index.tsx
@@ -157,6 +157,7 @@ export { default as RadioTileMainExample } from './RadioTile.main';
 export { default as RadioTileColorExample } from './RadioTile.color';
 
 export { default as SearchBoxMainExample } from './SearchBox.main';
+export { default as SearchBoxBasicExample } from './SearchBox.basic';
 export { default as SearchBoxSizeExample } from './SearchBox.size';
 export { default as SearchBoxExpandableExample } from './SearchBox.expandable';
 export { default as SearchBoxStatusExample } from './SearchBox.status';

--- a/apps/website/src/pages/docs/searchbox.mdx
+++ b/apps/website/src/pages/docs/searchbox.mdx
@@ -1,0 +1,29 @@
+---
+title: SearchBox
+description:
+layout: ./_layout.astro
+propsPath: '@itwin/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx'
+thumbnail:
+group: inputs
+---
+
+import PropsTable from '~/components/PropsTable.astro';
+import LiveExample from '~/components/LiveExample.astro';
+import Placeholder from '~/components/Placeholder.astro';
+import * as AllExamples from '~/examples';
+
+<p>{frontmatter.description}</p>
+
+<Placeholder componentPageName='input-select' />
+
+<LiveExample src='Select.main.tsx'>
+  <AllExamples.SelectMainExample client:load />
+</LiveExample>
+
+A select is a control element meant to allow the user to select an option from a list. Depending on type, it is either visible at all times (permanent) or only if the user triggers it by clicking an element or right-clicking (temporary).
+
+There are select menus that are called ‘temporary’; they appear as fully expanded and do not possess a collapsed state. Instead of collapsing and expanding, they are dismissed from the interface by clicking away. They may reappear only when the user triggers them again, either by right-clicking or clicking an item associated with it.
+
+## Props
+
+<PropsTable path={frontmatter.propsPath} />

--- a/apps/website/src/pages/docs/searchbox.mdx
+++ b/apps/website/src/pages/docs/searchbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: SearchBox
-description: The search tool is the primary way for users to quickly access the information they need.
+description: The primary way for users to quickly access the information they need.
 layout: ./_layout.astro
 propsPath: '@itwin/itwinui-react/esm/core/SearchBox/SearchBox.d.ts'
 thumbnail:
@@ -17,17 +17,23 @@ import * as AllExamples from '~/examples';
   <AllExamples.SearchBoxMainExample client:load />
 </LiveExample>
 
+The SearchBox can be used to search for content, filter tree view or table. It can be added to the header for full page search or next to the component you want to use it for.
+
 ## Variants
 
 ### Basic
 
-<LiveExample src='SearchBox.main.tsx'>
-  <AllExamples.SearchBoxMainExample client:load />
+<LiveExample src='SearchBox.basic.tsx'>
+  <AllExamples.SearchBoxBasicExample client:load />
 </LiveExample>
+
+Basic SearchBox includes input field with search icon in front of it. You can access input by using `inputProps` property like we are doing in this example.
 
 <LiveExample src='SearchBox.customopen.tsx'>
   <AllExamples.SearchBoxCustomOpenExample client:load />
 </LiveExample>
+
+You also can fully customize the SearchBox by combining [subcomponents](#subcomponents) and other components.
 
 ### Expandable
 
@@ -35,21 +41,61 @@ import * as AllExamples from '~/examples';
   <AllExamples.SearchBoxExpandableExample client:load />
 </LiveExample>
 
+Expandable SearchBox is an [IconButton](button#icon-button) to save space on the screen. It expands into search input on click. Expandable SearchBox has collapse button at the end of the search input.
+
 <LiveExample src='SearchBox.custom.tsx'>
   <AllExamples.SearchBoxCustomExample client:load />
 </LiveExample>
 
-## Style
+Expandable SearchBox can be customized by using `ExpandedState` and `CollapsedState` [subcomponents](#subcomponents). Don't forget to add `ExpandButton` and `CollapseButton` or use `isExpanded` property to achieve expandable functionality.
+
+### Size
 
 <LiveExample src='SearchBox.size.tsx'>
   <AllExamples.SearchBoxSizeExample client:load />
 </LiveExample>
 
+SearchBox can be changed to have small or large size. By default it's "medium".
+
+### Status
+
 <LiveExample src='SearchBox.status.tsx'>
   <AllExamples.SearchBoxStatusExample client:load />
 </LiveExample>
 
+SearchBox, same as [input](input#status), can have a status.
+
 ## Usage
+
+- Most of the cases, use the non-expandable SearchBox.
+- Expandable SearchBox should only be used in tight spaces where non-expandable SearchBox does not fit.
+
+There are two types of search interactions you can implement:
+
+1. Manual search - user has to click "Search" button for search to be activated
+2. Automatic search - user does not have to finish typing a query for it to be treated. The search brings up results as soon as something is entered in the field. The results should adapt dynamically to what the user types.
+
+There are several options how to present search results:
+
+- Filtering search - search should only bring up results that match the query. Everything that is unrelated should be hidden.
+- Highlighting search - results matching the query will be highlighted and everything on the page remains visible.
+- Unsuccessful search (no results) - if the search brings up no results, an empty/error page with a message explaining to the user what went wrong should be displayed.
+
+## Subcomponents
+
+- SearchBox.Input - Input to be placed within SearchBox
+
+- SearchBox.Button - Button to be placed within SearchBox. Default has looking glass icon.
+
+- SearchBox.Icon - Icon to be placed within SearchBox. Default has looking glass icon.
+
+- SearchBox.ExpandButton - Expand button for expandable SearchBox. Clicking on this will expand SearchBox.
+
+- SearchBox.CollapseButton - Collapse button for expandable SearchBox. Clicking on this button will collapse SearchBox.
+
+- SearchBox.ExpandedState - Subcomponent to customize expanded state of the SearchBox.
+
+- SearchBox.CollapsedState - Subcomponent to customize collapsed state.
 
 ## Props
 

--- a/apps/website/src/pages/docs/searchbox.mdx
+++ b/apps/website/src/pages/docs/searchbox.mdx
@@ -1,6 +1,6 @@
 ---
 title: SearchBox
-description: The primary way for users to quickly access the information they need.
+description: A search input component
 layout: ./_layout.astro
 propsPath: '@itwin/itwinui-react/esm/core/SearchBox/SearchBox.d.ts'
 thumbnail:
@@ -23,47 +23,47 @@ The SearchBox can be used to search for content, filter tree view or table. It c
 
 ### Basic
 
+Basic SearchBox includes input field with search icon in front of it. You can access input by using `inputProps` property like we are doing in this example.
+
 <LiveExample src='SearchBox.basic.tsx'>
   <AllExamples.SearchBoxBasicExample client:load />
 </LiveExample>
 
-Basic SearchBox includes input field with search icon in front of it. You can access input by using `inputProps` property like we are doing in this example.
+You also can fully customize the SearchBox by combining [subcomponents](#subcomponents) and other components.
 
 <LiveExample src='SearchBox.customopen.tsx'>
   <AllExamples.SearchBoxCustomOpenExample client:load />
 </LiveExample>
 
-You also can fully customize the SearchBox by combining [subcomponents](#subcomponents) and other components.
-
 ### Expandable
+
+Expandable SearchBox is an [IconButton](button#icon-button) to save space on the screen. It expands into search input on click. Expandable SearchBox has collapse button at the end of the search input.
 
 <LiveExample src='SearchBox.expandable.tsx'>
   <AllExamples.SearchBoxExpandableExample client:load />
 </LiveExample>
 
-Expandable SearchBox is an [IconButton](button#icon-button) to save space on the screen. It expands into search input on click. Expandable SearchBox has collapse button at the end of the search input.
+Expandable SearchBox can be customized by using `ExpandedState` and `CollapsedState` [subcomponents](#subcomponents). Don't forget to add `ExpandButton` and `CollapseButton` or use `isExpanded` property to achieve expandable functionality.
 
 <LiveExample src='SearchBox.custom.tsx'>
   <AllExamples.SearchBoxCustomExample client:load />
 </LiveExample>
 
-Expandable SearchBox can be customized by using `ExpandedState` and `CollapsedState` [subcomponents](#subcomponents). Don't forget to add `ExpandButton` and `CollapseButton` or use `isExpanded` property to achieve expandable functionality.
-
 ### Size
+
+SearchBox can be changed to have small or large size. By default it's "medium".
 
 <LiveExample src='SearchBox.size.tsx'>
   <AllExamples.SearchBoxSizeExample client:load />
 </LiveExample>
 
-SearchBox can be changed to have small or large size. By default it's "medium".
-
 ### Status
+
+SearchBox, same as [input](input#status), can have a status.
 
 <LiveExample src='SearchBox.status.tsx'>
   <AllExamples.SearchBoxStatusExample client:load />
 </LiveExample>
-
-SearchBox, same as [input](input#status), can have a status.
 
 ## Usage
 

--- a/apps/website/src/pages/docs/searchbox.mdx
+++ b/apps/website/src/pages/docs/searchbox.mdx
@@ -1,28 +1,55 @@
 ---
 title: SearchBox
-description:
+description: The search tool is the primary way for users to quickly access the information they need.
 layout: ./_layout.astro
-propsPath: '@itwin/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx'
+propsPath: '@itwin/itwinui-react/esm/core/SearchBox/SearchBox.d.ts'
 thumbnail:
 group: inputs
 ---
 
 import PropsTable from '~/components/PropsTable.astro';
 import LiveExample from '~/components/LiveExample.astro';
-import Placeholder from '~/components/Placeholder.astro';
 import * as AllExamples from '~/examples';
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='input-select' />
-
-<LiveExample src='Select.main.tsx'>
-  <AllExamples.SelectMainExample client:load />
+<LiveExample src='SearchBox.main.tsx'>
+  <AllExamples.SearchBoxMainExample client:load />
 </LiveExample>
 
-A select is a control element meant to allow the user to select an option from a list. Depending on type, it is either visible at all times (permanent) or only if the user triggers it by clicking an element or right-clicking (temporary).
+## Variants
 
-There are select menus that are called ‘temporary’; they appear as fully expanded and do not possess a collapsed state. Instead of collapsing and expanding, they are dismissed from the interface by clicking away. They may reappear only when the user triggers them again, either by right-clicking or clicking an item associated with it.
+### Basic
+
+<LiveExample src='SearchBox.main.tsx'>
+  <AllExamples.SearchBoxMainExample client:load />
+</LiveExample>
+
+<LiveExample src='SearchBox.customopen.tsx'>
+  <AllExamples.SearchBoxCustomOpenExample client:load />
+</LiveExample>
+
+### Expandable
+
+<LiveExample src='SearchBox.expandable.tsx'>
+  <AllExamples.SearchBoxExpandableExample client:load />
+</LiveExample>
+
+<LiveExample src='SearchBox.custom.tsx'>
+  <AllExamples.SearchBoxCustomExample client:load />
+</LiveExample>
+
+## Style
+
+<LiveExample src='SearchBox.size.tsx'>
+  <AllExamples.SearchBoxSizeExample client:load />
+</LiveExample>
+
+<LiveExample src='SearchBox.status.tsx'>
+  <AllExamples.SearchBoxStatusExample client:load />
+</LiveExample>
+
+## Usage
 
 ## Props
 

--- a/packages/itwinui-react/src/core/SearchBox/SearchBox.tsx
+++ b/packages/itwinui-react/src/core/SearchBox/SearchBox.tsx
@@ -390,11 +390,11 @@ export const SearchBox = Object.assign(SearchBoxComponent, {
    */
   Button: SearchBoxButton,
   /**
-   * Close button for expandable SearchBox. Clicking on this button will collapse SearchBox.
+   * Collapse button for expandable SearchBox. Clicking on this button will collapse SearchBox.
    */
   CollapseButton: SearchBoxCollapseButton,
   /**
-   * Open button for expandable SearchBox. Clicking on this will expand SearchBox.
+   * Expand button for expandable SearchBox. Clicking on this will expand SearchBox.
    */
   ExpandButton: SearchBoxExpandButton,
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Update jsdoc for ExpandButton and CollapseButton. Was still using open and close words.

## Testing

N/A

## Docs

Added examples and text in SearchBox documentation page.