### PR TITLE
fix Popover controlled mode during first render

### DIFF
--- a/.changeset/poor-bees-sneeze.md
+++ b/.changeset/poor-bees-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where using Popover components in controlled mode (through `visible` prop) was appending it to the wrong root element.

--- a/packages/itwinui-react/src/core/utils/components/Popover.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Popover.tsx
@@ -8,7 +8,7 @@ import cx from 'classnames';
 import Tippy from '@tippyjs/react';
 import type { TippyProps } from '@tippyjs/react';
 import type { Placement, Instance } from 'tippy.js';
-import { useMergedRefs } from '../hooks/useMergedRefs.js';
+import { useMergedRefs, useIsClient } from '../hooks/index.js';
 export type PopoverInstance = Instance;
 import '@itwin/itwinui-css/css/utils.css';
 import { ThemeContext } from '../../ThemeProvider/ThemeProvider.js';
@@ -40,7 +40,7 @@ export type PopoverProps = {
 export const Popover = React.forwardRef((props: PopoverProps, ref) => {
   const [mounted, setMounted] = React.useState(false);
   const themeInfo = React.useContext(ThemeContext);
-  const isDomAvailable = useIsDomAvailable();
+  const isDomAvailable = useIsClient();
 
   const tippyRef = React.useRef<Element>(null);
   const refs = useMergedRefs(tippyRef, ref);
@@ -161,9 +161,3 @@ export const hideOnEscOrTab = {
 };
 
 export default Popover;
-
-const useIsDomAvailable = () => {
-  const [isDomAvailable, setIsDomAvailable] = React.useState(false);
-  React.useEffect(() => void setIsDomAvailable(true), []);
-  return isDomAvailable;
-};

--- a/packages/itwinui-react/src/core/utils/components/Popover.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Popover.tsx
@@ -40,6 +40,7 @@ export type PopoverProps = {
 export const Popover = React.forwardRef((props: PopoverProps, ref) => {
   const [mounted, setMounted] = React.useState(false);
   const themeInfo = React.useContext(ThemeContext);
+  const isDomAvailable = useIsDomAvailable();
 
   const tippyRef = React.useRef<Element>(null);
   const refs = useMergedRefs(tippyRef, ref);
@@ -74,6 +75,10 @@ export const Popover = React.forwardRef((props: PopoverProps, ref) => {
     zIndex: 99999,
     ...props,
     className: cx('iui-popover', props.className),
+    // add additional check for isDomAvailable when using in controlled mode,
+    // because rootRef is not available in first render
+    visible:
+      props.visible !== undefined ? props.visible && isDomAvailable : undefined,
     plugins: [
       lazyLoad,
       removeTabIndex,
@@ -156,3 +161,9 @@ export const hideOnEscOrTab = {
 };
 
 export default Popover;
+
+const useIsDomAvailable = () => {
+  const [isDomAvailable, setIsDomAvailable] = React.useState(false);
+  React.useEffect(() => void setIsDomAvailable(true), []);
+  return isDomAvailable;
+};


### PR DESCRIPTION
## Changes

Ported from https://github.com/iTwin/iTwinUI/pull/1265#issuecomment-1545755572 for release in v2. It could fix some of the issues with our Popover.

## Testing

Fixes the weird edge cases that I was facing in #1265, and doesn't cause any existing tests to break, which is good.

## Docs

N/A