### PR TITLE
Animate Side Navigation submenu with CSS

### DIFF
--- a/packages/itwinui-css/src/side-navigation/side-navigation.scss
+++ b/packages/itwinui-css/src/side-navigation/side-navigation.scss
@@ -161,8 +161,27 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   }
 }
 
+//animating technique from https://css-tricks.com/css-grid-can-do-auto-height-transitions/
+.iui-submenu {
+  display: grid;
+  grid-template-columns: 0fr;
+  overflow: hidden;
+  z-index: -1;
+  @media (prefers-reduced-motion: no-preference) {
+    transition: grid-template-columns var(--iui-duration-2), visibility var(--iui-duration-2),
+      transform var(--iui-duration-2);
+    transition-timing-function: ease-out;
+  }
+}
+
 .iui-side-navigation-submenu {
-  min-inline-size: calc(var(--iui-size-3xl) * 2);
+  // min-block-size: 0;
+  min-inline-size: 0;
+  visibility: hidden;
+  @media (prefers-reduced-motion: no-preference) {
+    transition: visibility var(--iui-duration-2) ease-out;
+  }
+  // min-inline-size: calc(var(--iui-size-3xl) * 2);
   max-inline-size: 50vw;
   block-size: 100%;
   overflow-x: hidden;
@@ -171,13 +190,6 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   resize: horizontal;
   background-color: var(--iui-color-background);
   border-inline-end: 1px solid var(--iui-color-border);
-
-  @include mixins.iui-transition-group;
-
-  &.iui-enter-active,
-  &.iui-exit-active {
-    display: flex;
-  }
 
   &-content {
     padding: 0 var(--iui-size-s) var(--iui-size-s);
@@ -214,8 +226,24 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   }
 }
 
+.iui-submenu.iui-expanded {
+  grid-template-columns: 1fr;
+}
+
+.iui-submenu.iui-expanded .iui-side-navigation-submenu {
+  visibility: visible;
+  transform: translateX(0%);
+}
+
+.iui-submenu {
+  &:not(.iui-expanded) {
+    transform: translateX(-100%);
+  }
+}
+
 .iui-side-navigation-wrapper {
   display: flex;
   position: relative;
   block-size: 100%;
+  isolation: isolate;
 }

--- a/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
+++ b/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { WithCSSTransition, SvgChevronRight, Box } from '../utils/index.js';
+import { SvgChevronRight, Box } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { IconButton } from '../Buttons/index.js';
 import { Tooltip } from '../Tooltip/index.js';
@@ -151,14 +151,19 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
         {expanderPlacement === 'bottom' && ExpandButton}
       </Box>
       {submenu && (
-        <WithCSSTransition
-          in={isSubmenuOpen}
-          dimension='width'
-          timeout={200}
-          classNames='iui'
+        <Box
+          className={cx(
+            'iui-submenu',
+            {
+              'iui-expanded': isSubmenuOpen,
+            },
+            className,
+          )}
+          ref={forwardedRef}
+          {...rest}
         >
           {submenu}
-        </WithCSSTransition>
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
- Removed `WithCSSTransition` from Side Navigation submenu's transition and instead use [CSS](https://css-tricks.com/css-grid-can-do-auto-height-transitions/)
- Not working correctly yet, animation seems off speed for the different layers:
![sidenav](https://github.com/iTwin/iTwinUI/assets/22462084/34cadb82-f703-4ea1-8e6b-39c997480303)

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->
- Manual testing in Storybook

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

- TBD: changeset