### PR TITLE
button group a11y compliance

### DIFF
--- a/.changeset/ten-grapes-approve.md
+++ b/.changeset/ten-grapes-approve.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Orientation attribute removed from ButtonGroup to meet a11y accessibility requirements.
+`aria-orientation` attribute removed from ButtonGroup to meet accessibility requirements.

--- a/.changeset/ten-grapes-approve.md
+++ b/.changeset/ten-grapes-approve.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Orientation attribute removed from ButtonGroup to meet a11y accessibility requirements.

--- a/examples/ButtonGroup.input.tsx
+++ b/examples/ButtonGroup.input.tsx
@@ -18,7 +18,7 @@ export default () => {
       <ButtonGroup>
         <Button>Button 1</Button>
         <Input />
-        <IconButton>
+        <IconButton label='search'>
           <SvgSearch />
         </IconButton>
       </ButtonGroup>

--- a/examples/ButtonGroup.input.tsx
+++ b/examples/ButtonGroup.input.tsx
@@ -17,13 +17,16 @@ export default () => {
     <Flex flexDirection='column' gap='m'>
       <ButtonGroup>
         <Button>Button 1</Button>
-        <Input />
+        <Input aria-label='search bar' />
         <IconButton label='search'>
           <SvgSearch />
         </IconButton>
       </ButtonGroup>
       <ButtonGroup>
-        <Input value='https://itwinui.bentley.com/docs/buttongroup' />
+        <Input
+          aria-label='input text bar'
+          value='https://itwinui.bentley.com/docs/buttongroup'
+        />
         <Button styleType='high-visibility'>Copy</Button>
       </ButtonGroup>
     </Flex>

--- a/examples/ButtonGroup.input.tsx
+++ b/examples/ButtonGroup.input.tsx
@@ -17,14 +17,14 @@ export default () => {
     <Flex flexDirection='column' gap='m'>
       <ButtonGroup>
         <Button>Button 1</Button>
-        <Input aria-label='search bar' />
-        <IconButton label='search'>
+        <Input aria-label='Search bar' />
+        <IconButton label='Search'>
           <SvgSearch />
         </IconButton>
       </ButtonGroup>
       <ButtonGroup>
         <Input
-          aria-label='input text bar'
+          aria-label='URL'
           value='https://itwinui.bentley.com/docs/buttongroup'
         />
         <Button styleType='high-visibility'>Copy</Button>

--- a/examples/ButtonGroup.main.tsx
+++ b/examples/ButtonGroup.main.tsx
@@ -14,16 +14,16 @@ import {
 export default () => {
   return (
     <ButtonGroup>
-      <IconButton onClick={() => {}} label='add'>
+      <IconButton onClick={() => {}} label='Add'>
         <SvgAdd />
       </IconButton>
-      <IconButton onClick={() => {}} label='edit' isActive>
+      <IconButton onClick={() => {}} label='Edit' isActive>
         <SvgEdit />
       </IconButton>
-      <IconButton disabled onClick={() => {}} label='delete'>
+      <IconButton disabled onClick={() => {}} label='Delete'>
         <SvgDelete />
       </IconButton>
-      <IconButton onClick={() => {}} label='undo'>
+      <IconButton onClick={() => {}} label='Undo'>
         <SvgUndo />
       </IconButton>
     </ButtonGroup>

--- a/examples/ButtonGroup.main.tsx
+++ b/examples/ButtonGroup.main.tsx
@@ -14,16 +14,16 @@ import {
 export default () => {
   return (
     <ButtonGroup>
-      <IconButton onClick={() => {}}>
+      <IconButton onClick={() => {}} aria-label='add'>
         <SvgAdd />
       </IconButton>
-      <IconButton onClick={() => {}} isActive>
+      <IconButton onClick={() => {}} aria-label='edit' isActive>
         <SvgEdit />
       </IconButton>
-      <IconButton disabled onClick={() => {}}>
+      <IconButton disabled onClick={() => {}} aria-label='delete'>
         <SvgDelete />
       </IconButton>
-      <IconButton onClick={() => {}}>
+      <IconButton onClick={() => {}} aria-label='undo'>
         <SvgUndo />
       </IconButton>
     </ButtonGroup>

--- a/examples/ButtonGroup.main.tsx
+++ b/examples/ButtonGroup.main.tsx
@@ -14,16 +14,16 @@ import {
 export default () => {
   return (
     <ButtonGroup>
-      <IconButton onClick={() => {}} aria-label='add'>
+      <IconButton onClick={() => {}} label='add'>
         <SvgAdd />
       </IconButton>
-      <IconButton onClick={() => {}} aria-label='edit' isActive>
+      <IconButton onClick={() => {}} label='edit' isActive>
         <SvgEdit />
       </IconButton>
-      <IconButton disabled onClick={() => {}} aria-label='delete'>
+      <IconButton disabled onClick={() => {}} label='delete'>
         <SvgDelete />
       </IconButton>
-      <IconButton onClick={() => {}} aria-label='undo'>
+      <IconButton onClick={() => {}} label='undo'>
         <SvgUndo />
       </IconButton>
     </ButtonGroup>

--- a/examples/ButtonGroup.overflow.tsx
+++ b/examples/ButtonGroup.overflow.tsx
@@ -47,7 +47,7 @@ export default () => {
                 })
             }
           >
-            <IconButton label='more'>
+            <IconButton label='More'>
               <SvgMore />
             </IconButton>
           </DropdownMenu>

--- a/examples/ButtonGroup.overflow.tsx
+++ b/examples/ButtonGroup.overflow.tsx
@@ -16,7 +16,7 @@ export default () => {
     .fill(null)
     .map((_, _index) => {
       return (
-        <IconButton>
+        <IconButton label='placeholder'>
           <SvgPlaceholder />
         </IconButton>
       );
@@ -47,7 +47,7 @@ export default () => {
                 })
             }
           >
-            <IconButton>
+            <IconButton label='more'>
               <SvgMore />
             </IconButton>
           </DropdownMenu>

--- a/examples/ButtonGroup.overflow.tsx
+++ b/examples/ButtonGroup.overflow.tsx
@@ -16,7 +16,7 @@ export default () => {
     .fill(null)
     .map((_, _index) => {
       return (
-        <IconButton label='placeholder'>
+        <IconButton label='Placeholder'>
           <SvgPlaceholder />
         </IconButton>
       );

--- a/examples/ButtonGroup.usage.tsx
+++ b/examples/ButtonGroup.usage.tsx
@@ -20,22 +20,22 @@ export default () => {
         New
       </Button>
       <ButtonGroup>
-        <IconButton>
+        <IconButton label='edit'>
           <SvgEdit />
         </IconButton>
-        <IconButton disabled>
+        <IconButton disabled label='delete'>
           <SvgDelete />
         </IconButton>
-        <IconButton>
+        <IconButton label='undo'>
           <SvgUndo />
         </IconButton>
       </ButtonGroup>
       <Flex.Spacer />
       <ButtonGroup>
-        <IconButton isActive>
+        <IconButton isActive label='filter'>
           <SvgFilter />
         </IconButton>
-        <IconButton>
+        <IconButton label='search'>
           <SvgSearch />
         </IconButton>
       </ButtonGroup>

--- a/examples/ButtonGroup.usage.tsx
+++ b/examples/ButtonGroup.usage.tsx
@@ -20,22 +20,22 @@ export default () => {
         New
       </Button>
       <ButtonGroup>
-        <IconButton label='edit'>
+        <IconButton label='Edit'>
           <SvgEdit />
         </IconButton>
-        <IconButton disabled label='delete'>
+        <IconButton disabled label='Delete'>
           <SvgDelete />
         </IconButton>
-        <IconButton label='undo'>
+        <IconButton label='Undo'>
           <SvgUndo />
         </IconButton>
       </ButtonGroup>
       <Flex.Spacer />
       <ButtonGroup>
-        <IconButton isActive label='filter'>
+        <IconButton isActive label='Filter'>
           <SvgFilter />
         </IconButton>
-        <IconButton label='search'>
+        <IconButton label='Search'>
           <SvgSearch />
         </IconButton>
       </ButtonGroup>

--- a/examples/ButtonGroup.vertical.tsx
+++ b/examples/ButtonGroup.vertical.tsx
@@ -14,16 +14,16 @@ import {
 export default () => {
   return (
     <ButtonGroup orientation='vertical'>
-      <IconButton onClick={() => {}}>
+      <IconButton onClick={() => {}} label='add'>
         <SvgAdd />
       </IconButton>
-      <IconButton onClick={() => {}} isActive>
+      <IconButton onClick={() => {}} label='edit' isActive>
         <SvgEdit />
       </IconButton>
-      <IconButton disabled onClick={() => {}}>
+      <IconButton disabled onClick={() => {}} label='delete'>
         <SvgDelete />
       </IconButton>
-      <IconButton onClick={() => {}}>
+      <IconButton onClick={() => {}} label='undo'>
         <SvgUndo />
       </IconButton>
     </ButtonGroup>

--- a/examples/ButtonGroup.vertical.tsx
+++ b/examples/ButtonGroup.vertical.tsx
@@ -14,16 +14,16 @@ import {
 export default () => {
   return (
     <ButtonGroup orientation='vertical'>
-      <IconButton onClick={() => {}} label='add'>
+      <IconButton onClick={() => {}} label='Add'>
         <SvgAdd />
       </IconButton>
-      <IconButton onClick={() => {}} label='edit' isActive>
+      <IconButton onClick={() => {}} label='Edit' isActive>
         <SvgEdit />
       </IconButton>
-      <IconButton disabled onClick={() => {}} label='delete'>
+      <IconButton disabled onClick={() => {}} label='Delete'>
         <SvgDelete />
       </IconButton>
-      <IconButton onClick={() => {}} label='undo'>
+      <IconButton onClick={() => {}} label='Undo'>
         <SvgUndo />
       </IconButton>
     </ButtonGroup>

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -99,6 +99,7 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
         className,
       )}
       aria-orientation={orientation}
+      aria-role='toolbar'
       ref={refs}
       {...rest}
     >

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -98,8 +98,6 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
         },
         className,
       )}
-      aria-orientation={orientation}
-      aria-role='toolbar'
       ref={refs}
       {...rest}
     >


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Bringing `ButtonGroup` examples to a11y compliance. `ButtonGroup` component brought to compliance by removing `aria-orientation` attribute .


<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Unit testing & visual testing will be conducted. 

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

TBD
