### PR TITLE
CI: dont publish test images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,34 +320,6 @@ jobs:
           name: 'backstop_test_results'
           path: '${{ github.workspace }}/packages/itwinui-css/backstop/results/'
 
-      - name: Host test results on gh pages
-        continue-on-error: true
-        if: github.ref != 'refs/heads/main' && github.ref != 'ref/heads/dev' && failure()
-        uses: JamesIves/github-pages-deploy-action@4.1.3
-        with:
-          branch: gh-pages
-          folder: ${{ github.workspace }}/packages/itwinui-css/backstop/results
-          target-folder: ${{ github.event.number }}/results
-          single-commit: true
-          git-config-name: github-actions[bot]
-          git-config-email: github-actions[bot]@users.noreply.github.com
-
-      - name: Post test results link under Checks
-        if: github.ref != 'refs/heads/main' && github.ref != 'ref/heads/dev' && always()
-        continue-on-error: true
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ github.event.pull_request.head.sha }}',
-              state: '${{ job.status }}',
-              context: 'Test results',
-              ...(context.job.status !== 'success' && { description: 'Backstop html report' }),
-              ...(context.job.status !== 'success' && { target_url: 'https://itwin.github.io/iTwinUI/${{ github.event.number }}/results/html_report/' }),
-            })
-
   visual-test-react:
     name: Run visual tests (react)
     needs: install


### PR DESCRIPTION
## Changes

The [gh-pages](https://github.com/iTwin/iTwinUI/tree/gh-pages) branch is kinda getting out of hand as it's full of thousands of images from test failures. This slows up deployments which take 2-5 mins to complete. Not publishing these images should speed things up.

The test image artifacts still get uploaded if somebody wants to download the zip.

## Testing

N/A

## Docs

N/A