### PR TITLE
fix vite config for windows

### DIFF
--- a/packages/itwinui-react/src/styles.js/vite.config.mjs
+++ b/packages/itwinui-react/src/styles.js/vite.config.mjs
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Changes

windows build was failing because of returning invalid paths.
![](https://github.com/iTwin/iTwinUI/assets/9084735/02ebb7c7-bfe0-42b1-8dfb-eb2e8686a1b6)

this is what happens when you trust code written by copilot. 🙃

changed `__dirname` to use `fileURLToPath` and changed `path.resolve` to `path.join`.

## Testing

Tested on:
- [x] macbook
- [x] CI (linux)
- [x] windows (tested by @LostABike and also in #1339)

## Docs

N/A