### PR TITLE
use only data attribute for variables

### DIFF
--- a/.changeset/few-ghosts-judge.md
+++ b/.changeset/few-ghosts-judge.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-variables': major
+---
+
+`iui-root` has been removed. `data-iui-theme` must now always be set in order to use variables.

--- a/apps/portal/src/pages/index.astro
+++ b/apps/portal/src/pages/index.astro
@@ -32,7 +32,7 @@ const links = [
     </style>
   </head>
 
-  <body data-iui-theme>
+  <body class='iui-root' data-iui-theme>
     <h1 class='iui-text-title'>
       <span class='iui-visually-hidden'>iTwinUI</span>{titleSuffix}
     </h1>

--- a/apps/portal/src/pages/index.astro
+++ b/apps/portal/src/pages/index.astro
@@ -32,7 +32,7 @@ const links = [
     </style>
   </head>
 
-  <body class='iui-root'>
+  <body data-iui-theme>
     <h1 class='iui-text-title'>
       <span class='iui-visually-hidden'>iTwinUI</span>{titleSuffix}
     </h1>

--- a/apps/website/src/components/variables/_wrapper.astro
+++ b/apps/website/src/components/variables/_wrapper.astro
@@ -1,10 +1,8 @@
 ---
 import '@itwin/itwinui-variables';
-
-const { class: className, ...props } = Astro.props;
 ---
 
-<article {...props} data-iui-theme='dark' class:list={['iui-root', className]}>
+<article data-iui-theme='dark' {...Astro.props}>
   <slot />
 </article>
 

--- a/apps/website/src/pages/_global.astro
+++ b/apps/website/src/pages/_global.astro
@@ -236,7 +236,7 @@ const { content = {} } = Astro.props;
     </style>
   </head>
 
-  <body class='_iui3-root' data-iui-theme='dark'>
+  <body data-iui-theme='dark'>
     <slot />
 
     <!-- Util classes/styles and scripts -->

--- a/packages/itwinui-css/backstop/tests/alert.html
+++ b/packages/itwinui-css/backstop/tests/alert.html
@@ -46,7 +46,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Alert</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/anchor.html
+++ b/packages/itwinui-css/backstop/tests/anchor.html
@@ -28,7 +28,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Anchor</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/avatar.html
+++ b/packages/itwinui-css/backstop/tests/avatar.html
@@ -41,7 +41,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Avatar</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/badge.html
+++ b/packages/itwinui-css/backstop/tests/badge.html
@@ -30,7 +30,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Badge</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/blockquote.html
+++ b/packages/itwinui-css/backstop/tests/blockquote.html
@@ -27,7 +27,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Blockquote</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/breadcrumbs.html
+++ b/packages/itwinui-css/backstop/tests/breadcrumbs.html
@@ -36,7 +36,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Breadcrumbs</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/button.html
+++ b/packages/itwinui-css/backstop/tests/button.html
@@ -61,7 +61,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Button</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/carousel.html
+++ b/packages/itwinui-css/backstop/tests/carousel.html
@@ -54,7 +54,10 @@
 
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Carousel</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/checkbox.html
+++ b/packages/itwinui-css/backstop/tests/checkbox.html
@@ -37,7 +37,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Checkbox</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/code.html
+++ b/packages/itwinui-css/backstop/tests/code.html
@@ -25,7 +25,10 @@
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Code</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/color-picker.html
+++ b/packages/itwinui-css/backstop/tests/color-picker.html
@@ -25,7 +25,10 @@
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Color Picker</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/color.html
+++ b/packages/itwinui-css/backstop/tests/color.html
@@ -115,7 +115,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Color</h1>
 

--- a/packages/itwinui-css/backstop/tests/column-filter.html
+++ b/packages/itwinui-css/backstop/tests/column-filter.html
@@ -29,7 +29,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Column filter</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/date-picker.html
+++ b/packages/itwinui-css/backstop/tests/date-picker.html
@@ -30,7 +30,10 @@
       section {padding: 12px;}
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Date picker</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/dialog.html
+++ b/packages/itwinui-css/backstop/tests/dialog.html
@@ -42,7 +42,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Dialog</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/expandable-block.html
+++ b/packages/itwinui-css/backstop/tests/expandable-block.html
@@ -38,7 +38,10 @@
       })
     </script>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Expandable block</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/fieldset.html
+++ b/packages/itwinui-css/backstop/tests/fieldset.html
@@ -32,7 +32,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Fieldset</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/file-upload.html
+++ b/packages/itwinui-css/backstop/tests/file-upload.html
@@ -65,7 +65,10 @@
       });
     </script>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>File upload</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/footer.html
+++ b/packages/itwinui-css/backstop/tests/footer.html
@@ -31,7 +31,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Footer</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/header.html
+++ b/packages/itwinui-css/backstop/tests/header.html
@@ -59,7 +59,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Header</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/iModel-loader.html
+++ b/packages/itwinui-css/backstop/tests/iModel-loader.html
@@ -41,7 +41,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <section>
       <div id="imodel-loader-page">

--- a/packages/itwinui-css/backstop/tests/icon.html
+++ b/packages/itwinui-css/backstop/tests/icon.html
@@ -45,7 +45,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Icon</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/index.html
+++ b/packages/itwinui-css/backstop/tests/index.html
@@ -104,7 +104,10 @@
   </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <a
       href="https://github.com/iTwin/iTwinUI"
       class="github-corner"

--- a/packages/itwinui-css/backstop/tests/information-panel.html
+++ b/packages/itwinui-css/backstop/tests/information-panel.html
@@ -119,7 +119,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Information panel</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/input.html
+++ b/packages/itwinui-css/backstop/tests/input.html
@@ -52,7 +52,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Input</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/keyboard.html
+++ b/packages/itwinui-css/backstop/tests/keyboard.html
@@ -25,7 +25,10 @@
       kbd.iui-keyboard { margin: 0 2px; }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Keyboard</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/location-marker.html
+++ b/packages/itwinui-css/backstop/tests/location-marker.html
@@ -31,7 +31,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Location Marker</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/menu.html
+++ b/packages/itwinui-css/backstop/tests/menu.html
@@ -47,7 +47,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Menu</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/non-ideal-state.html
+++ b/packages/itwinui-css/backstop/tests/non-ideal-state.html
@@ -40,7 +40,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button style="position:fixed"></theme-button>
     <div
       id="nis-401"

--- a/packages/itwinui-css/backstop/tests/progress-indicator.html
+++ b/packages/itwinui-css/backstop/tests/progress-indicator.html
@@ -46,7 +46,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Progress indicator</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/radio-tile.html
+++ b/packages/itwinui-css/backstop/tests/radio-tile.html
@@ -50,7 +50,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Radio tile</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/radio.html
+++ b/packages/itwinui-css/backstop/tests/radio.html
@@ -37,7 +37,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Radio</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/select.html
+++ b/packages/itwinui-css/backstop/tests/select.html
@@ -56,7 +56,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Select</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/side-navigation.html
+++ b/packages/itwinui-css/backstop/tests/side-navigation.html
@@ -53,7 +53,10 @@
     </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Side navigation</h1>
 

--- a/packages/itwinui-css/backstop/tests/skip-to-content.html
+++ b/packages/itwinui-css/backstop/tests/skip-to-content.html
@@ -42,7 +42,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <a
       href="#demo-skip-to-here"
       class="iui-skip-to-content-link"

--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -52,7 +52,10 @@
 
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Slider</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/stepper.html
+++ b/packages/itwinui-css/backstop/tests/stepper.html
@@ -26,7 +26,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Stepper</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/surface.html
+++ b/packages/itwinui-css/backstop/tests/surface.html
@@ -87,7 +87,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Surface</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/table.html
+++ b/packages/itwinui-css/backstop/tests/table.html
@@ -137,7 +137,10 @@
     </script>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Table</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/tabs.html
+++ b/packages/itwinui-css/backstop/tests/tabs.html
@@ -34,7 +34,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Tabs</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/tag.html
+++ b/packages/itwinui-css/backstop/tests/tag.html
@@ -29,7 +29,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Tag</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/textarea.html
+++ b/packages/itwinui-css/backstop/tests/textarea.html
@@ -32,7 +32,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Text area</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/tile.html
+++ b/packages/itwinui-css/backstop/tests/tile.html
@@ -109,7 +109,10 @@
     </script>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Tile</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/time-picker.html
+++ b/packages/itwinui-css/backstop/tests/time-picker.html
@@ -23,7 +23,10 @@
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Time picker</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/toggle-switch.html
+++ b/packages/itwinui-css/backstop/tests/toggle-switch.html
@@ -32,7 +32,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Toggle switch</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/tooltip.html
+++ b/packages/itwinui-css/backstop/tests/tooltip.html
@@ -58,7 +58,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Tooltip</h1>
 

--- a/packages/itwinui-css/backstop/tests/transfer-list.html
+++ b/packages/itwinui-css/backstop/tests/transfer-list.html
@@ -34,7 +34,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>TransferList</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/tree.html
+++ b/packages/itwinui-css/backstop/tests/tree.html
@@ -29,7 +29,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Tree</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/typography.html
+++ b/packages/itwinui-css/backstop/tests/typography.html
@@ -28,7 +28,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Typography</h1>
     <hr />

--- a/packages/itwinui-css/backstop/tests/workflow-diagram.html
+++ b/packages/itwinui-css/backstop/tests/workflow-diagram.html
@@ -26,7 +26,10 @@
       }
     </style>
   </head>
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <theme-button></theme-button>
     <h1>Workflow diagram</h1>
     <hr />

--- a/packages/itwinui-variables/README.md
+++ b/packages/itwinui-variables/README.md
@@ -6,10 +6,6 @@
 npm install @itwin/itwinui-variables
 ```
 
-```console
-yarn add @itwin/itwinui-variables
-```
-
 ## Usage
 
 Import in CSS:
@@ -18,7 +14,7 @@ Import in CSS:
 @import '@itwin/itwinui-variables';
 ```
 
-Or in JS:
+Or in JS (if using a bundler):
 
 ```js
 import '@itwin/itwinui-variables';
@@ -30,9 +26,9 @@ import '@itwin/itwinui-variables';
 > @import '@itwin/itwinui-variables/index.css';
 > ```
 
-Add the `iui-root` class to the top of your app.
+Specify a theme ("light" or "dark") by adding a `data-iui-theme` attribute to the top of your app.
 ```html
-<body class="iui-root">
+<body data-iui-theme="light">
   <!-- your application code -->
 </body>
 ```
@@ -47,24 +43,22 @@ button {
 }
 ```
 
-By default, the variables use light theme. You can switch to dark theme using `data-iui-theme` in your HTML.
+You can also specify `data-iui-contrast` to switch to a high contrast version of the current theme.
 
 ```html
-<body class="iui-root" data-iui-theme="dark">
+<body data-iui-theme="dark" data-iui-contrast="high">
   <!-- your application code -->
 </body>
 ```
 
-You can also specify `data-iui-contrast` to switch to a high contrast theme.
-
-```html
-<body class="iui-root" data-iui-theme="dark" data-iui-contrast="high">
-  <!-- your application code -->
-</body>
-```
-
-If you want the variables to automatically respect the user preferences (color-scheme and contrast), then additionally import `os.css`:
+If you want the variables to automatically respect the user preferences (`prefers-color-scheme` and `prefers-contrast`), then you need to additionally import `os.css`, and use `data-iui-theme` without a value. For example:
 
 ```css
+@import '@itwin/itwinui-variables';
 @import '@itwin/itwinui-variables/os.css';
+```
+```html
+<body data-iui-theme>
+  <!-- your application code -->
+</body>
 ```

--- a/packages/itwinui-variables/src/index.scss
+++ b/packages/itwinui-variables/src/index.scss
@@ -8,7 +8,7 @@
 @use './colors';
 
 // global vars shared between all themes
-:where(.iui-root) {
+:where([data-iui-theme]) {
   @include spacing;
   @include component-heights;
   @include border-radii;
@@ -19,10 +19,7 @@
   @include colors.unthemed;
 }
 
-:where(
-.iui-root, // default to light theme on root if data attribute not set
-.iui-root[data-iui-theme='light']
-) {
+:where([data-iui-theme='light']) {
   @include themes.light-theme;
 
   &:where([data-iui-contrast='high']) {
@@ -30,7 +27,7 @@
   }
 }
 
-:where(.iui-root[data-iui-theme='dark']) {
+:where([data-iui-theme='dark']) {
   @include themes.dark-theme;
 
   &:where([data-iui-contrast='high']) {

--- a/packages/itwinui-variables/src/os.scss
+++ b/packages/itwinui-variables/src/os.scss
@@ -3,7 +3,7 @@
 @use './themes/index' as themes;
 @use './colors';
 
-.iui-root {
+:where([data-iui-theme]) {
   @media (prefers-color-scheme: dark) {
     @include themes.dark-theme;
   }

--- a/scripts/createComponent.js
+++ b/scripts/createComponent.js
@@ -231,7 +231,7 @@ const demoHtmlFactory = (directory, componentName) => {
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
     </style>
   </head>
-  <body class="iui-root">
+  <body class="iui-root" data-iui-theme>
     <theme-button></theme-button>
     <h1>${componentName}</h1>
     <hr />


### PR DESCRIPTION
## Changes

Removed `iui-root` class from variables because the class will change between major versions, whereas the data attribute won't.

This change will help iTwinUI-variables v3 to be compatible with components from iTwinUI-react v2, v3, v4.

## Testing

Visited portal, html pages, storybook, docs site. Everything looks the same as before. All existing tests pass.

## Docs

added changeset.
