### PR TITLE
fix: Add minWidth to resizable Dialog

### DIFF
--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -4,6 +4,7 @@
 
 $iui-dialog-width: 380px;
 $iui-dialogue-resizable-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins + button height + partially visible text
+$iui-dialogue-resizable-min-width: 14.5rem; // 14.5rem = 232px = margins + button width x 2
 
 .iui-dialog-wrapper {
   position: fixed;
@@ -118,6 +119,11 @@ $iui-dialogue-resizable-min-height: 7.75rem; // 7.75rem = 124px = title bar heig
   flex-direction: column;
   border: 1px solid var(--iui-color-border);
   min-height: $iui-dialogue-resizable-min-height;
+}
+
+.iui-dialog-resizable {
+  min-height: $iui-dialogue-resizable-min-height;
+  min-width: $iui-dialogue-resizable-min-width;
 }
 
 .iui-dialog-animation {

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
@@ -174,6 +174,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
             'iui-dialog-full-page': styleType === 'fullPage',
             'iui-dialog-visible': isOpen,
             'iui-dialog-draggable': isDraggable,
+            'iui-dialog-resizable': isResizable,
           },
           className,
         )}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Add new class `iui-dialog-resizable` to fix resize bug.

Before:

https://github.com/iTwin/iTwinUI/assets/83585998/23744a6d-712e-407a-9b43-500cc3fab363

After:

https://github.com/iTwin/iTwinUI/assets/83585998/23770bb5-f2d5-4711-9f19-2eb733217e9e


## Testing

WIP

## Docs

WIP
