### PR TITLE
scope variables within react stylesheet

### DIFF
--- a/packages/itwinui-react/src/styles.js/vite.config.mjs
+++ b/packages/itwinui-react/src/styles.js/vite.config.mjs
@@ -46,6 +46,24 @@ export default defineConfig({
         return `_iui3-${name.replace('iui-', '')}`;
       },
     },
+    postcss: {
+      plugins: [
+        Object.assign(
+          () => ({
+            postcssPlugin: true,
+            Rule(rule) {
+              if (
+                rule.type === 'rule' &&
+                rule.selector?.startsWith(':where([data-iui-theme')
+              ) {
+                rule.selector = `:where(.iui-root)${rule.selector}`;
+              }
+            },
+          }),
+          { postcss: true },
+        ),
+      ],
+    },
   },
 });
 


### PR DESCRIPTION
## Changes

After #1359, the `styles.css` created within react would cause global side effects, so I've created a simple postcss plugin to dynamically scope the variables to only the hashed iui-root class.

The result:
1. `@itwin/itwinui-variables` is still usable without a class, only data attributes.
2. `@itwin/itwinui-react` is self-contained and no longer affects independent usage of `@itwin/itwinui-variables`.

## Testing

Confirmed working by inspecting generated stylesheet.

<img width="934" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/d18c1429-4611-40b3-ae9a-eb0bbd8a0adb">

<img width="946" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/0974e085-24b6-4e7d-920d-e7d2ca508535">


## Docs

changeset not needed, as this is a small, almost-invisible change in an unreleased feature.

i will work on docs for variables compatibility table later.