### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-*       @iTwin/itwinui-css-1 @iTwin/itwinui-css-2
+*       @iTwin/itwinui-1 @iTwin/itwinui-2


### PR DESCRIPTION
Updating codeowners with new teams have just been set up, deprecating the iTwinUI-css-[x] ones.

Merging into `main` first and then `dev`.