### PR TITLE
Adding Props to `LabeledTextarea`

### DIFF
--- a/apps/storybook/src/LabeledTextarea.stories.tsx
+++ b/apps/storybook/src/LabeledTextarea.stories.tsx
@@ -32,6 +32,9 @@ export const Basic: Story<Partial<LabeledTextareaProps>> = (args) => {
       label='Textarea Label'
       message='Display Message'
       placeholder='This is a textarea'
+      labelProps={{ className: 'some label' }}
+      messageProps={{ className: 'some message' }}
+      inputProps={{ className: 'some input' }}
       {...args}
     />
   );

--- a/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
+++ b/packages/itwinui-react/src/core/LabeledTextarea/LabeledTextarea.tsx
@@ -7,6 +7,7 @@ import { StatusIconMap, InputContainer, useId } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { Textarea } from '../Textarea/index.js';
 import type { LabeledInputProps } from '../LabeledInput/LabeledInput.js';
+import cx from 'classnames';
 
 type LabeledTextareaProps = {
   /**
@@ -29,6 +30,18 @@ type LabeledTextareaProps = {
    * Custom style for textarea.
    */
   textareaStyle?: React.CSSProperties;
+  /**
+   * Custom class name for input.
+   */
+  inputProps?: React.ComponentProps<'div'>;
+  /**
+   * Custom class name for label.
+   */
+  labelProps?: React.ComponentProps<'label'>;
+  /**
+   * Custom class name for message.
+   */
+  messageProps?: React.ComponentProps<'div'>;
 } & Pick<LabeledInputProps, 'svgIcon' | 'displayStyle' | 'iconDisplayStyle'>;
 
 /**
@@ -64,6 +77,9 @@ export const LabeledTextarea = React.forwardRef((props, ref) => {
     status,
     textareaClassName,
     textareaStyle,
+    inputProps,
+    labelProps,
+    messageProps,
     displayStyle = 'default',
     iconDisplayStyle = displayStyle === 'default' ? 'block' : 'inline',
     svgIcon,
@@ -76,15 +92,21 @@ export const LabeledTextarea = React.forwardRef((props, ref) => {
 
   return (
     <InputContainer
+      as='div'
+      {...inputProps}
+      {...labelProps}
+      {...messageProps}
       label={label}
+      labelProps={cx(className, labelProps?.className)}
       disabled={disabled}
       required={required}
       status={status}
       message={message}
+      messageProps={cx(className, messageProps?.className)}
       icon={icon}
       isLabelInline={displayStyle === 'inline'}
       isIconInline={iconDisplayStyle === 'inline'}
-      className={className}
+      className={cx(className, inputProps?.className)}
       style={style}
       inputId={id}
     >


### PR DESCRIPTION
## Changes

#1368 -  Adding the ability for each node element in `LabeledTextarea` to have a custom className.

## Testing

WIP;

## Docs

N/A
