### PR TITLE
v2: allow `styleType='high-visibility'` in `DropdownButton`

### DIFF
--- a/.changeset/chatty-actors-attend.md
+++ b/.changeset/chatty-actors-attend.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`DropdownButton` now supports `styleType='high-visibility'` to make it blue. This should be used sparingly, as a default or borderless dropdown button is the better choice in most cases.

--- a/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -97,7 +97,6 @@ export const DropdownButton = React.forwardRef(
             )
           }
           ref={refs}
-          aria-label='Dropdown'
           {...rest}
         >
           {children}

--- a/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/DropdownButton/DropdownButton.tsx
@@ -28,7 +28,7 @@ export type DropdownButtonProps = {
    * Use 'borderless' to hide outline.
    * @default 'default'
    */
-  styleType?: 'default' | 'borderless';
+  styleType?: 'default' | 'borderless' | 'high-visibility';
   /**
    * Props for the `DropdownMenu` which extends `PopoverProps`.
    */


### PR DESCRIPTION
## Changes

Pretty simple change in types, as all the code is already wired up correctly. Closes #1394

## Testing

https://github.com/iTwin/iTwinUI/assets/9084735/b0903553-0846-4ff1-b578-e403b4a2216c

<img width="116" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/a41429ab-dc1c-40df-9a86-3ae97631aba7">

## Docs

Added changeset.

Not adding story or docs example, because we don't want to encourage this pattern everywhere. I believe we originally added the restriction on purpose, but multiple users have asked for this since then. /cc @FlyersPh9 