### PR TITLE
fix: `FileUpload` missing styles

### DIFF
--- a/.changeset/spicy-tomatoes-leave.md
+++ b/.changeset/spicy-tomatoes-leave.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`FileUpload`: fix missing anchor style

--- a/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
@@ -10,10 +10,12 @@ import {
   useSafeContext,
   useId,
   mergeEventHandlers,
+  VisuallyHidden,
 } from '../utils/index.js';
 import cx from 'classnames';
 import { FileEmptyCard } from './FileEmptyCard.js';
 import { Anchor } from '../Typography/Anchor/Anchor.js';
+import '@itwin/itwinui-css/css/file-upload.css';
 
 const toBytes = (bytes: number) => {
   const units = [' bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -168,7 +170,7 @@ const FileUploadCardInput = React.forwardRef<
   HTMLInputElement,
   FileUploadCardInputProps
 >((props, ref) => {
-  const { children, className, onChange, id, ...rest } = props;
+  const { children, onChange, id, ...rest } = props;
   const { files, onFilesChange, setInternalFiles, inputId, setInputId } =
     useSafeContext(FileUploadCardContext);
 
@@ -196,8 +198,8 @@ const FileUploadCardInput = React.forwardRef<
 
   return (
     <>
-      <input
-        className={cx('iui-visually-hidden', className)}
+      <VisuallyHidden
+        as='input'
         type='file'
         onChange={mergeEventHandlers(onChange, (e) => {
           const _files = Array.from(e.currentTarget.files || []);

--- a/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
@@ -13,6 +13,7 @@ import {
 } from '../utils/index.js';
 import cx from 'classnames';
 import { FileEmptyCard } from './FileEmptyCard.js';
+import { Anchor } from '../Typography/Anchor/Anchor.js';
 
 const toBytes = (bytes: number) => {
   const units = [' bytes', 'KB', 'MB', 'GB', 'TB'];
@@ -148,17 +149,12 @@ const FileUploadCardInputLabel = React.forwardRef<
   HTMLLabelElement,
   FileUploadCardInputLabelProps
 >((props, ref) => {
-  const { children, className, ...rest } = props;
+  const { children, ...rest } = props;
   const { inputId } = useSafeContext(FileUploadCardContext);
   return (
-    <label
-      className={cx('iui-anchor', className)}
-      ref={ref}
-      htmlFor={inputId}
-      {...rest}
-    >
+    <Anchor as='label' ref={ref} htmlFor={inputId} {...rest}>
       {children}
-    </label>
+    </Anchor>
   );
 });
 FileUploadCardInputLabel.displayName = 'FileUploadCard.InputLabel';

--- a/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useTheme, SvgUpload } from '../utils/index.js';
 import '@itwin/itwinui-css/css/file-upload.css';
+import { Anchor } from '../Typography/Anchor/Anchor.js';
 
 export type FileUploadTemplateProps = {
   /**
@@ -62,7 +63,7 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
     <div className={cx('iui-file-upload-template', className)} {...rest}>
       <SvgUpload className='iui-template-icon' aria-hidden />
       <div className='iui-template-text'>
-        <label className='iui-anchor'>
+        <Anchor as='label'>
           <input
             className='iui-browse-input'
             type='file'
@@ -71,7 +72,7 @@ export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
             accept={acceptType}
           />
           {label}
-        </label>
+        </Anchor>
         <div>{subtitle}</div>
         {children}
       </div>


### PR DESCRIPTION
## Changes

- Replaced `label` element with `Anchor` component, so css gets imported for it.
- Import missed css in `FileUploadCard`
- Use `VisuallyHidden` instead of class. Probably, this was also broken.

## Testing

Before my change, this is the outcome for `FileUpload`
<img width="764" alt="image" src="https://github.com/iTwin/iTwinUI/assets/81580355/9de7b1ac-0ba1-420d-a9a4-3443868a4d50">

After:
<img width="903" alt="image" src="https://github.com/iTwin/iTwinUI/assets/81580355/c0fe8f3d-b560-46b1-a30d-4f205c2bd882">

Can use this code
```
 <FileUpload onFileDropped={() => {}}>
       <FileUploadTemplate>nothing</FileUploadTemplate>
 </FileUpload>
```

Important thing I have noticed:
dev build in Vite (at least) includes all the css from all available components. I was pretty sure that was not the case some time ago... That means, that testing environment with dev build is not really isolated.
As a result, the same happens in all the code sandboxes in examples..
Storybook also has all the css included, so you would never reproduce it there.

This was not a bug in V1, because back then `iui-anchor` style was included in global ( I think).
I would suggest reviewing your testing environments to ensure no stuff from outside ends up included.
