### PR TITLE
filter out null children in buttongroup

### DIFF
--- a/.changeset/purple-beds-hammer.md
+++ b/.changeset/purple-beds-hammer.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in ButtonGroup where null/undefined children were also getting wrapped by empty `<div>`s.

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -74,7 +74,10 @@ export const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
     } = props;
 
     const items = React.useMemo(
-      () => React.Children.map(children, (child) => <div>{child}</div>) ?? [],
+      () =>
+        React.Children.map(children, (child) =>
+          !!child ? <div>{child}</div> : undefined,
+        )?.filter(Boolean) ?? [],
       [children],
     );
 


### PR DESCRIPTION
## Changes

Filtering out null/undefined children when mapping over children, because otherwise they get converted into `<div></div>` and break border-radius logic which relies on `:first-child`/`:last-child`.

## Testing

Can be tested by simply doing this:
```jsx
<ButtonGroup>
  <IconButton>
    <SvgAdd />
  </IconButton>

  <IconButton>
    <SvgEdit />
  </IconButton>

  {null}
</ButtonGroup>
```

Before:
![pointy](https://github.com/iTwin/iTwinUI/assets/9084735/99be7f19-19fa-462d-9209-84e86b69fef5)

After:
![rounded](https://github.com/iTwin/iTwinUI/assets/9084735/68c3801b-8faf-4cb3-8aa5-79cbb31955ba)


## Docs

N/A