### PR TITLE
ignore webpack/vite errors with dynamic imports

### DIFF
--- a/packages/itwinui-react/src/core/utils/functions/import.ts
+++ b/packages/itwinui-react/src/core/utils/functions/import.ts
@@ -11,4 +11,5 @@
 export const dynamicImport =
   typeof jest === undefined
     ? new Function('specifier', 'return import(specifier)')
-    : (specifier: string) => import(specifier);
+    : (specifier: string) =>
+        import(/* webpackIgnore: true */ /* @vite-ignore */ specifier);


### PR DESCRIPTION
## Changes

webpack and vite both freak out when they encounter a dynamic import with a dynamic specifier, so ignoring them. the whole point of this syntax is to be lazy-loaded only when necessary, so it doesn't need to be optimized by bundlers.

## Testing

no longer seeing these warnings
<img width="1263" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/00b4742c-8f8e-47d5-b817-f93d76337da7">


## Docs

n/a

changeset not needed imo, because this file was only added in v3