### PR TITLE
retry `yarn` on windows if failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,13 @@ jobs:
             playgrounds/*/node_modules
           key: modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
-      - if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: yarn
+      - name: yarn
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: yarn
 
   audit:
     name: Audit node modules


### PR DESCRIPTION
## Changes

For some reason, the install job on windows keeps randomly failing everytime the lockfile changes, so now it will be retried upto 3 times.

## Testing

N/A

## Docs

N/A