### PR TITLE
add Box to remaining components

### DIFF
--- a/packages/itwinui-react/src/core/ExpandableBlock/ExpandableBlock.tsx
+++ b/packages/itwinui-react/src/core/ExpandableBlock/ExpandableBlock.tsx
@@ -126,7 +126,7 @@ export const ExpandableBlock = React.forwardRef((props, ref) => {
       ref={ref}
       {...rest}
     >
-      <div
+      <Box
         aria-expanded={expanded}
         className='iui-header'
         tabIndex={0}
@@ -134,16 +134,16 @@ export const ExpandableBlock = React.forwardRef((props, ref) => {
         onKeyDown={onKeyDown}
       >
         <SvgChevronRight className='iui-icon' aria-hidden />
-        <span className='iui-expandable-block-label'>
-          <div className='iui-title'>{title}</div>
-          {caption && <div className='iui-caption'>{caption}</div>}
-        </span>
+        <Box as='span' className='iui-expandable-block-label'>
+          <Box className='iui-title'>{title}</Box>
+          {caption && <Box className='iui-caption'>{caption}</Box>}
+        </Box>
         {icon && <Icon fill={status}>{icon}</Icon>}
-      </div>
+      </Box>
       <WithCSSTransition in={expanded}>
-        <div className='iui-expandable-content'>
+        <Box className='iui-expandable-content'>
           <div>{children}</div>
-        </div>
+        </Box>
       </WithCSSTransition>
     </Box>
   );

--- a/packages/itwinui-react/src/core/utils/icons/Svg.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/Svg.tsx
@@ -2,15 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as React from 'react';
-import { Svg } from './Svg.js';
+import { polymorphic } from '../functions/polymorphic.js';
 
-export const SvgColumnManager = (
-  props: React.ComponentPropsWithoutRef<'svg'>,
-) => {
-  return (
-    <Svg {...props}>
-      <path d='m1 0h2v16h-2m6-16h2v16h-2m6-16h2v16h-2' />
-    </Svg>
-  );
-};
+export const Svg = polymorphic.svg('', { viewBox: '0 0 16 16' });

--- a/packages/itwinui-react/src/core/utils/icons/SvgCalendar.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCalendar.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCalendar = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCalendar = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M13,13H9V10h4ZM16,3V15a1,1,0,0,1-1,1H1a1,1,0,0,1-1-1V3A1,1,0,0,1,1,2H3V0H4V2h8V0h1V2h2A1,1,0,0,1,16,3ZM15,6H1v9H15Z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCaretDownSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCaretDownSmall.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCaretDownSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCaretDownSmall = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M4.807 6h6.395a.28.28 0 0 1 .24.443L8.27 9.9a.34.34 0 0 1-.481 0L4.566 6.443A.27.27 0 0 1 4.806 6z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCaretRightSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCaretRightSmall.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCaretRightSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCaretRightSmall = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M6.003 4.807v6.4a.28.28 0 0 0 .443.24L9.9 8.27a.34.34 0 0 0 0-.48L6.446 4.566a.269.269 0 0 0-.443.24z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCaretUpSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCaretUpSmall.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCaretUpSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCaretUpSmall = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M4.807 9.997h6.395a.28.28 0 0 0 .24-.443L8.27 6.097a.34.34 0 0 0-.48 0h-.001L4.566 9.554a.27.27 0 0 0 .24.443z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCheckmark.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCheckmark.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCheckmark = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCheckmark = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M6,14L0,8l2-2l4,4l8-8l2,2L6,14z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCheckmarkSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCheckmarkSmall.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCheckmarkSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCheckmarkSmall = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m6 13.4-4.7-4.7 1.4-1.4 3.3 3.3 7.3-7.3 1.4 1.4z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgChevronLeft.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgChevronLeft.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgChevronLeft = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgChevronLeft = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m11.3 0 1.4 1.4-6.6 6.6 6.6 6.6-1.4 1.4-8-8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgChevronLeftDouble.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgChevronLeftDouble.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgChevronLeftDouble = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgChevronLeftDouble = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m14.6 0 1.4 1.4-6.6 6.6 6.6 6.6-1.4 1.4-8-8zm-6.6 0 1.4 1.4-6.6 6.6 6.6 6.6-1.4 1.4-8-8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgChevronRight.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgChevronRight.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgChevronRight = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgChevronRight = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m4.7 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgChevronRightDouble.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgChevronRightDouble.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgChevronRightDouble = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgChevronRightDouble = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m1.4 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8zm6.6 0-1.4 1.4 6.6 6.6-6.6 6.6 1.4 1.4 8-8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgClose.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgClose.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgClose = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgClose = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m14 0-6 6-6-6-2 2 6 6-6 6 2 2 6-6 6 6 2-2-6-6 6-6' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgCloseSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgCloseSmall.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgCloseSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgCloseSmall = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m12.5 2-4.5 4.5-4.5-4.5-1.5 1.5 4.5 4.5-4.5 4.5 1.5 1.5 4.5-4.5 4.5 4.5 1.5-1.5-4.5-4.5 4.5-4.5z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgDocument.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgDocument.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgDocument = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgDocument = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M10 0H2v16h12V4h-4zm1 0v3h3z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgFilter.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgFilter.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgFilter = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgFilter = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m0 0v2l6 5v9l4-3v-6l6-5v-2z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgFilterHollow.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgFilterHollow.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgFilterHollow = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgFilterHollow = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M15 1v.5L9.4 6.2l-.4.3v6L7 14V6.5l-.4-.3L1 1.5V1zm1-1H0v2l6 5v9l4-3V7l6-5z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgImportantSmall.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgImportantSmall.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgImportantSmall = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgImportantSmall = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M6.25 1h3.5v3.19l-.676 6.408H6.91L6.25 4.19zm.12 10.572h3.268V15H6.37z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgInfoCircular.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgInfoCircular.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgInfoCircular = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgInfoCircular = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M8 0a8 8 0 1 0 8 8 8 8 0 0 0-8-8zm1.2 3.2a.923.923 0 0 1 .997.843l.003.057a1.31 1.31 0 0 1-1.3 1.2.945.945 0 0 1-1-1 1.228 1.228 0 0 1 1.3-1.1zm-2 9.6c-.5 0-.9-.3-.5-1.7l.6-2.4c.1-.4.1-.5 0-.5-.2-.1-.9.2-1.3.5l-.2-.5a6.497 6.497 0 0 1 3.3-1.6c.5 0 .6.6.3 1.6l-.7 2.6c-.1.5-.1.6.1.6a2.003 2.003 0 0 0 1.1-.6l.3.4a5.769 5.769 0 0 1-3 1.6z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgMore.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgMore.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgMore = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgMore = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m4 8a2 2 0 1 1 -2-2 2 2 0 0 1 2 2zm4-2a2 2 0 1 0 2 2 2 2 0 0 0 -2-2zm6 0a2 2 0 1 0 2 2 2 2 0 0 0 -2-2z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgMoreVertical.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgMoreVertical.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgMoreVertical = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgMoreVertical = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m8 4a2 2 0 1 1 2-2 2 2 0 0 1 -2 2zm2 4a2 2 0 1 0 -2 2 2 2 0 0 0 2-2zm0 6a2 2 0 1 0 -2 2 2 2 0 0 0 2-2z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgNew.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgNew.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgNew = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgNew = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M8 5a1 1 0 0 1-1-1V1a1 1 0 0 1 2 0v3a1 1 0 0 1-1 1zM4.535 7a.997.997 0 0 1-.499-.134l-2.598-1.5a1 1 0 1 1 1-1.732l2.598 1.5A1 1 0 0 1 4.536 7zM1.94 12.5a1 1 0 0 1-.501-1.866l2.598-1.5a1 1 0 1 1 1 1.732l-2.598 1.5a.997.997 0 0 1-.499.134zM8 16a1 1 0 0 1-1-1v-3a1 1 0 0 1 2 0v3a1 1 0 0 1-1 1zm6.061-3.5a.995.995 0 0 1-.499-.134l-2.598-1.5a1 1 0 1 1 1-1.732l2.598 1.5a1 1 0 0 1-.5 1.866zM11.465 7a1 1 0 0 1-.501-1.866l2.598-1.5a1 1 0 1 1 1 1.732l-2.598 1.5a.995.995 0 0 1-.5.134z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgSearch.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgSearch.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgSearch = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgSearch = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m11 9.7c.7-1 1.1-2.2 1.1-3.5.1-3.5-2.7-6.2-6-6.2-3.4 0-6.1 2.7-6.1 6.1s2.7 6.1 6.1 6.1c1.3 0 2.5-.4 3.5-1.1l4.9 4.9 1.4-1.4zm-5 .5c-2.3 0-4.1-1.8-4.1-4.1s1.8-4.1 4.1-4.1 4.1 1.8 4.1 4.1-1.8 4.1-4.1 4.1' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgSmileyHappy.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgSmileyHappy.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgSmileyHappy = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgSmileyHappy = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='M8 12.5a5.19 5.19 0 0 1-3.872-1.666.5.5 0 1 1 .744-.668A4.191 4.191 0 0 0 8 11.5a4.191 4.191 0 0 0 3.128-1.334.5.5 0 1 1 .744.668A5.19 5.19 0 0 1 8 12.5zM11 5a1.146 1.146 0 0 1 1 1.25 1.146 1.146 0 0 1-1 1.25 1.146 1.146 0 0 1-1-1.25A1.146 1.146 0 0 1 11 5zM5 5a1.146 1.146 0 0 1 1 1.25A1.146 1.146 0 0 1 5 7.5a1.146 1.146 0 0 1-1-1.25A1.146 1.146 0 0 1 5 5zm3-5a8 8 0 1 0 8 8 8 8 0 0 0-8-8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgSortDown.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgSortDown.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgSortDown = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgSortDown = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m7 0v12.7l-3.8-3.7-1.2 1.2 6 5.8 1.2-1.2 4.8-4.6-1.2-1.2-3.8 3.7v-12.7z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgSortUp.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgSortUp.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgSortUp = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgSortUp = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m9 16v-12.7l3.8 3.7 1.2-1.2-6-5.8-1.2 1.2-4.8 4.6 1.2 1.2 3.8-3.7v12.7z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgStatusError.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgStatusError.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgStatusError = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgStatusError = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m8 0a8 8 0 1 0 8 8 8 8 0 0 0 -8-8zm1 12h-2v-2h2zm0-3h-2v-5h2z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgStatusSuccess.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgStatusSuccess.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgStatusSuccess = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgStatusSuccess = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m8 0a8 8 0 1 0 8 8 8 8 0 0 0 -8-8zm-1.35 12-3.65-3.41 1.4-1.3 2.36 2.2 4.83-4.49 1.41 1.29z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgStatusWarning.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgStatusWarning.tsx
@@ -3,10 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgStatusWarning = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgStatusWarning = (
+  props: React.ComponentPropsWithoutRef<'svg'>,
+) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m15.86807 13.26721-6.77-11.62a1.15 1.15 0 0 0 -1.1-.67 1.17 1.17 0 0 0 -1.1.69l-6.77 11.59a1.2 1.2 0 0 0 1.1 1.72h13.45a1.19 1.19 0 0 0 1.19-1.71zm-6.87-.29h-2v-2h2zm0-3h-2v-5h2z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgSwap.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgSwap.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgSwap = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgSwap = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m5 15-3.78125-3.5 3.78125-3.5v2h8v3h-8zm6-7 3.78125-3.5-3.78125-3.5v2h-8v3h8z' />
-    </svg>
+    </Svg>
   );
 };

--- a/packages/itwinui-react/src/core/utils/icons/SvgUpload.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/SvgUpload.tsx
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-export const SvgUpload = (props: React.ComponentProps<'svg'>) => {
+import { Svg } from './Svg.js';
+
+export const SvgUpload = (props: React.ComponentPropsWithoutRef<'svg'>) => {
   return (
-    <svg viewBox='0 0 16 16' {...props}>
+    <Svg {...props}>
       <path d='m2 5h4v7h4v-7h4l-6-5zm12 6v3h-12v-3h-2v5h16v-5z' />
-    </svg>
+    </Svg>
   );
 };


### PR DESCRIPTION
## Changes

1. In #1298, Box was missed (accidentally) in `ExpandableBlock`, so added that.
2. In #1298, Box was skipped (intentionally) from svgs, but I noticed in #1302 that it was breaking some styles in places where we apply a class directly on svg. In the future I would like to make sure that all svgs are only styled through a wrapping component (e.g. `<Icon>`) but for now I've added Box.

## Testing

This PR by itself shouldn't have any visible change, but it will be used as a base for #1302 where more extensive testing will be done.

## Docs

No changeset needed.