### PR TITLE
set global focus styling

### DIFF
--- a/.changeset/spicy-houses-join.md
+++ b/.changeset/spicy-houses-join.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': minor
+'@itwin/itwinui-css': minor
+---
+
+All elements under the root will now get a default focus styling matching `--iui-color-border-accent`.

--- a/packages/itwinui-css/src/global.scss
+++ b/packages/itwinui-css/src/global.scss
@@ -30,4 +30,8 @@
   &::after {
     box-sizing: border-box;
   }
+
+  &:where(:focus-visible) {
+    outline: 2px solid var(--iui-color-border-accent);
+  }
 }


### PR DESCRIPTION
## Changes

Added a simple focus outline to all elements under `iui-root`. This will help third-party elements feel more consistent with the design system, and it will also be more accessible because the default browser focus styling can often be questionable.

## Testing

TBD

## Docs

added changeset