### PR TITLE
remove deprecated `UserIcon`

### DIFF
--- a/.changeset/nasty-walls-juggle.md
+++ b/.changeset/nasty-walls-juggle.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': major
+---
+
+Removed previously-deprecated `UserIcon` and `UserIconGroup` components. Also removed `userIcon` prop from `Header`.

--- a/packages/itwinui-react/src/core/Avatar/Avatar.tsx
+++ b/packages/itwinui-react/src/core/Avatar/Avatar.tsx
@@ -115,9 +115,4 @@ export const Avatar = React.forwardRef((props, ref) => {
   );
 }) as PolymorphicForwardRefComponent<'span', AvatarProps>;
 
-/**
- * @deprecated Since v2, this has been renamed to `Avatar`
- */
-export const UserIcon = Avatar;
-
 export default Avatar;

--- a/packages/itwinui-react/src/core/Avatar/index.ts
+++ b/packages/itwinui-react/src/core/Avatar/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { Avatar, UserIcon } from './Avatar.js';
+export { Avatar } from './Avatar.js';
 export default './Avatar';

--- a/packages/itwinui-react/src/core/AvatarGroup/AvatarGroup.tsx
+++ b/packages/itwinui-react/src/core/AvatarGroup/AvatarGroup.tsx
@@ -129,9 +129,4 @@ export const AvatarGroup = React.forwardRef((props, ref) => {
   );
 }) as PolymorphicForwardRefComponent<'div', AvatarGroupProps>;
 
-/**
- * @deprecated Since v2, this has been renamed to `AvatarGroup`
- */
-export const UserIconGroup = AvatarGroup;
-
 export default AvatarGroup;

--- a/packages/itwinui-react/src/core/AvatarGroup/index.ts
+++ b/packages/itwinui-react/src/core/AvatarGroup/index.ts
@@ -2,5 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { AvatarGroup, UserIconGroup } from './AvatarGroup.js';
+export { AvatarGroup } from './AvatarGroup.js';
 export default './AvatarGroup';

--- a/packages/itwinui-react/src/core/Header/Header.tsx
+++ b/packages/itwinui-react/src/core/Header/Header.tsx
@@ -37,11 +37,8 @@ type HeaderProps = {
   breadcrumbs?: React.ReactNode;
   /**
    * Content displayed to the left of the `menuItems`
-   * (expects array of `IconButton`, potentially wrapped in a `DropdownMenu`)
+   * (expects array of icons/avatars wrapped in `IconButton` and/or `DropdownMenu`).
    *
-   * Since v2, `userIcon` is deprecated.
-   * The new recommendation is to add `Avatar` (Called `UserIcon` before v2) to the end of `actions`.
-   * `Avatar` can be wrapped in `IconButton` and `DropdownMenu` if needed.
    * @example
    * [
    *  <IconButton><SvgNotification /></IconButton>,
@@ -62,22 +59,6 @@ type HeaderProps = {
    * Children is put in the center of the Header.
    */
   children?: React.ReactNode;
-  /**
-   * @deprecated Since v2, add your `UserIcon` (called `Avatar` since v2) to the end of `actions` itself
-   *
-   * User icon
-   *
-   * It's size and transition will be handled between slim/not slim state of the
-   * Header
-   * (expects `UserIcon`, can be wrapped in `IconButton` and `DropdownMenu` if needed)
-   * @example
-   * <DropdownMenu menuItems={...}>
-   *   <IconButton styleType='borderless'>
-   *     <UserIcon ... />
-   *   </IconButton>
-   * </DropdownMenu>
-   */
-  userIcon?: React.ReactNode;
   /**
    * Items in the more dropdown menu.
    * Pass a function that takes the `close` argument (to close the menu),
@@ -132,7 +113,6 @@ export const Header = React.forwardRef((props, forwardedRef) => {
     breadcrumbs,
     isSlim = false,
     actions,
-    userIcon,
     menuItems,
     translatedStrings,
     className,
@@ -157,7 +137,6 @@ export const Header = React.forwardRef((props, forwardedRef) => {
       {children && <Box className='iui-page-header-center'>{children}</Box>}
       <Box className='iui-page-header-right'>
         {actions}
-        {userIcon}
         {menuItems && (
           <DropdownMenu menuItems={menuItems}>
             <IconButton

--- a/packages/itwinui-react/src/core/index.ts
+++ b/packages/itwinui-react/src/core/index.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 export { Alert } from './Alert/index.js';
 
-export { Avatar, UserIcon } from './Avatar/index.js';
+export { Avatar } from './Avatar/index.js';
 
-export { AvatarGroup, UserIconGroup } from './AvatarGroup/index.js';
+export { AvatarGroup } from './AvatarGroup/index.js';
 
 export { Backdrop } from './Backdrop/index.js';
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

yeet

## Testing

N/A

## Docs

added changeset.

updated migration guide. https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v3-migration-guide#usericon--usericongroup