### PR TITLE
set global focus styling

### DIFF
--- a/.changeset/few-ghosts-judge.md
+++ b/.changeset/few-ghosts-judge.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-variables': major
+---
+
+`iui-root` has been removed. `data-iui-theme` must now always be set in order to use variables.

--- a/.changeset/nervous-birds-shake.md
+++ b/.changeset/nervous-birds-shake.md
@@ -1,6 +1,6 @@
 ---
 '@itwin/itwinui-react': patch
-'@itwin/itwinui-varoan;es': patch
+'@itwin/itwinui-variables': patch
 ---
 
 The `color-scheme` property will now be correctly set for dark theme, resulting in better theming of built-in html elements.

--- a/.changeset/nervous-birds-shake.md
+++ b/.changeset/nervous-birds-shake.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-varoan;es': patch
+---
+
+The `color-scheme` property will now be correctly set for dark theme, resulting in better theming of built-in html elements.

--- a/apps/portal/src/pages/index.astro
+++ b/apps/portal/src/pages/index.astro
@@ -32,7 +32,7 @@ const links = [
     </style>
   </head>
 
-  <body data-iui-theme>
+  <body class='iui-root' data-iui-theme>
     <h1 class='iui-text-title'>
       <span class='iui-visually-hidden'>iTwinUI</span>{titleSuffix}
     </h1>

--- a/apps/portal/src/pages/index.astro
+++ b/apps/portal/src/pages/index.astro
@@ -32,7 +32,7 @@ const links = [
     </style>
   </head>
 
-  <body class='iui-root'>
+  <body data-iui-theme>
     <h1 class='iui-text-title'>
       <span class='iui-visually-hidden'>iTwinUI</span>{titleSuffix}
     </h1>

--- a/apps/website/src/components/variables/_wrapper.astro
+++ b/apps/website/src/components/variables/_wrapper.astro
@@ -1,10 +1,8 @@
 ---
 import '@itwin/itwinui-variables';
-
-const { class: className, ...props } = Astro.props;
 ---
 
-<article {...props} data-iui-theme='dark' class:list={['iui-root', className]}>
+<article data-iui-theme='dark' {...Astro.props}>
   <slot />
 </article>
 

--- a/apps/website/src/pages/_global.astro
+++ b/apps/website/src/pages/_global.astro
@@ -236,7 +236,7 @@ const { content = {} } = Astro.props;
     </style>
   </head>
 
-  <body class='_iui3-root' data-iui-theme='dark'>
+  <body data-iui-theme='dark'>
     <slot />
 
     <!-- Util classes/styles and scripts -->

--- a/packages/itwinui-css/backstop/tests/index.html
+++ b/packages/itwinui-css/backstop/tests/index.html
@@ -104,7 +104,10 @@
   </style>
   </head>
 
-  <body class="iui-root">
+  <body
+    class="iui-root"
+    data-iui-theme
+  >
     <a
       href="https://github.com/iTwin/iTwinUI"
       class="github-corner"

--- a/packages/itwinui-variables/README.md
+++ b/packages/itwinui-variables/README.md
@@ -6,10 +6,6 @@
 npm install @itwin/itwinui-variables
 ```
 
-```console
-yarn add @itwin/itwinui-variables
-```
-
 ## Usage
 
 Import in CSS:
@@ -18,7 +14,7 @@ Import in CSS:
 @import '@itwin/itwinui-variables';
 ```
 
-Or in JS:
+Or in JS (if using a bundler):
 
 ```js
 import '@itwin/itwinui-variables';
@@ -30,9 +26,9 @@ import '@itwin/itwinui-variables';
 > @import '@itwin/itwinui-variables/index.css';
 > ```
 
-Add the `iui-root` class to the top of your app.
+Specify a theme ("light" or "dark") by adding a `data-iui-theme` attribute to the top of your app.
 ```html
-<body class="iui-root">
+<body data-iui-theme="light">
   <!-- your application code -->
 </body>
 ```
@@ -47,24 +43,22 @@ button {
 }
 ```
 
-By default, the variables use light theme. You can switch to dark theme using `data-iui-theme` in your HTML.
+You can also specify `data-iui-contrast` to switch to a high contrast version of the current theme.
 
 ```html
-<body class="iui-root" data-iui-theme="dark">
+<body data-iui-theme="dark" data-iui-contrast="high">
   <!-- your application code -->
 </body>
 ```
 
-You can also specify `data-iui-contrast` to switch to a high contrast theme.
-
-```html
-<body class="iui-root" data-iui-theme="dark" data-iui-contrast="high">
-  <!-- your application code -->
-</body>
-```
-
-If you want the variables to automatically respect the user preferences (color-scheme and contrast), then additionally import `os.css`:
+If you want the variables to automatically respect the user preferences (`prefers-color-scheme` and `prefers-contrast`), then you need to additionally import `os.css`, and use `data-iui-theme` without a value. For example:
 
 ```css
+@import '@itwin/itwinui-variables';
 @import '@itwin/itwinui-variables/os.css';
+```
+```html
+<body data-iui-theme>
+  <!-- your application code -->
+</body>
 ```

--- a/packages/itwinui-variables/src/index.scss
+++ b/packages/itwinui-variables/src/index.scss
@@ -8,7 +8,7 @@
 @use './colors';
 
 // global vars shared between all themes
-:where(.iui-root) {
+:where([data-iui-theme]) {
   @include spacing;
   @include component-heights;
   @include border-radii;
@@ -19,10 +19,7 @@
   @include colors.unthemed;
 }
 
-:where(
-.iui-root, // default to light theme on root if data attribute not set
-.iui-root[data-iui-theme='light']
-) {
+:where([data-iui-theme='light']) {
   @include themes.light-theme;
 
   &:where([data-iui-contrast='high']) {
@@ -30,7 +27,7 @@
   }
 }
 
-:where(.iui-root[data-iui-theme='dark']) {
+:where([data-iui-theme='dark']) {
   @include themes.dark-theme;
 
   &:where([data-iui-contrast='high']) {

--- a/packages/itwinui-variables/src/index.scss
+++ b/packages/itwinui-variables/src/index.scss
@@ -9,6 +9,7 @@
 
 // global vars shared between all themes
 :where([data-iui-theme]) {
+  color-scheme: light dark;
   @include spacing;
   @include component-heights;
   @include border-radii;
@@ -20,6 +21,7 @@
 }
 
 :where([data-iui-theme='light']) {
+  color-scheme: light;
   @include themes.light-theme;
 
   &:where([data-iui-contrast='high']) {
@@ -28,6 +30,7 @@
 }
 
 :where([data-iui-theme='dark']) {
+  color-scheme: dark;
   @include themes.dark-theme;
 
   &:where([data-iui-contrast='high']) {

--- a/packages/itwinui-variables/src/os.scss
+++ b/packages/itwinui-variables/src/os.scss
@@ -3,7 +3,7 @@
 @use './themes/index' as themes;
 @use './colors';
 
-.iui-root {
+:where([data-iui-theme]) {
   @media (prefers-color-scheme: dark) {
     @include themes.dark-theme;
   }


### PR DESCRIPTION
## Changes

Added a simple focus outline to all elements under `iui-root`. This will help third-party elements feel more consistent with the design system, and it will also be more accessible because the default browser focus styling can often be questionable.

## Testing

TBD

## Docs

added changeset