### PR TITLE
keep FileUploadCard.Input hidden on focus

### DIFF
--- a/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
@@ -201,6 +201,7 @@ const FileUploadCardInput = React.forwardRef<
       <VisuallyHidden
         as='input'
         type='file'
+        unhideOnFocus={false}
         onChange={mergeEventHandlers(onChange, (e) => {
           const _files = Array.from(e.currentTarget.files || []);
           onFilesChange?.(_files);


### PR DESCRIPTION
## Changes

#1309 broke FileUpload where the input was inadvertently showing on focus.
![](https://github.com/iTwin/iTwinUI/assets/9084735/c7540e90-b58c-4c15-8228-0ab2422cda67)

So added missing `unhideOnFocus={false}` prop.

## Testing

N/A

## Docs

N/A