### PR TITLE
bug: Patching useId

### DIFF
--- a/.changeset/odd-seals-thank.md
+++ b/.changeset/odd-seals-thank.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Add fix in `useId` to avoid bundlers trying to import non-existing export.

--- a/packages/itwinui-react/src/core/utils/hooks/useId.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useId.ts
@@ -15,4 +15,7 @@ export const useId = () => {
   return React.useMemo(() => `iui-${uniqueValue}`, [uniqueValue]);
 };
 
-const useUniqueValue = React.useId ?? (() => getRandomValue(10));
+// This is needed to avoid bundlers trying to import non-existing export.
+// Read more: https://github.com/webpack/webpack/issues/14814
+const _React = React;
+const useUniqueValue = _React.useId ?? (() => getRandomValue(10));


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Patch needed to avoid bundlers trying to import non-existing export.
Read more: https://github.com/webpack/webpack/issues/14814

## Testing

Run CRA app with new version

## Docs

Comment in code
