### PR TITLE
constrain tabs height to let content grow

### DIFF
--- a/.changeset/wet-planes-dance.md
+++ b/.changeset/wet-planes-dance.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue in `Tabs` where tabs-list was becoming too tall when the tabpanel didn't have enough content inside.

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -123,6 +123,7 @@ $borderless-horizontal-tab-min-height: calc(
 @mixin iui-tabs-horizontal {
   grid-template-areas: 'tabs tabs-actions' 'tabs-content tabs-content';
   grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
 
   .iui-tabs {
     display: flex;


### PR DESCRIPTION
## Changes

this should partially fix the user-reported issue where tabs-list was growing when tabpanel content was not big enough.

this is the same as what we do in vertical tabs.

https://github.com/iTwin/iTwinUI/blob/d90b55239b5a14c6c2173ff11ec61597196893b6/packages/itwinui-css/src/tabs/base.scss#L181-L184

## Testing

tested with a few different versions of custom css in codesandbox. also verified in user's app.

## Docs

added changeset