### PR TITLE
bump target to `es2020`

### DIFF
--- a/packages/itwinui-react/tsconfig.json
+++ b/packages/itwinui-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2020",
     "lib": ["es6", "dom"],
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Changes

Should reduce the size of our deliverable and make it a bit easier to debug, as es2020 adds "nice" features like nullish coalescing and optional chaining.

## Testing

N/A

## Docs

N/A