### PR TITLE
fix(DatePicker): allow month and year change even if date is disabled

### DIFF
--- a/packages/itwinui-react/src/core/DatePicker/DatePicker.test.tsx
+++ b/packages/itwinui-react/src/core/DatePicker/DatePicker.test.tsx
@@ -491,9 +491,32 @@ it('should prevent selecting disabled dates', async () => {
   await userEvent.keyboard('{Enter}');
   expect(onClick).not.toHaveBeenCalled();
 
-  // next month/year button should be disabled
-  expect(screen.getByLabelText('Previous year')).not.toBeDisabled();
-  expect(screen.getByLabelText('Previous month')).not.toBeDisabled();
-  expect(screen.getByLabelText('Next month')).toBeDisabled();
-  expect(screen.getByLabelText('Next year')).toBeDisabled();
+  // next month/year button should be enabled, but should not allow to choose the day
+  const nextYearButton = screen.getByLabelText('Next year');
+  expect(nextYearButton).toBeEnabled();
+  await userEvent.click(nextYearButton);
+  assertMonthYear(container, 'June', '2021');
+  await userEvent.click(getByText('22'));
+  expect(onClick).not.toHaveBeenCalled();
+
+  const nextMonthButton = screen.getByLabelText('Next month');
+  expect(nextMonthButton).toBeEnabled();
+  await userEvent.click(nextMonthButton);
+  assertMonthYear(container, 'July', '2021');
+  await userEvent.click(getByText('11'));
+  expect(onClick).not.toHaveBeenCalled();
+
+  const previousYearButton = screen.getByLabelText('Previous year');
+  expect(previousYearButton).toBeEnabled();
+  await userEvent.click(previousYearButton);
+  assertMonthYear(container, 'July', '2020');
+  await userEvent.click(getByText('10'));
+  expect(onClick).not.toHaveBeenCalled();
+
+  const previousMonthButton = screen.getByLabelText('Previous month');
+  expect(previousMonthButton).toBeEnabled();
+  await userEvent.click(previousMonthButton);
+  assertMonthYear(container, 'June', '2020');
+  await userEvent.click(getByText('24'));
+  expect(onClick).not.toHaveBeenCalled();
 });

--- a/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
+++ b/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
@@ -434,22 +434,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
     }
   };
 
-  const isPreviousMonthDisabled = isDateDisabled?.(
-    new Date(displayedYear, displayedMonthIndex, 0),
-  );
-
-  const isNextMonthDisabled = isDateDisabled?.(
-    new Date(displayedYear, displayedMonthIndex + 1, 1),
-  );
-
-  const isPreviousYearDisabled = isDateDisabled?.(
-    new Date(displayedYear - 1, 11, 31),
-  );
-
-  const isNextYearDisabled = isDateDisabled?.(
-    new Date(displayedYear + 1, 0, 1),
-  );
-
   const handleCalendarKeyDown = (
     event: React.KeyboardEvent<HTMLDivElement>,
   ) => {
@@ -465,9 +449,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
       case 'ArrowDown':
         adjustedFocusedDay.setDate(focusedDay.getDate() + 7);
         if (adjustedFocusedDay.getMonth() !== displayedMonthIndex) {
-          if (isNextMonthDisabled) {
-            return;
-          }
           handleMoveToNextMonth();
         }
         setFocusedDay(adjustedFocusedDay);
@@ -477,9 +458,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
       case 'ArrowUp':
         adjustedFocusedDay.setDate(focusedDay.getDate() - 7);
         if (adjustedFocusedDay.getMonth() !== displayedMonthIndex) {
-          if (isPreviousMonthDisabled) {
-            return;
-          }
           handleMoveToPreviousMonth();
         }
         setFocusedDay(adjustedFocusedDay);
@@ -489,9 +467,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
       case 'ArrowLeft':
         adjustedFocusedDay.setDate(focusedDay.getDate() - 1);
         if (adjustedFocusedDay.getMonth() !== displayedMonthIndex) {
-          if (isPreviousMonthDisabled) {
-            return;
-          }
           handleMoveToPreviousMonth();
         }
         setFocusedDay(adjustedFocusedDay);
@@ -501,9 +476,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
       case 'ArrowRight':
         adjustedFocusedDay.setDate(focusedDay.getDate() + 1);
         if (adjustedFocusedDay.getMonth() !== displayedMonthIndex) {
-          if (isNextMonthDisabled) {
-            return;
-          }
           handleMoveToNextMonth();
         }
         setFocusedDay(adjustedFocusedDay);
@@ -566,7 +538,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
               onClick={handleMoveToPreviousYear}
               aria-label='Previous year'
               size='small'
-              disabled={isPreviousYearDisabled}
             >
               <SvgChevronLeftDouble />
             </IconButton>
@@ -576,7 +547,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
             onClick={handleMoveToPreviousMonth}
             aria-label='Previous month'
             size='small'
-            disabled={isPreviousMonthDisabled}
           >
             <SvgChevronLeft />
           </IconButton>
@@ -594,7 +564,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
             onClick={handleMoveToNextMonth}
             aria-label='Next month'
             size='small'
-            disabled={isNextMonthDisabled}
           >
             <SvgChevronRight />
           </IconButton>
@@ -604,7 +573,6 @@ export const DatePicker = (props: DatePickerProps): JSX.Element => {
               onClick={handleMoveToNextYear}
               aria-label='Next year'
               size='small'
-              disabled={isNextYearDisabled}
             >
               <SvgChevronRightDouble />
             </IconButton>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

I have removed disabled state from month and year. This should be allowed in general as this is view only and only the day selection should be disabled.
Valid case:

![image](https://github.com/iTwin/iTwinUI/assets/81580355/cacdc16a-ac7c-46bc-8e45-c39afafd1a97)

Select previous day than today is disabled. But currently selected date is in the disabled range. In this case, all navigation to next month is disabled (but you need to choose a new date which is not in the past)

