### PR TITLE
Adding [x]Props to ProgressIndicators 

### DIFF
--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
@@ -81,3 +81,28 @@ it('renders ProgressLinear with 2 labels', () => {
   screen.getByText('Processing...');
   screen.getByText('test.dgn');
 });
+
+it('passes custom props to ProgressLinear parts', () => {
+  const value = 100;
+  const labels = ['Upload done!', '100%'];
+  const status = 'positive';
+  const { container } = render(
+    <ProgressLinear
+      value={value}
+      labels={labels}
+      labelGroupProps={{
+        className: 'custom-label-group-class',
+        style: { fontSize: 12 },
+      }}
+      status={status}
+    />,
+  );
+
+  // Label group test
+
+  const labelGroup = container.querySelector(
+    '.iui-progress-indicator-linear-label.custom-label-group-class',
+  ) as HTMLElement;
+  expect(labelGroup).toBeTruthy;
+  expect(labelGroup.style.fontSize).toBe('12px');
+});

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
@@ -31,6 +31,10 @@ type ProgressLinearProps = {
    * Status of progress.
    */
   status?: 'positive' | 'negative';
+  /**
+   * Pass props to ProgressLinear label group.
+   */
+  labelGroupProps?: React.ComponentProps<'div'>;
 };
 
 /**
@@ -56,6 +60,7 @@ export const ProgressLinear = React.forwardRef((props, forwardedRef) => {
     isAnimated = false,
     status,
     className,
+    labelGroupProps,
     ...rest
   } = props;
 
@@ -76,7 +81,14 @@ export const ProgressLinear = React.forwardRef((props, forwardedRef) => {
       {...rest}
     >
       {labels.length > 0 && (
-        <Box className='iui-progress-indicator-linear-label'>
+        <Box
+          as='div'
+          {...labelGroupProps}
+          className={cx(
+            'iui-progress-indicator-linear-label',
+            labelGroupProps?.className,
+          )}
+        >
           {labels.map((label, index) => (
             <span key={index}>{label}</span>
           ))}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Adding props to `ProgressIndicatorLinear` and `ProgressIndicatorLinear` to improve DOM-Node customization. 
Addresses #1368 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Unit & visual testing to be conducted. 

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

TBD
