### PR TITLE
Removing setFocus from components

### DIFF
--- a/.changeset/two-poems-sing.md
+++ b/.changeset/two-poems-sing.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': major
+---
+
+Removed `setFocus` prop from Checkbox, ColorPicker, ComboBox, Input, LabeledInput, LabeledTextarea, Radio, RadioTile, Select, Slider, ToggleSwitch. Users can use `ref` to focus the element.

--- a/apps/storybook/src/Breadcrumbs.stories.tsx
+++ b/apps/storybook/src/Breadcrumbs.stories.tsx
@@ -259,7 +259,6 @@ export const FolderNavigation: Story<BreadcrumbsProps> = (args) => {
       />
       {isEditing ? (
         <Input
-          setFocus
           defaultValue={items.slice(0, lastIndex + 1).join('/')}
           onChange={({ target: { value } }) => {
             const lastItem = value.substring(

--- a/apps/storybook/src/Slider.stories.tsx
+++ b/apps/storybook/src/Slider.stories.tsx
@@ -146,7 +146,6 @@ CustomTooltip.args = {
   tooltipProps: (index, val) => {
     return { placement: 'right', content: `\$${val}.00` };
   },
-  setFocus: true,
 };
 
 export const CustomTickNoTooltip: Story<SliderProps> = (args) => {

--- a/apps/storybook/src/Slider.test.ts
+++ b/apps/storybook/src/Slider.test.ts
@@ -20,6 +20,9 @@ describe('Slider', () => {
     it(testName, function () {
       const id = Cypress.storyId(storyPath, testName);
       cy.visit('iframe', { qs: { id } });
+      if (testName === 'Custom Tooltip') {
+        cy.get('[role=slider').focus();
+      }
       cy.compareSnapshot(testName);
     });
   });

--- a/examples/Breadcrumbs.folder.tsx
+++ b/examples/Breadcrumbs.folder.tsx
@@ -63,7 +63,6 @@ export default () => {
       />
       {isEditing ? (
         <Input
-          setFocus
           defaultValue={items.slice(0, lastIndex + 1).join('/')}
           onChange={({ target: { value } }) => {
             const lastItem = value.substring(

--- a/packages/itwinui-react/src/core/Checkbox/Checkbox.test.tsx
+++ b/packages/itwinui-react/src/core/Checkbox/Checkbox.test.tsx
@@ -108,22 +108,6 @@ it('renders negative component', () => {
   ).toBeTruthy();
 });
 
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container } = render(
-    <Checkbox label='Some checkbox' ref={onRef} setFocus />,
-  );
-
-  assertBaseElements(container);
-
-  screen.getByText('Some checkbox');
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});
-
 it('displays a spinner when isLoading is set to true', () => {
   const { container } = render(<Checkbox label='Some checkbox' isLoading />);
 

--- a/packages/itwinui-react/src/core/Checkbox/Checkbox.tsx
+++ b/packages/itwinui-react/src/core/Checkbox/Checkbox.tsx
@@ -28,10 +28,6 @@ type CheckboxProps = {
    */
   variant?: 'default' | 'eyeball';
   /**
-   * Set focus on checkbox.
-   */
-  setFocus?: boolean;
-  /**
    * Display a loading state.
    * @default false
    */
@@ -66,7 +62,6 @@ export const Checkbox = React.forwardRef((props, ref) => {
     label,
     status,
     variant = 'default',
-    setFocus,
     isLoading = false,
     wrapperProps = {},
     labelProps = {},
@@ -76,12 +71,6 @@ export const Checkbox = React.forwardRef((props, ref) => {
 
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const refs = useMergedRefs<HTMLInputElement>(inputElementRef, ref);
-
-  React.useEffect(() => {
-    if (inputElementRef.current && setFocus) {
-      inputElementRef.current.focus();
-    }
-  }, [setFocus]);
 
   React.useEffect(() => {
     if (inputElementRef.current) {

--- a/packages/itwinui-react/src/core/ColorPicker/ColorPicker.test.tsx
+++ b/packages/itwinui-react/src/core/ColorPicker/ColorPicker.test.tsx
@@ -438,26 +438,6 @@ it('should preserve hue when color dot is black/at bottom of square', () => {
   );
 });
 
-it('should set focus if setFocus is true', () => {
-  const { container } = render(
-    <ColorPicker setFocus>
-      <ColorBuilder />
-    </ColorPicker>,
-  );
-  expect(container.querySelector('.iui-color-picker')).toBeTruthy();
-  expect(container.querySelector('.iui-color-dot')).toHaveFocus(); // first tabbable element
-});
-
-it('should not set focus if setFocus is false', () => {
-  const { container } = render(
-    <ColorPicker>
-      <ColorBuilder />
-    </ColorPicker>,
-  );
-  expect(container.querySelector('.iui-color-picker')).toBeTruthy();
-  expect(container.querySelector('.iui-color-dot')).not.toHaveFocus();
-});
-
 it('should render advanced color picker with opacity slider', () => {
   const { container } = render(
     <ColorPicker showAlpha={true}>

--- a/packages/itwinui-react/src/core/ColorPicker/ColorPicker.tsx
+++ b/packages/itwinui-react/src/core/ColorPicker/ColorPicker.tsx
@@ -3,12 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import {
-  ColorValue,
-  getTabbableElements,
-  useMergedRefs,
-  Box,
-} from '../utils/index.js';
+import { ColorValue, useMergedRefs, Box } from '../utils/index.js';
 import type {
   ColorType,
   HsvColor,
@@ -48,11 +43,6 @@ type ColorPickerProps = {
    */
   onChangeComplete?: (color: ColorValue) => void;
   /**
-   * If true, the first focusable element in the color picker will automatically be focused.
-   * @default false
-   */
-  setFocus?: boolean;
-  /**
    * If true, ColorBuilder will show the alpha slider and ColorInputPanel will show an alpha input.
    * @default false
    */
@@ -79,20 +69,11 @@ export const ColorPicker = React.forwardRef((props, forwardedRef) => {
     selectedColor,
     onChange,
     onChangeComplete,
-    setFocus = false,
     showAlpha = false,
     ...rest
   } = props;
 
   const ref = React.useRef<HTMLDivElement>(null);
-
-  // set focus on the first tabbable element
-  React.useEffect(() => {
-    if (ref.current && setFocus) {
-      const tabbableElements = getTabbableElements(ref.current);
-      (tabbableElements[0] as HTMLElement).focus();
-    }
-  }, [setFocus]);
 
   const inColor = React.useMemo(
     () => getColorValue(selectedColor),

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -101,7 +101,7 @@ export type ComboBoxProps<T> = {
   /**
    * Native input element props.
    */
-  inputProps?: Omit<React.ComponentProps<typeof Input>, 'setFocus'>;
+  inputProps?: React.ComponentProps<typeof Input>;
   /**
    * Props to customize dropdown menu behavior.
    */

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -9,8 +9,8 @@ import {
   useMergedRefs,
   useContainerWidth,
   mergeEventHandlers,
-  type PolymorphicForwardRefComponent,
 } from '../utils/index.js';
+import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { ComboBoxMultipleContainer } from './ComboBoxMultipleContainer.js';
 import {
   ComboBoxStateContext,

--- a/packages/itwinui-react/src/core/Input/Input.test.tsx
+++ b/packages/itwinui-react/src/core/Input/Input.test.tsx
@@ -24,17 +24,6 @@ it('should render disabled component', () => {
   );
 });
 
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container } = render(<Input ref={onRef} setFocus />);
-  assertBaseElement(container);
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});
-
 it('should take class and style', () => {
   const { container } = render(
     <Input className='my-class' style={{ width: 50 }} />,

--- a/packages/itwinui-react/src/core/Input/Input.tsx
+++ b/packages/itwinui-react/src/core/Input/Input.tsx
@@ -9,11 +9,6 @@ import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 
 export type InputProps = {
   /**
-   * Set focus on input element.
-   * @default false
-   */
-  setFocus?: boolean;
-  /**
    * Modify size of the input.
    */
   size?: 'small' | 'large';
@@ -27,15 +22,9 @@ export type InputProps = {
  * <Input size='small' />
  */
 export const Input = React.forwardRef((props, ref) => {
-  const { setFocus = false, size, className, ...rest } = props;
+  const { size, className, ...rest } = props;
   const inputRef = React.useRef<HTMLInputElement>(null);
   const refs = useMergedRefs<HTMLInputElement>(inputRef, ref);
-
-  React.useEffect(() => {
-    if (inputRef.current && setFocus) {
-      inputRef.current.focus();
-    }
-  }, [setFocus]);
 
   return (
     <Box

--- a/packages/itwinui-react/src/core/LabeledInput/LabeledInput.test.tsx
+++ b/packages/itwinui-react/src/core/LabeledInput/LabeledInput.test.tsx
@@ -74,20 +74,6 @@ it.each(['positive', 'negative', 'warning'] as const)(
   },
 );
 
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container, getByText } = render(
-    <LabeledInput label='some label' ref={onRef} setFocus />,
-  );
-  assertBaseElement(container);
-  getByText('some label');
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});
-
 it('should take class and style on container', () => {
   const { container, getByText } = render(
     <LabeledInput

--- a/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
+++ b/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { StatusIconMap, InputContainer, useId } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { Textarea } from '../Textarea/index.js';
-import type { TextareaProps } from '../Textarea/Textarea.js';
 import type { LabeledInputProps } from '../LabeledInput/LabeledInput.js';
 
 type LabeledTextareaProps = {
@@ -30,8 +29,7 @@ type LabeledTextareaProps = {
    * Custom style for textarea.
    */
   textareaStyle?: React.CSSProperties;
-} & Pick<LabeledInputProps, 'svgIcon' | 'displayStyle' | 'iconDisplayStyle'> &
-  TextareaProps;
+} & Pick<LabeledInputProps, 'svgIcon' | 'displayStyle' | 'iconDisplayStyle'>;
 
 /**
  * Textarea wrapper that allows for additional styling and labelling

--- a/packages/itwinui-react/src/core/Radio/Radio.test.tsx
+++ b/packages/itwinui-react/src/core/Radio/Radio.test.tsx
@@ -114,19 +114,3 @@ it.each(['label', 'input'] as const)(
     expect(container.querySelector(el)).toHaveClass('customClass');
   },
 );
-
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container } = render(
-    <Radio label='Some label' ref={onRef} setFocus />,
-  );
-
-  assertBaseElements(container);
-
-  screen.getByText('Some label');
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});

--- a/packages/itwinui-react/src/core/Radio/Radio.tsx
+++ b/packages/itwinui-react/src/core/Radio/Radio.tsx
@@ -17,11 +17,6 @@ type RadioProps = {
    * Status of the radio.
    */
   status?: 'positive' | 'warning' | 'negative';
-  /**
-   * Set focus on radio element.
-   * @default false
-   */
-  setFocus?: boolean;
 };
 
 /**
@@ -35,24 +30,10 @@ type RadioProps = {
  * <Radio status='negative' label='Negative' />
  */
 export const Radio = React.forwardRef((props, ref) => {
-  const {
-    className,
-    disabled = false,
-    label,
-    status,
-    style,
-    setFocus = false,
-    ...rest
-  } = props;
+  const { className, disabled = false, label, status, style, ...rest } = props;
 
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const refs = useMergedRefs<HTMLInputElement>(inputElementRef, ref);
-
-  React.useEffect(() => {
-    if (inputElementRef.current && setFocus) {
-      inputElementRef.current.focus();
-    }
-  }, [setFocus]);
 
   const radio = (
     <Box

--- a/packages/itwinui-react/src/core/RadioTiles/RadioTile.test.tsx
+++ b/packages/itwinui-react/src/core/RadioTiles/RadioTile.test.tsx
@@ -59,18 +59,3 @@ it('should take class and style', () => {
   expect(element).toBeTruthy();
   expect(element.style.width).toBe('80px');
 });
-
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container } = render(
-    <RadioTile label='Some label' ref={onRef} setFocus />,
-  );
-
-  expect(container.querySelector('.iui-radio-tile')).toBeTruthy();
-
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});

--- a/packages/itwinui-react/src/core/RadioTiles/RadioTile.tsx
+++ b/packages/itwinui-react/src/core/RadioTiles/RadioTile.tsx
@@ -20,11 +20,6 @@ type RadioTileProps = {
    * Additional description, if needed.
    */
   description?: React.ReactNode;
-  /**
-   * Set focus on radio tile element.
-   * @default false
-   */
-  setFocus?: boolean;
 };
 
 /**
@@ -33,24 +28,10 @@ type RadioTileProps = {
  * <RadioTile label='My tile' description='Some info' icon={<SvgSmileyHappy />} />
  */
 export const RadioTile = React.forwardRef((props, ref) => {
-  const {
-    icon,
-    label,
-    description,
-    setFocus = false,
-    className,
-    style,
-    ...rest
-  } = props;
+  const { icon, label, description, className, style, ...rest } = props;
 
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const refs = useMergedRefs<HTMLInputElement>(inputElementRef, ref);
-
-  React.useEffect(() => {
-    if (inputElementRef.current && setFocus) {
-      inputElementRef.current.focus();
-    }
-  }, [setFocus]);
 
   return (
     <Box as='label' className={cx('iui-radio-tile', className)} style={style}>

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -123,13 +123,14 @@ it('should render disabled select', async () => {
 
 it('should set focus on select and call onBlur', () => {
   const onBlur = jest.fn();
-  const { container } = renderComponent({ setFocus: true, onBlur });
+  const { container } = renderComponent({ onBlur });
 
   const select = container.querySelector('.iui-input-with-icon') as HTMLElement;
   assertSelect(select);
   const selectButton = container.querySelector(
     '.iui-select-button',
   ) as HTMLElement;
+  selectButton.focus();
   expect(selectButton).toBeTruthy();
   expect(selectButton.getAttribute('tabIndex')).toBe('0');
   expect(selectButton).toHaveFocus();

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -138,11 +138,6 @@ export type SelectProps<T> = {
    */
   size?: 'small' | 'large';
   /**
-   * Set focus on select.
-   * @default false
-   */
-  setFocus?: boolean;
-  /**
    * Custom renderer for an item in the dropdown list. `MenuItem` item props are going to be populated if not provided.
    */
   itemRenderer?: (
@@ -232,7 +227,6 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
     placeholder,
     disabled = false,
     size,
-    setFocus = false,
     itemRenderer,
     selectedItemRenderer,
     className,
@@ -272,12 +266,6 @@ export const Select = <T,>(props: SelectProps<T>): JSX.Element => {
     },
     [onHide],
   );
-
-  React.useEffect(() => {
-    if (selectRef.current && !disabled && setFocus) {
-      selectRef.current.focus();
-    }
-  }, [setFocus, disabled]);
 
   React.useEffect(() => {
     if (selectRef.current) {

--- a/packages/itwinui-react/src/core/Slider/Slider.test.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.test.tsx
@@ -146,52 +146,37 @@ it('should render provided min max label nodes', () => {
   expect(container.querySelector('.span-max')?.textContent).toBe('big');
 });
 
-it('should set focus', () => {
-  let element: HTMLDivElement | null = null;
-  const onRef = (ref: HTMLDivElement) => {
-    element = ref;
-  };
-  const { container } = render(
-    <Slider ref={onRef} values={defaultSingleValue} setFocus />,
-  );
+it('should show tooltip when focused', async () => {
+  const { container } = render(<Slider values={defaultSingleValue} />);
   assertBaseElement(container);
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(
-    container.querySelector('.iui-slider-thumb'),
-  );
-});
-
-it('should show tooltip when focused', () => {
-  const { container } = render(<Slider values={defaultSingleValue} setFocus />);
-  assertBaseElement(container);
+  await userEvent.tab();
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
   expect(document.querySelector('.iui-tooltip')?.textContent).toBe('50');
 });
 
-it('should not show tooltip if visibility is overridden', () => {
+it('should not show tooltip if visibility is overridden', async () => {
   const { container } = render(
     <Slider
       values={defaultSingleValue}
-      setFocus
       tooltipProps={() => {
         return { visible: false };
       }}
     />,
   );
   assertBaseElement(container);
+  await userEvent.tab();
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
   expect(document.querySelector('.iui-tooltip')).toBeFalsy();
 });
 
-it('should show custom tooltip when focused', () => {
+it('should show custom tooltip when focused', async () => {
   const { container } = render(
     <Slider
       values={defaultSingleValue}
-      setFocus
       tooltipProps={(index, val) => {
         return {
           content: `\$${val}.00`,
@@ -200,6 +185,7 @@ it('should show custom tooltip when focused', () => {
     />,
   );
   assertBaseElement(container);
+  await userEvent.tab();
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
@@ -313,14 +299,13 @@ it('should activate thumb on pointerDown', () => {
   expect(thumb.classList).toContain('iui-active');
 });
 
-it('should process keystrokes when thumb has focus', () => {
+it('should process keystrokes when thumb has focus', async () => {
   const handleOnUpdate = jest.fn();
   const handleOnChange = jest.fn();
   const { container } = render(
     <Slider
       values={[50]}
       step={5}
-      setFocus
       onUpdate={handleOnUpdate}
       onChange={handleOnChange}
     />,
@@ -329,6 +314,7 @@ it('should process keystrokes when thumb has focus', () => {
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
 
+  await userEvent.tab();
   expect(document.activeElement).toEqual(thumb);
   expect(thumb.getAttribute('aria-valuenow')).toEqual('50');
 
@@ -384,12 +370,12 @@ it('should process keystrokes when thumb has focus', () => {
   expect(handleOnChange).toHaveBeenCalledTimes(3);
 });
 
-it('should limit keystrokes processing to adjacent points by default', () => {
-  const { container } = render(<Slider values={[40, 80]} step={5} setFocus />);
+it('should limit keystrokes processing to adjacent points by default', async () => {
+  const { container } = render(<Slider values={[40, 80]} step={5} />);
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-
+  await userEvent.tab();
   expect(document.activeElement).toEqual(thumb);
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
 
@@ -414,13 +400,12 @@ it('should limit keystrokes processing to adjacent points by default', () => {
   expect(thumb.getAttribute('aria-valuenow')).toEqual('75');
 });
 
-it('should limit keystrokes processing by min max when allow-crossing is set', () => {
+it('should limit keystrokes processing by min max when allow-crossing is set', async () => {
   const handleOnChange = jest.fn();
   const { container } = render(
     <Slider
       values={[40, 80]}
       step={5}
-      setFocus
       thumbMode='allow-crossing'
       onChange={handleOnChange}
     />,
@@ -428,7 +413,7 @@ it('should limit keystrokes processing by min max when allow-crossing is set', (
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-
+  await userEvent.tab();
   expect(document.activeElement).toEqual(thumb);
   expect(thumb.getAttribute('aria-valuenow')).toEqual('40');
 

--- a/packages/itwinui-react/src/core/Slider/Slider.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.tsx
@@ -88,11 +88,6 @@ const focusThumb = (sliderContainer: HTMLDivElement, activeIndex: number) => {
 
 export type SliderProps = {
   /**
-   * Set focus on first thumb in slider element.
-   * @default false
-   */
-  setFocus?: boolean;
-  /**
    * Minimum slider value.
    * @default 0
    */
@@ -192,7 +187,7 @@ export type SliderProps = {
  * @example
  * <Slider values={[10]} min={0} max={60} disabled />
  * <Slider values={[10, 20]} min={0} max={50} step={2} />
- * <Slider values={[10, 20, 30, 40]} min={0} max={60} setFocus
+ * <Slider values={[10, 20, 30, 40]} min={0} max={60}
  *   thumbMode='allow-crossing' />
  */
 export const Slider = React.forwardRef((props, ref) => {
@@ -201,7 +196,6 @@ export const Slider = React.forwardRef((props, ref) => {
     max = 100,
     values,
     step = 1,
-    setFocus = false,
     tooltipProps,
     disabled = false,
     tickLabels,
@@ -245,12 +239,6 @@ export const Slider = React.forwardRef((props, ref) => {
   }, [trackDisplayMode, currentValues]);
 
   const containerRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    if (containerRef.current && setFocus) {
-      focusThumb(containerRef.current, 0);
-    }
-  }, [setFocus]);
 
   const getNumDecimalPlaces = React.useMemo(() => {
     const stepString = step.toString();

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
@@ -3,7 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Popover, SvgCalendar, isBefore } from '../../../utils/index.js';
+import {
+  Popover,
+  SvgCalendar,
+  isBefore,
+  type PolymorphicForwardRefComponent,
+} from '../../../utils/index.js';
 import { LabeledInput } from '../../../LabeledInput/index.js';
 import { DatePicker } from '../../../DatePicker/index.js';
 import { IconButton } from '../../../Buttons/index.js';
@@ -21,17 +26,12 @@ export type DatePickerInputProps = {
    * The 'to' date for the 'from' DatePickerInput or the 'from' date for the 'to' DatePickerInput
    */
   selectedDate?: Date;
-  /**
-   * Set focus.
-   * @default false
-   */
-  setFocus?: boolean;
 } & Omit<
   React.ComponentProps<typeof LabeledInput>,
   'value' | 'onChange' | 'svgIcon' | 'displayStyle'
 >;
 
-const DatePickerInput = (props: DatePickerInputProps) => {
+const DatePickerInput = React.forwardRef((props, forwardedRef) => {
   const {
     onChange,
     date,
@@ -39,7 +39,6 @@ const DatePickerInput = (props: DatePickerInputProps) => {
     formatDate,
     isFromOrTo,
     selectedDate,
-    setFocus = false,
     ...rest
   } = props;
 
@@ -88,14 +87,6 @@ const DatePickerInput = (props: DatePickerInputProps) => {
     [onChange, parseInput],
   );
 
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    if (inputRef.current && setFocus) {
-      inputRef.current.focus();
-    }
-  }, [setFocus]);
-
   return (
     <Popover
       content={
@@ -116,7 +107,7 @@ const DatePickerInput = (props: DatePickerInputProps) => {
       appendTo='parent'
     >
       <LabeledInput
-        ref={inputRef}
+        ref={forwardedRef}
         displayStyle='inline'
         value={inputValue}
         onChange={onInputChange}
@@ -134,6 +125,6 @@ const DatePickerInput = (props: DatePickerInputProps) => {
       />
     </Popover>
   );
-};
+}) as PolymorphicForwardRefComponent<'input', DatePickerInputProps>;
 
 export default DatePickerInput;

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
@@ -21,6 +21,11 @@ export type DatePickerInputProps = {
    * The 'to' date for the 'from' DatePickerInput or the 'from' date for the 'to' DatePickerInput
    */
   selectedDate?: Date;
+  /**
+   * Set focus.
+   * @default false
+   */
+  setFocus?: boolean;
 } & Omit<
   React.ComponentProps<typeof LabeledInput>,
   'value' | 'onChange' | 'svgIcon' | 'displayStyle'
@@ -34,6 +39,7 @@ const DatePickerInput = (props: DatePickerInputProps) => {
     formatDate,
     isFromOrTo,
     selectedDate,
+    setFocus = false,
     ...rest
   } = props;
 
@@ -82,6 +88,14 @@ const DatePickerInput = (props: DatePickerInputProps) => {
     [onChange, parseInput],
   );
 
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (inputRef.current && setFocus) {
+      inputRef.current.focus();
+    }
+  }, [setFocus]);
+
   return (
     <Popover
       content={
@@ -102,6 +116,7 @@ const DatePickerInput = (props: DatePickerInputProps) => {
       appendTo='parent'
     >
       <LabeledInput
+        ref={inputRef}
         displayStyle='inline'
         value={inputValue}
         onChange={onInputChange}

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
@@ -3,12 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import {
-  Popover,
-  SvgCalendar,
-  isBefore,
-  type PolymorphicForwardRefComponent,
-} from '../../../utils/index.js';
+import { Popover, SvgCalendar, isBefore } from '../../../utils/index.js';
+import type { PolymorphicForwardRefComponent } from '../../../utils/index.js';
 import { LabeledInput } from '../../../LabeledInput/index.js';
 import { DatePicker } from '../../../DatePicker/index.js';
 import { IconButton } from '../../../Buttons/index.js';

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -125,7 +125,6 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         placeholder={placeholder}
         selectedDate={to}
         isFromOrTo='from'
-        setFocus
       />
       <DatePickerInput
         label={translatedStrings.to}

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -125,6 +125,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         placeholder={placeholder}
         selectedDate={to}
         isFromOrTo='from'
+        setFocus
       />
       <DatePickerInput
         label={translatedStrings.to}

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -65,6 +65,14 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
   const [from, setFrom] = React.useState<Date | undefined>(
     column.filterValue?.[0] ? new Date(column.filterValue?.[0]) : undefined,
   );
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
   const onFromChange = React.useCallback((date?: Date) => {
     setFrom((prevDate) => {
       if (prevDate || !date) {
@@ -116,6 +124,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
   return (
     <BaseFilter>
       <DatePickerInput
+        ref={inputRef}
         label={translatedStrings.from}
         date={from}
         onChange={onFromChange}
@@ -125,7 +134,6 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         placeholder={placeholder}
         selectedDate={to}
         isFromOrTo='from'
-        setFocus
       />
       <DatePickerInput
         label={translatedStrings.to}

--- a/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
@@ -34,6 +34,14 @@ export const NumberRangeFilter = <T extends Record<string, unknown>>(
 
   const translatedStrings = { ...defaultStrings, ...translatedLabels };
 
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
   const [from, setFrom] = React.useState<string | undefined>(
     column.filterValue?.[0] ?? '',
   );
@@ -58,6 +66,7 @@ export const NumberRangeFilter = <T extends Record<string, unknown>>(
   return (
     <BaseFilter>
       <LabeledInput
+        ref={inputRef}
         label={translatedStrings.from}
         value={from}
         onChange={(e) => setFrom(e.target.value)}

--- a/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
@@ -64,7 +64,6 @@ export const NumberRangeFilter = <T extends Record<string, unknown>>(
         onKeyDown={onKeyDown}
         type='number'
         displayStyle='inline'
-        setFocus
       />
       <LabeledInput
         label={translatedStrings.to}

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
@@ -40,7 +40,6 @@ export const TextFilter = <T extends Record<string, unknown>>(
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onKeyDown}
-        setFocus
       />
       <FilterButtonBar
         setFilter={() => setFilter(text)}

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
@@ -24,6 +24,14 @@ export const TextFilter = <T extends Record<string, unknown>>(
 
   const [text, setText] = React.useState(column.filterValue ?? '');
 
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.altKey) {
       return;
@@ -37,6 +45,7 @@ export const TextFilter = <T extends Record<string, unknown>>(
   return (
     <BaseFilter>
       <Input
+        ref={inputRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onKeyDown}

--- a/packages/itwinui-react/src/core/Textarea/Textarea.test.tsx
+++ b/packages/itwinui-react/src/core/Textarea/Textarea.test.tsx
@@ -64,13 +64,3 @@ it('should have passed value', () => {
   expect(textarea).toBeTruthy();
   expect(textarea.value).toEqual('test-value');
 });
-
-it('should set focus', () => {
-  const { container } = render(<Textarea setFocus={true} />);
-
-  const textarea = container.querySelector(
-    'textarea.iui-input',
-  ) as HTMLTextAreaElement;
-  expect(textarea).toBeTruthy();
-  expect(document.activeElement).toEqual(textarea);
-});

--- a/packages/itwinui-react/src/core/Textarea/Textarea.tsx
+++ b/packages/itwinui-react/src/core/Textarea/Textarea.tsx
@@ -7,31 +7,17 @@ import * as React from 'react';
 import { useMergedRefs, Box } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 
-export type TextareaProps = {
-  /**
-   * Set focus on textarea element.
-   * @default false
-   */
-  setFocus?: boolean;
-};
-
 /**
  * Basic textarea component
  * @example
- * <Textarea setFocus={true} placeholder='This is a textarea' />
+ * <Textarea placeholder='This is a textarea' />
  * <Textarea disabled={true} placeholder='This is a disabled textarea' />
  */
 export const Textarea = React.forwardRef((props, ref) => {
-  const { className, rows = 3, setFocus = false, ...rest } = props;
+  const { className, rows = 3, ...rest } = props;
 
   const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
   const refs = useMergedRefs<HTMLTextAreaElement>(ref, textAreaRef);
-
-  React.useEffect(() => {
-    if (textAreaRef.current && setFocus) {
-      textAreaRef.current.focus();
-    }
-  }, [setFocus]);
 
   return (
     <Box
@@ -42,6 +28,6 @@ export const Textarea = React.forwardRef((props, ref) => {
       {...rest}
     />
   );
-}) as PolymorphicForwardRefComponent<'textarea', TextareaProps>;
+}) as PolymorphicForwardRefComponent<'textarea'>;
 
 export default Textarea;

--- a/packages/itwinui-react/src/core/ToggleSwitch/ToggleSwitch.test.tsx
+++ b/packages/itwinui-react/src/core/ToggleSwitch/ToggleSwitch.test.tsx
@@ -104,22 +104,6 @@ it('should render label on the left', () => {
   getByText('my label');
 });
 
-it('should set focus', () => {
-  let element: HTMLInputElement | null = null;
-  const onRef = (ref: HTMLInputElement) => {
-    element = ref;
-  };
-  const { container, getByText } = render(
-    <ToggleSwitch label='my label' ref={onRef} setFocus />,
-  );
-
-  assertBaseElements(container, 'right');
-
-  getByText('my label');
-  expect(element).toBeTruthy();
-  expect(document.activeElement).toEqual(element);
-});
-
 it('should apply style and class', () => {
   const { container } = render(
     <ToggleSwitch className='my-class' style={{ width: 80 }} />,

--- a/packages/itwinui-react/src/core/ToggleSwitch/ToggleSwitch.tsx
+++ b/packages/itwinui-react/src/core/ToggleSwitch/ToggleSwitch.tsx
@@ -17,11 +17,6 @@ type ToggleSwitchProps = {
    * @default 'right'
    */
   labelPosition?: 'left' | 'right';
-  /**
-   * Set focus on toggle.
-   * @default false
-   */
-  setFocus?: boolean;
 } & (
   | {
       /**
@@ -69,7 +64,6 @@ export const ToggleSwitch = React.forwardRef((props, ref) => {
     disabled = false,
     labelPosition = 'right',
     label,
-    setFocus = false,
     className,
     style,
     size = 'default',
@@ -79,11 +73,6 @@ export const ToggleSwitch = React.forwardRef((props, ref) => {
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const refs = useMergedRefs<HTMLInputElement>(inputElementRef, ref);
 
-  React.useEffect(() => {
-    if (inputElementRef.current && setFocus) {
-      inputElementRef.current.focus();
-    }
-  }, [setFocus]);
   return (
     <Box
       as={label ? 'label' : 'div'}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Most of components have refs. Therefore custom setFocus functionality is not needed anymore - users can set focus themselves using said ref.

Removed `setFocus` from:
- Checkbox
- ColorPicker
- ComboBox
- Input
- LabeledInput
- LabeledTextarea
- Radio
- RadioTile
- Select
- Slider
- ToggleSwitch

Added setFocus functionality to:
- TextFilter
- NumberRangeFilter
- DateRangeFilter

Keeping setFocus on (because of more complex use case):
- DatePicker
- Dialog
- Menu
- TimePicker

## Testing

- Updated unit tests to manually focus 
- Visual tests pass

## Docs

- [x] changeset
- [ ] wiki
