### PR TITLE
Deprecate FileUploadTemplate

### DIFF
--- a/.changeset/brave-suits-exercise.md
+++ b/.changeset/brave-suits-exercise.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': major
+---
+
+Deprecated `FileUploadTemplate`. Removed all of its references.

--- a/apps/storybook/src/FileUpload.stories.tsx
+++ b/apps/storybook/src/FileUpload.stories.tsx
@@ -11,7 +11,6 @@ import {
   FileUploadCard,
   FileEmptyCard,
   FileUploadProps,
-  FileUploadTemplate,
   LabeledInput,
   IconButton,
 } from '@itwin/itwinui-react';
@@ -33,26 +32,6 @@ export default {
   },
   title: 'Core/FileUpload',
 } as Meta<FileUploadProps>;
-
-export const Default: Story<FileUploadProps> = (args) => {
-  const [files, setFiles] = useState<Array<File>>([]);
-
-  return (
-    <FileUpload
-      {...args}
-      onFileDropped={(files) => {
-        setFiles(Array.from(files));
-        action(`${files.length} files uploaded`)();
-      }}
-    >
-      <FileUploadTemplate
-        onChange={(e) => setFiles(Array.from(e.target.files || []))}
-      >
-        {files.map((f) => f.name).join(', ')}
-      </FileUploadTemplate>
-    </FileUpload>
-  );
-};
 
 export const WrappingInput: Story<FileUploadProps> = (args) => {
   const [files, setFiles] = useState<Array<File>>([]);

--- a/apps/storybook/src/FileUpload.test.ts
+++ b/apps/storybook/src/FileUpload.test.ts
@@ -5,7 +5,6 @@
 describe('FileUpload', () => {
   const storyPath = 'Core/FileUpload';
   const tests = [
-    'Default',
     'Wrapping Input',
     'Default File Upload Card',
     'Custom File Upload Card',

--- a/apps/website/src/examples/FileUpload.main.tsx
+++ b/apps/website/src/examples/FileUpload.main.tsx
@@ -3,20 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { FileUpload, FileUploadTemplate } from '@itwin/itwinui-react';
+import { FileUpload, FileUploadCard, Box } from '@itwin/itwinui-react';
 
 export default () => {
-  const [files, setFiles] = React.useState([]);
-
+  const [files, setFiles] = React.useState<Array<File>>([]);
   return (
     <FileUpload
+      style={{ position: 'absolute' }}
       onFileDropped={(files) => {
-        setFiles(Array.from(files));
+        setFiles(files);
+        action(`${files.length} files uploaded`)();
       }}
     >
-      <FileUploadTemplate onChange={(e) => setFiles(Array.from(e.target.files || []))}>
-        {files.map((f) => f.name).join(', ')}
-      </FileUploadTemplate>
+      <FileUploadCard files={files} onFilesChange={(files) => setFiles(files)} />
     </FileUpload>
   );
 };

--- a/packages/itwinui-react/src/core/FileUpload/FileUpload.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUpload.tsx
@@ -12,7 +12,6 @@ export type FileUploadProps = {
   /**
    * Content shown over `children` when file is being dragged onto the component.
    * Should always be used when drag content differs from `children` being wrapped.
-   * Can be skipped if wrapping `FileUploadTemplate`.
    */
   dragContent?: React.ReactNode;
   /**
@@ -21,16 +20,16 @@ export type FileUploadProps = {
   onFileDropped: (files: FileList) => void;
   /**
    * Component to wrap `FileUpload` around.
-   * Either pass `FileUploadTemplate` (for default state) or a different component to wrap.
+   * Either pass `FileUploadCard` (for default state) or a different component to wrap.
    */
   children: React.ReactNode;
 } & CommonProps;
 
 /**
- * File upload component to be wrapped around `FileUploadTemplate` or any arbitrary component.
+ * File upload component to be wrapped around `FileUploadCard` or any arbitrary component.
  * Provides support for dragging and dropping multiple files.
  * @example
- * <FileUpload onFileDropped={console.log}><FileUploadTemplate /></FileUpload>
+ * <FileUpload onFileDropped={console.log}><FileUploadCard /></FileUpload>
  * <FileUpload dragContent='Drop file here' onFileDropped={console.log}><Textarea /></FileUpload>
  */
 export const FileUpload = React.forwardRef(

--- a/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
@@ -41,10 +41,7 @@ export type FileUploadTemplateProps = {
 } & React.ComponentProps<'div'>;
 
 /**
- * Default template to be used with the `FileUpload` wrapper component.
- * Contains a hidden input with styled labels (customizable).
- * @example
- * <FileUploadTemplate onChange={(e) => console.log(e.target.files)} />
+ * @deprecated Use `FileUploadCard` instead.
  */
 export const FileUploadTemplate = (props: FileUploadTemplateProps) => {
   const {

--- a/packages/itwinui-react/src/core/FileUpload/index.ts
+++ b/packages/itwinui-react/src/core/FileUpload/index.ts
@@ -6,9 +6,6 @@ export { FileUpload } from './FileUpload.js';
 export type { FileUploadProps } from './FileUpload.js';
 export default './FileUpload';
 
-export { FileUploadTemplate } from './FileUploadTemplate.js';
-export type { FileUploadTemplateProps } from './FileUploadTemplate.js';
-
 export { FileUploadCard } from './FileUploadCard.js';
 export type {
   FileUploadCardProps,

--- a/packages/itwinui-react/src/core/index.ts
+++ b/packages/itwinui-react/src/core/index.ts
@@ -102,13 +102,11 @@ export type { FieldsetProps } from './Fieldset/index.js';
 
 export {
   FileUpload,
-  FileUploadTemplate,
   FileUploadCard,
   FileEmptyCard,
 } from './FileUpload/index.js';
 export type {
   FileUploadProps,
-  FileUploadTemplateProps,
   FileUploadCardProps,
   FileUploadCardIconProps,
   FileUploadCardInfoProps,


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

- Removed `FileUploadTemplate` references from:
 + indexes imports
 + Removed the Default example from Storybook because it is the same as the Default File Upload Card example, but with `FileUploadTemplate` instead of `FileUploadCard`.
 + Doc Website (replaced with `FileUploadCard`)
 + marked deprecated in jsdoc
 + updated relevant jsdocs in `FileUpload`

- Did not remove (yet?):
 + `FileUploadTemplate.tsx` itself
 + `FileUploadTemplate.test.tsx`

Do we remove those right now? ^

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

- Tested the changes in vite when replacing `FileUploadTemplate` with `FileUploadCard`, also make sure main example on website works as intended. It doesn't but should work after #1329 merged because I independently tested this fix on this branch.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

- Changes in jsdocs
- Updated website main example
- Brief description in migration guide
