### PR TITLE
add exception for svg when reverting v1 styles

### DIFF
--- a/.changeset/fluffy-dogs-vanish.md
+++ b/.changeset/fluffy-dogs-vanish.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where `ProgressRadial` was not correctly showing when used inside a v2 boundary within a v1 page.

--- a/packages/itwinui-css/src/global.scss
+++ b/packages/itwinui-css/src/global.scss
@@ -4,7 +4,7 @@
 
 // reset anything that may have been set by v1
 :where(.iui-body, [class*='iui-theme-']) :where(.iui-root, [data-iui-theme]) {
-  :where([class*='iui-']:not(.iui-root)) {
+  :where([class*='iui-']:not(.iui-root, svg *)) {
     &,
     &::before,
     &::after {


### PR DESCRIPTION
## Changes

Problem: https://stackblitz.com/edit/vitejs-vite-12mizp?file=src%2FApp.jsx

This was happening because the properties that are set on the internal svg elements (through html attributes) were being reverted.
![](https://github.com/iTwin/iTwinUI/assets/9084735/73d7ba9b-996a-412d-8806-b2ba55be223e)
![](https://github.com/iTwin/iTwinUI/assets/9084735/5d697387-777f-455b-a757-db478641167f)

Solution: Added an exception for `svg *` when reverting.

## Testing

Before:
![no v2 spinner](https://github.com/iTwin/iTwinUI/assets/9084735/1f646fa0-2800-433d-90e8-35def94bd68e)

After:
![v2 spinner!](https://github.com/iTwin/iTwinUI/assets/9084735/f29ad94d-b6f0-4b71-8ab5-a4ca5db6f4df)

## Docs

N/A
