### PR TITLE
fix a11y ci failing at install step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,7 +379,7 @@ jobs:
 
       - run: yarn build --filter=itwinui-react
 
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@v5.8.3
         with:
           working-directory: testing/a11y
           component: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -383,3 +383,4 @@ jobs:
         with:
           working-directory: testing/a11y
           component: true
+          install-command: yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,7 +379,7 @@ jobs:
 
       - run: yarn build --filter=itwinui-react
 
-      - uses: cypress-io/github-action@v5.8.3
+      - uses: cypress-io/github-action@v5
         with:
           working-directory: testing/a11y
           component: true

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^18.0.2",
     "@types/react-dom": "^18.0.2",
     "configs": "*",
-    "cypress": "12.16.0",
+    "cypress": "12.17.2",
     "cypress-image-diff-js": "1.23.0",
     "dotenv-cli": "7.0.0",
     "eslint": "^8.14.0",

--- a/apps/storybook/scripts/run-tests.js
+++ b/apps/storybook/scripts/run-tests.js
@@ -5,7 +5,7 @@
 const spawn = require('child_process').spawn;
 const args = process.argv.slice(2).join(' ');
 
-const IMAGE_NAME = 'cypress/included:12.16.0'; // https://hub.docker.com/r/cypress/included
+const IMAGE_NAME = 'cypress/included:12.17.2'; // https://hub.docker.com/r/cypress/included
 
 // Need to use this script because current directory variable is different in different shells
 const dockerProcess = spawn(

--- a/testing/a11y/package.json
+++ b/testing/a11y/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@itwin/itwinui-react": "3.0.0-dev.6",
     "axe-core": "^4.7.2",
-    "cypress": "^12.17.2",
+    "cypress": "12.17.2",
     "cypress-axe": "^1.4.0",
     "examples": "*"
   }

--- a/testing/a11y/package.json
+++ b/testing/a11y/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@itwin/itwinui-react": "3.0.0-dev.6",
     "axe-core": "^4.7.2",
-    "cypress": "^12.16.0",
+    "cypress": "^12.17.2",
     "cypress-axe": "^1.4.0",
     "examples": "*"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,7 +1561,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@cypress/request@^2.88.10":
+"@cypress/request@^2.88.11":
   version "2.88.12"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
   integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
@@ -6148,12 +6148,12 @@ cypress-recurse@^1.13.1:
   resolved "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.20.0.tgz"
   integrity sha512-8/gqot/XnVkSF8ssgn3zLRTfPw7Bum2tMIOxf6NO+Wqk0MBQdd4NPNVCObllZmmviLsGmF6ZXwlbXZ8TYvD6dw==
 
-cypress@12.16.0, cypress@^12.16.0:
-  version "12.16.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.16.0.tgz#d0dcd0725a96497f4c60cf54742242259847924c"
-  integrity sha512-mwv1YNe48hm0LVaPgofEhGCtLwNIQEjmj2dJXnAkY1b4n/NE9OtgPph4TyS+tOtYp5CKtRmDvBzWseUXQTjbTg==
+cypress@12.17.2, cypress@^12.17.2:
+  version "12.17.2"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.2.tgz#040ac55de1e811f6e037d231a2869d5ab8c29c85"
+  integrity sha512-hxWAaWbqQBzzMuadSGSuQg5PDvIGOovm6xm0hIfpCVcORsCAj/gF2p0EvfnJ4f+jK2PCiDgP6D2eeE9/FK4Mjg==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "^2.88.11"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
     "@types/sinonjs__fake-timers" "8.1.1"
@@ -6190,7 +6190,7 @@ cypress@12.16.0, cypress@^12.16.0:
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -13256,7 +13256,7 @@ semver-truncate@^3.0.0:
   dependencies:
     semver "^7.3.5"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@~7.0.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@~7.0.0:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
   integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6148,7 +6148,7 @@ cypress-recurse@^1.13.1:
   resolved "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.20.0.tgz"
   integrity sha512-8/gqot/XnVkSF8ssgn3zLRTfPw7Bum2tMIOxf6NO+Wqk0MBQdd4NPNVCObllZmmviLsGmF6ZXwlbXZ8TYvD6dw==
 
-cypress@12.17.2, cypress@^12.17.2:
+cypress@12.17.2:
   version "12.17.2"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.2.tgz#040ac55de1e811f6e037d231a2869d5ab8c29c85"
   integrity sha512-hxWAaWbqQBzzMuadSGSuQg5PDvIGOovm6xm0hIfpCVcORsCAj/gF2p0EvfnJ4f+jK2PCiDgP6D2eeE9/FK4Mjg==


### PR DESCRIPTION
### Changes

- bumped `cypress`, pinned version
- changed cypress github-action's `install-command` to just `yarn` (without `--frozen-lockfile`)

I believe the problem was that Yarn v1, in their infinite wisdom, does not respect `resolutions` when running install from a subdirectory of the monorepo. So, when cypress tries to install from a subdirectory, the lockfile changes and it fails CI because of `--frozen-lockfile`

### Testing

now correctly runs in CI. 🎉 https://github.com/iTwin/iTwinUI/actions/runs/5731719926/job/15533266054

| Before | After |
| --- | --- |
| <img width="900" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/23cc46ca-0aff-481d-9168-a059229be03a"> | <img width="1073" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/cafa6dc5-0de0-4022-9d14-56df75d4c622"> |

### Docs

N/A