### PR TITLE
v1: use nested `.v1` layer name instead of `-v1` suffix

### DIFF
--- a/packages/itwinui-css/CHANGELOG.md
+++ b/packages/itwinui-css/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.63.3
+
+- `@layer itwinui-v1` has been renamed to `@layer itwinui.v1`. This allows applications to use the `itwinui` layer name to orchestrate overall layer order.
+
 ### 0.63.2
 
 - All styles are now wrapped in `@layer`. This makes it possible to easily override and prevent conflicts with the next major version. ([#1037](https://www.github.com/iTwin/iTwinUI/pull/1037))

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/itwinui-css",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "author": "Bentley Systems",
   "license": "MIT",
   "main": "src/index.scss",

--- a/packages/itwinui-css/src/alert/classes.scss
+++ b/packages/itwinui-css/src/alert/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-alert {
     @include iui-alert;
 

--- a/packages/itwinui-css/src/anchor/classes.scss
+++ b/packages/itwinui-css/src/anchor/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-anchor {
     @include iui-anchor;
 

--- a/packages/itwinui-css/src/backdrop/classes.scss
+++ b/packages/itwinui-css/src/backdrop/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-backdrop {
     @include iui-backdrop;
   }

--- a/packages/itwinui-css/src/badge/classes.scss
+++ b/packages/itwinui-css/src/badge/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-badge {
     @include iui-badge;
   }

--- a/packages/itwinui-css/src/blockquote/classes.scss
+++ b/packages/itwinui-css/src/blockquote/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-blockquote {
     @include iui-blockquote;
   }

--- a/packages/itwinui-css/src/breadcrumbs/classes.scss
+++ b/packages/itwinui-css/src/breadcrumbs/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-breadcrumbs {
     @include iui-breadcrumbs;
   }

--- a/packages/itwinui-css/src/button/classes.scss
+++ b/packages/itwinui-css/src/button/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-button {
     @include iui-button;
     @include iui-button-size;

--- a/packages/itwinui-css/src/carousel/classes.scss
+++ b/packages/itwinui-css/src/carousel/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-carousel {
     @include iui-carousel;
   }

--- a/packages/itwinui-css/src/code/classes.scss
+++ b/packages/itwinui-css/src/code/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-code {
     @include iui-code;
   }

--- a/packages/itwinui-css/src/color-picker/classes.scss
+++ b/packages/itwinui-css/src/color-picker/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-color-picker {
     @include iui-color-picker;
   }

--- a/packages/itwinui-css/src/date-picker/classes.scss
+++ b/packages/itwinui-css/src/date-picker/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-date-picker {
     @include iui-date-picker;
   }

--- a/packages/itwinui-css/src/dialog/classes.scss
+++ b/packages/itwinui-css/src/dialog/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-dialog-wrapper {
     @include iui-dialog-wrapper;
   }

--- a/packages/itwinui-css/src/expandable-block/classes.scss
+++ b/packages/itwinui-css/src/expandable-block/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-expandable-block {
     @include iui-expandable-block;
   }

--- a/packages/itwinui-css/src/fieldset/classes.scss
+++ b/packages/itwinui-css/src/fieldset/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-fieldset {
     @include iui-fieldset;
   }

--- a/packages/itwinui-css/src/file-upload/classes.scss
+++ b/packages/itwinui-css/src/file-upload/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-file-upload {
     @include iui-file-upload;
   }

--- a/packages/itwinui-css/src/footer/classes.scss
+++ b/packages/itwinui-css/src/footer/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-legal-footer {
     @include iui-legal-footer;
   }

--- a/packages/itwinui-css/src/header/classes.scss
+++ b/packages/itwinui-css/src/header/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-page-header {
     @include iui-page-header;
   }

--- a/packages/itwinui-css/src/icon/classes.scss
+++ b/packages/itwinui-css/src/icon/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-icons-default {
     @include iui-icons-default;
   }

--- a/packages/itwinui-css/src/information-panel/classes.scss
+++ b/packages/itwinui-css/src/information-panel/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-information-panel-wrapper {
     @include iui-information-panel-wrapper;
   }

--- a/packages/itwinui-css/src/inputs/classes.scss
+++ b/packages/itwinui-css/src/inputs/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-input-container {
     @include iui-input-container;
 

--- a/packages/itwinui-css/src/keyboard/classes.scss
+++ b/packages/itwinui-css/src/keyboard/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-keyboard {
     @include iui-keyboard;
   }

--- a/packages/itwinui-css/src/location-marker/classes.scss
+++ b/packages/itwinui-css/src/location-marker/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-location-marker-default {
     @include iui-location-marker-default;
   }

--- a/packages/itwinui-css/src/menu/classes.scss
+++ b/packages/itwinui-css/src/menu/classes.scss
@@ -3,7 +3,7 @@
 @import './index';
 @import '../surface/index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-menu {
     @include iui-surface;
     @include iui-list-menu;

--- a/packages/itwinui-css/src/non-ideal-state/classes.scss
+++ b/packages/itwinui-css/src/non-ideal-state/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-non-ideal-state {
     @include iui-non-ideal-state;
   }

--- a/packages/itwinui-css/src/notification-marker/classes.scss
+++ b/packages/itwinui-css/src/notification-marker/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   @each $status in primary, positive, warning, negative, accessory {
     .iui-notification-#{$status} {
       @include iui-notification-marker($status: $status);

--- a/packages/itwinui-css/src/popover/classes.scss
+++ b/packages/itwinui-css/src/popover/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-popover {
     @include iui-popover;
   }

--- a/packages/itwinui-css/src/progress-indicator/classes.scss
+++ b/packages/itwinui-css/src/progress-indicator/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-progress-indicator-linear {
     @include iui-progress-indicator-linear;
 

--- a/packages/itwinui-css/src/radio-tile/classes.scss
+++ b/packages/itwinui-css/src/radio-tile/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-radio-tile {
     @include iui-radio-tile;
   }

--- a/packages/itwinui-css/src/reset-global-styles.scss
+++ b/packages/itwinui-css/src/reset-global-styles.scss
@@ -3,7 +3,7 @@
 @import './style/index';
 @import './text/mixins';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   html,
   body {
     @include iui-font-family;

--- a/packages/itwinui-css/src/side-navigation/classes.scss
+++ b/packages/itwinui-css/src/side-navigation/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-side-navigation {
     @include iui-side-navigation;
   }

--- a/packages/itwinui-css/src/skip-to-content/classes.scss
+++ b/packages/itwinui-css/src/skip-to-content/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-skip-to-content-link {
     @include iui-skip-to-content-link;
   }

--- a/packages/itwinui-css/src/slider/classes.scss
+++ b/packages/itwinui-css/src/slider/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-slider-horizontal {
     @include iui-slider-horizontal;
   }

--- a/packages/itwinui-css/src/style/global.scss
+++ b/packages/itwinui-css/src/style/global.scss
@@ -3,7 +3,9 @@
 @import './index';
 @import './anchor';
 
-@layer itwinui-v1 {
+@layer itwinui-v1, itwinui.v1, itwinui.v2, itwinui.v3;
+
+@layer itwinui.v1 {
   html {
     @include theme-variables(light);
 

--- a/packages/itwinui-css/src/surface/classes.scss
+++ b/packages/itwinui-css/src/surface/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-surface {
     @include iui-surface;
   }

--- a/packages/itwinui-css/src/table/classes.scss
+++ b/packages/itwinui-css/src/table/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-table {
     @include iui-table;
 

--- a/packages/itwinui-css/src/tabs/classes.scss
+++ b/packages/itwinui-css/src/tabs/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-tabs-wrapper {
     display: flex;
     position: relative;

--- a/packages/itwinui-css/src/tag/classes.scss
+++ b/packages/itwinui-css/src/tag/classes.scss
@@ -3,7 +3,7 @@
 @import './tag';
 @import '../anchor/index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-tag {
     @include iui-tag;
   }

--- a/packages/itwinui-css/src/text/classes.scss
+++ b/packages/itwinui-css/src/text/classes.scss
@@ -3,7 +3,7 @@
 @import './index';
 @import './mixins';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-text-headline {
     @include iui-text(headline);
   }

--- a/packages/itwinui-css/src/tile/classes.scss
+++ b/packages/itwinui-css/src/tile/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-tile {
     @include iui-tile;
 

--- a/packages/itwinui-css/src/time-picker/classes.scss
+++ b/packages/itwinui-css/src/time-picker/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-time-picker {
     @include iui-time-picker;
   }

--- a/packages/itwinui-css/src/toast-notification/classes.scss
+++ b/packages/itwinui-css/src/toast-notification/classes.scss
@@ -10,7 +10,7 @@
   }
 }
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-toast-wrapper {
     pointer-events: none;
     position: fixed;

--- a/packages/itwinui-css/src/toggle-switch/classes.scss
+++ b/packages/itwinui-css/src/toggle-switch/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-toggle-switch-wrapper {
     @include iui-toggle-switch-wrapper;
   }

--- a/packages/itwinui-css/src/tooltip/classes.scss
+++ b/packages/itwinui-css/src/tooltip/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   // Statics version of hidden/visible animation handling
   .iui-tooltip-container {
     width: fit-content;

--- a/packages/itwinui-css/src/tree/classes.scss
+++ b/packages/itwinui-css/src/tree/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-tree {
     @include iui-tree;
   }

--- a/packages/itwinui-css/src/user-icon/classes.scss
+++ b/packages/itwinui-css/src/user-icon/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-user-icon {
     @include iui-user-icon;
 

--- a/packages/itwinui-css/src/wizard/classes.scss
+++ b/packages/itwinui-css/src/wizard/classes.scss
@@ -2,7 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @import './index';
 
-@layer itwinui-v1 {
+@layer itwinui.v1 {
   .iui-wizard {
     @include iui-wizard;
 


### PR DESCRIPTION
## Changes

Follow-up to #1412 and #1415. Renamed the layer and also specified layer order upfront (in `global.css`) to ensure correct order is used.

## Testing

N/A

## Docs

updated changelog.