### PR TITLE
Side navigation submenu animation with simpler transition

### DIFF
--- a/packages/itwinui-css/src/side-navigation/side-navigation.scss
+++ b/packages/itwinui-css/src/side-navigation/side-navigation.scss
@@ -171,12 +171,22 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   resize: horizontal;
   background-color: var(--iui-color-background);
   border-inline-end: 1px solid var(--iui-color-border);
+  z-index: -1;
+  visibility: hidden;
+  transform: translateX(-100%);
 
-  @include mixins.iui-transition-group;
+  @media (prefers-reduced-motion: no-preference) {
+    transition: visibility var(--iui-duration-2), transform var(--iui-duration-2);
+    transition-timing-function: ease-out;
+  }
 
-  &.iui-enter-active,
-  &.iui-exit-active {
-    display: flex;
+  :where(.iui-side-navigation-wrapper[data-iui-submenu-expanded='true']) & {
+    visibility: visible;
+    transform: translateX(0);
+    @media (prefers-reduced-motion: no-preference) {
+      transition: visibility var(--iui-duration-2), transform var(--iui-duration-2);
+      transition-timing-function: ease-out;
+    }
   }
 
   &-content {
@@ -217,5 +227,7 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
 .iui-side-navigation-wrapper {
   display: flex;
   position: relative;
+  isolation: isolate;
+  overflow: hidden;
   block-size: 100%;
 }

--- a/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
+++ b/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { WithCSSTransition, SvgChevronRight, Box } from '../utils/index.js';
+import { SvgChevronRight, Box } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { IconButton } from '../Buttons/index.js';
 import { Tooltip } from '../Tooltip/index.js';
@@ -106,6 +106,7 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
   return (
     <Box
       className={cx('iui-side-navigation-wrapper', className)}
+      data-iui-submenu-expanded={isSubmenuOpen}
       ref={forwardedRef}
       {...rest}
     >
@@ -150,16 +151,7 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
         </Box>
         {expanderPlacement === 'bottom' && ExpandButton}
       </Box>
-      {submenu && (
-        <WithCSSTransition
-          in={isSubmenuOpen}
-          dimension='width'
-          timeout={200}
-          classNames='iui'
-        >
-          {submenu}
-        </WithCSSTransition>
-      )}
+      {submenu ?? submenu}
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', SideNavigationProps>;


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@mayank99 following your suggestion using only `transformX` and based on https://web.dev/building-a-sidenav-component/#transforms. Also made another PR because this change effectively undo 95% of the [other PR](https://github.com/iTwin/iTwinUI/pull/1439) so might as well.

The `z-index: -1` is needed here because otherwise the submenu will slide on top of side navigation bar during transition

So far so good, only one issue: the parent/wrapper doesn't resize (to only the size of side navigation) when submenu is transited out of view.
Things I have tried include:
- add `flex-shrink: 1` to submenu
- add `justify-content: end` and `justify-items: end` to wrapper (also tried `align-self: end` too)
- testing different values for `block-size` and `width` submenu

Do you know what else could work?

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->
