### PR TITLE
remove deprecated `HorizontalTabs`/`VerticalTabs`

### DIFF
--- a/.changeset/violet-laws-stare.md
+++ b/.changeset/violet-laws-stare.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': major
+---
+
+Removed deprecated `HorizontalTabs` and `VerticalTabs` (replaced by `orientation` prop in `Tabs`).

--- a/packages/itwinui-react/src/core/Tabs/Tabs.tsx
+++ b/packages/itwinui-react/src/core/Tabs/Tabs.tsx
@@ -130,18 +130,6 @@ export type TabsProps = {
   TabsOverflowProps;
 
 /**
- * @deprecated Since v2, use `TabProps` with `Tabs`
- */
-type HorizontalTabsProps = Omit<TabsProps, 'orientation'>;
-
-/**
- * @deprecated Since v2, use `TabProps` with `Tabs`
- */
-type VerticalTabsProps = Omit<TabsProps, 'orientation' | 'type'> & {
-  type?: 'default' | 'borderless';
-};
-
-/**
  * Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
  * @example
  * const tabs = [
@@ -618,37 +606,5 @@ export const Tabs = (props: TabsProps) => {
     </Box>
   );
 };
-
-/**
- * @deprecated Since v2, directly use `Tabs` with `orientation: 'horizontal'`
- *
- * Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
- * @example
- * const tabs = [
- *   <Tab label='Label 1' sublabel='First tab' />,
- *   <Tab label='Label 2' sublabel='Active tab' />,
- *   <Tab label='Label 3' sublabel='Disabled tab' disabled icon={<SvgPlaceholder />} />,
- * ];
- * <HorizontalTabs labels={tabs} activeIndex={1}>Tabpanel content</HorizontalTabs>
- */
-export const HorizontalTabs = (props: HorizontalTabsProps) => (
-  <Tabs orientation='horizontal' {...props} />
-);
-
-/**
- * @deprecated Since v2, directly use `Tabs` with `orientation: 'vertical'`
- *
- * Tabs organize and allow navigation between groups of content that are related and at the same level of hierarchy.
- * @example
- * const tabs = [
- *   <Tab label='Label 1' sublabel='First tab' />,
- *   <Tab label='Label 2' sublabel='Active tab' />,
- *   <Tab label='Label 3' sublabel='Disabled tab' disabled icon={<SvgPlaceholder />} />,
- * ];
- * <VerticalTabs labels={tabs} activeIndex={1}>Tabpanel content</VerticalTabs>
- */
-export const VerticalTabs = (props: VerticalTabsProps) => (
-  <Tabs orientation='vertical' {...props} />
-);
 
 export default Tabs;

--- a/packages/itwinui-react/src/core/Tabs/index.ts
+++ b/packages/itwinui-react/src/core/Tabs/index.ts
@@ -2,6 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export { Tabs, VerticalTabs, HorizontalTabs } from './Tabs.js';
+export { Tabs } from './Tabs.js';
 
 export { Tab } from './Tab.js';

--- a/packages/itwinui-react/src/core/index.ts
+++ b/packages/itwinui-react/src/core/index.ts
@@ -75,7 +75,7 @@ export { List, ListItem } from './List/index.js';
 
 export { TransferList } from './TransferList/index.js';
 
-export { VerticalTabs, Tabs, Tab, HorizontalTabs } from './Tabs/index.js';
+export { Tabs, Tab } from './Tabs/index.js';
 
 export {
   InformationPanel,


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

yeet

## Testing

N/A

## Docs

Added changeset and updated [migration guide](https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v3-migration-guide#tabs).