### PR TITLE
Refactor slider

### DIFF
--- a/packages/itwinui-css/backstop/tests/slider.html
+++ b/packages/itwinui-css/backstop/tests/slider.html
@@ -27,25 +27,26 @@
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
       section[id^='demo'] {
         width: auto;
+        display: flex;
+        gap: 2rem;
+      }
+
+      #demo-default,
+      #demo-range {
+        flex-direction: column;
       }
 
       .iui-tooltip {
         display: none;
       }
 
-      .iui-slider-container .iui-slider-thumb:focus + .iui-tooltip,
-      .iui-slider-container .iui-slider-thumb:hover + .iui-tooltip,
-      .iui-slider-container .iui-slider-thumb.iui-active + .iui-tooltip {
+      .iui-slider .iui-slider-thumb:focus + .iui-tooltip,
+      .iui-slider .iui-slider-thumb:hover + .iui-tooltip,
+      .iui-slider .iui-slider-thumb.iui-active + .iui-tooltip {
         position: absolute;
         display: block;
         margin-top: -32px;
         transform: translateX(-50%);
-      }
-
-      #demo-default-vertical,
-      #demo-range-vertical {
-        display: flex;
-        gap: 2rem;
       }
     </style>
 
@@ -63,18 +64,131 @@
 
     <h2>Default</h2>
     <section id="demo-default">
+      <div
+        class="iui-slider iui-progress-slider"
+        aria-orientation="horizontal"
+      >
+        <div
+          class="iui-slider-track"
+          style="right: 50%;"
+        ></div>
+        <div
+          style="left: 50%;"
+          class="iui-slider-thumb"
+          role="slider"
+          tabindex="0"
+          aria-label="Volume Setting"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          aria-valuemax="100"
+          id="test-slider-1"
+        ></div>
+        <output
+          class="iui-tooltip"
+          style="left: 50%;"
+        >
+          50
+        </output>
+      </div>
+
+      <div
+        class="iui-slider iui-progress-slider"
+        aria-orientation="horizontal"
+      >
+        <div
+          class="iui-slider-track"
+          style="right: 50%;"
+        ></div>
+        <div
+          style="left: 50%;"
+          class="iui-slider-thumb"
+          role="slider"
+          tabindex="0"
+          aria-label="Volume Setting"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          aria-valuemax="100"
+          id="test-slider-1"
+        ></div>
+        <output
+          class="iui-tooltip"
+          style="left: 50%;"
+        >
+          50
+        </output>
+        <div class="iui-slider-ticks">
+          <span class="iui-slider-tick">0</span>
+          <span class="iui-slider-tick">10</span>
+          <span class="iui-slider-tick">20</span>
+          <span class="iui-slider-tick">30</span>
+          <span class="iui-slider-tick">40</span>
+          <span class="iui-slider-tick">50</span>
+          <span class="iui-slider-tick">60</span>
+          <span class="iui-slider-tick">70</span>
+          <span class="iui-slider-tick">80</span>
+          <span class="iui-slider-tick">90</span>
+          <span class="iui-slider-tick">100</span>
+        </div>
+      </div>
+
+      <div
+        class="iui-slider iui-progress-slider"
+        aria-orientation="horizontal"
+        aria-disabled="true"
+      >
+        <div
+          class="iui-slider-track"
+          style="right: 50%;"
+        ></div>
+        <div
+          style="left: 50%;"
+          class="iui-slider-thumb"
+          role="slider"
+          tabindex="0"
+          aria-label="Volume Setting"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          aria-valuemax="100"
+          id="test-slider-1"
+        ></div>
+        <output
+          class="iui-tooltip"
+          style="left: 50%;"
+        >
+          50
+        </output>
+        <div class="iui-slider-ticks">
+          <span class="iui-slider-tick">0</span>
+          <span class="iui-slider-tick">10</span>
+          <span class="iui-slider-tick">20</span>
+          <span class="iui-slider-tick">30</span>
+          <span class="iui-slider-tick">40</span>
+          <span class="iui-slider-tick">50</span>
+          <span class="iui-slider-tick">60</span>
+          <span class="iui-slider-tick">70</span>
+          <span class="iui-slider-tick">80</span>
+          <span class="iui-slider-tick">90</span>
+          <span class="iui-slider-tick">100</span>
+        </div>
+      </div>
+
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
 
-        <div class="iui-slider-component-container iui-slider-horizontal iui-input-group">
+        <div
+          class="iui-slider-container iui-input-group"
+          aria-orientation="horizontal"
+        >
           <span class="iui-slider-min">
             <svg-sound-mute
               class="iui-icon"
               aria-hidden="true"
             ></svg-sound-mute>
           </span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
+          <div
+            class="iui-slider iui-progress-slider"
+            aria-orientation="horizontal"
+          >
             <div
               class="iui-slider-track"
               style="right: 50%;"
@@ -107,15 +221,15 @@
 
       </div>
 
-      <br /><br />
-
       <div class="iui-input-container">
         <div class="iui-label">Slider with ticks</div>
 
-        <div class="iui-slider-component-container iui-slider-horizontal iui-input-group">
+        <div class="iui-slider-container iui-slider-horizontal iui-input-group">
           <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
+          <div
+            class="iui-slider iui-progress-slider"
+            aria-orientation="horizontal"
+          >
             <div
               class="iui-slider-track"
               style="right: 50%;"
@@ -138,7 +252,6 @@
               50
             </output>
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -157,15 +270,16 @@
 
       </div>
 
-      <br /><br />
-
       <div class="iui-input-container iui-disabled">
         <div class="iui-label">Disabled slider</div>
 
-        <div class="iui-slider-component-container iui-slider-horizontal iui-input-group iui-disabled">
+        <div class="iui-slider-container iui-slider-horizontal iui-input-group iui-disabled">
           <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
+          <div
+            class="iui-slider iui-progress-slider"
+            aria-orientation="horizontal"
+            aria-disabled="true"
+          >
             <div
               class="iui-slider-track"
               style="right: 50%;"
@@ -187,7 +301,6 @@
               50
             </output>
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -207,7 +320,7 @@
       </div>
     </section>
 
-    <br />
+    <!-- <br />
 
     <h2>Ranges</h2>
     <section id="demo-range">
@@ -216,8 +329,7 @@
 
         <div class="iui-slider-component-container iui-slider-horizontal iui-input-group">
           <span class="iui-slider-min">0</span>
-          <div class="
-              iui-slider-container iui-range-slider">
+          <div class="iui-slider-container iui-range-slider">
             <div class="iui-slider-rail"></div>
             <div
               class="iui-slider-track"
@@ -312,7 +424,6 @@
               80
             </output>
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -378,7 +489,6 @@
               80
             </output>
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -396,28 +506,99 @@
         </div>
 
       </div>
-    </section>
+    </section> -->
 
     <br />
 
     <h2>Default vertical</h2>
-    <section id="demo-default-vertical">
+    <section
+      id="demo-default-vertical"
+      style="height: 500px;"
+    >
+      <div
+        class="iui-slider"
+        aria-orientation="vertical"
+      >
+        <div
+          class="iui-slider-track"
+          style="bottom: 50%;"
+        ></div>
+        <div
+          style="bottom: 50%;"
+          class="iui-slider-thumb"
+          role="slider"
+          tabindex="0"
+          aria-label="Volume Setting"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          aria-valuemax="100"
+          id="test-slider-1"
+        ></div>
+        <output
+          class="iui-tooltip"
+          style="bottom: 50%;"
+        >
+          50
+        </output>
+      </div>
+
+      <div
+        class="iui-slider"
+        aria-orientation="vertical"
+      >
+        <div
+          class="iui-slider-track"
+          style="bottom: 50%;"
+        ></div>
+        <div
+          style="bottom: 50%;"
+          class="iui-slider-thumb"
+          role="slider"
+          tabindex="0"
+          aria-label="Volume Setting"
+          aria-valuemin="0"
+          aria-valuenow="50"
+          aria-valuemax="100"
+          id="test-slider-1"
+        ></div>
+        <output
+          class="iui-tooltip"
+          style="bottom: 50%;"
+        >
+          50
+        </output>
+        <div class="iui-slider-ticks">
+          <span class="iui-slider-tick">0</span>
+          <span class="iui-slider-tick">10</span>
+          <span class="iui-slider-tick">20</span>
+          <span class="iui-slider-tick">30</span>
+          <span class="iui-slider-tick">40</span>
+          <span class="iui-slider-tick">50</span>
+          <span class="iui-slider-tick">60</span>
+          <span class="iui-slider-tick">70</span>
+          <span class="iui-slider-tick">80</span>
+          <span class="iui-slider-tick">90</span>
+          <span class="iui-slider-tick">100</span>
+        </div>
+      </div>
+
       <div class="iui-input-container">
         <div class="iui-label">Volume</div>
-
-        <div
-          class="iui-slider-component-container iui-slider-vertical iui-input-group"
-          style="height: 500px;"
-        >
+        <div class="iui-slider-container iui-slider-vertical iui-input-group">
           <span class="iui-slider-min">
             <svg-sound-mute
               class="iui-icon"
               aria-hidden="true"
             ></svg-sound-mute>
           </span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div class="iui-slider-track"></div>
+          <div
+            class="iui-slider"
+            aria-orientation="vertical"
+          >
+            <div
+              class="iui-slider-track"
+              style="bottom: 50%;"
+            ></div>
             <div
               style="bottom: 50%;"
               class="iui-slider-thumb"
@@ -443,23 +624,17 @@
             ></svg-sound-loud>
           </span>
         </div>
-
       </div>
-
-      <br /><br />
 
       <div class="iui-input-container">
         <div class="iui-label">Slider with ticks</div>
-
-        <div
-          class="iui-slider-component-container iui-slider-vertical iui-input-group"
-          style="height: 500px;"
-        >
+        <div class="iui-slider-container iui-slider-vertical iui-input-group">
           <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
-            <div class="iui-slider-track">
-            </div>
+          <div
+            class="iui-slider"
+            aria-orientation="vertical"
+          >
+            <div class="iui-slider-track"></div>
             <div
               class="iui-slider-thumb"
               role="slider"
@@ -469,13 +644,11 @@
               aria-valuenow="50"
               aria-valuemax="100"
               id="test-slider-2"
-            >
-            </div>
+            ></div>
             <output class="iui-tooltip">
               50
             </output>
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -491,19 +664,17 @@
           </div>
           <span class="iui-slider-max">100</span>
         </div>
-
       </div>
 
       <div class="iui-input-container iui-disabled">
         <div class="iui-label">Disabled slider</div>
-
-        <div
-          class="iui-slider-component-container iui-slider-vertical iui-input-group iui-disabled"
-          style="height: 500px;"
-        >
+        <div class="iui-slider-container iui-slider-vertical iui-input-group iui-disabled">
           <span class="iui-slider-min">0</span>
-          <div class="iui-slider-container iui-progress-slider">
-            <div class="iui-slider-rail"></div>
+          <div
+            class="iui-slider"
+            aria-orientation="vertical"
+            aria-disabled="true"
+          >
             <div class="iui-slider-track">
             </div>
             <div
@@ -519,10 +690,7 @@
             <output class="iui-tooltip">
               50
             </output>
-
-
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -541,7 +709,7 @@
       </div>
     </section>
 
-    <br />
+    <!-- <br />
 
     <h2>Ranges Vertical</h2>
     <section id="demo-range-vertical">
@@ -635,7 +803,6 @@
             </output>
 
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -695,7 +862,6 @@
             </output>
 
             <div class="iui-slider-ticks">
-              <!-- You could generate the ticks based on your min, max & step values. -->
               <span class="iui-slider-tick">0</span>
               <span class="iui-slider-tick">10</span>
               <span class="iui-slider-tick">20</span>
@@ -713,7 +879,7 @@
         </div>
 
       </div>
-    </section>
+    </section> -->
 
     <script>
 
@@ -863,7 +1029,8 @@
       }
 
       function getIsVerticalSlider(sliderContainer) {
-        return sliderContainer.parentNode.classList.contains("iui-slider-vertical");
+        // return sliderContainer.parentNode.classList.contains("iui-slider-vertical");
+        return sliderContainer.getAttribute('aria-orientation') === 'vertical';
       }
 
       function initializeThumbProcessing(thumb, sliderContainer, mode) {
@@ -881,7 +1048,7 @@
           thumb.classList.add("iui-active");
           sliderContainer.classList.add("iui-grabbing");
           var ownerDoc = thumb.ownerDocument;
-          var track = sliderContainer.querySelector(".iui-slider-rail");
+          var track = sliderContainer.querySelector(".iui-slider::before");
           var handleMouseMove = function (event) {
             moveSlider(event, thumb, track, progress, mode, toolTip, otherThumb, sliderContainer);
           };
@@ -905,7 +1072,7 @@
       }
 
       function initializeAllProgressSliders() {
-        const allProgressSliderContainers = document.querySelectorAll(".iui-slider-container.iui-progress-slider");
+        const allProgressSliderContainers = document.querySelectorAll(".iui-slider.iui-progress-slider");
         allProgressSliderContainers.forEach(progressSliderContainer => {
           const thumb = progressSliderContainer.querySelector(".iui-slider-thumb");
           initializeThumbProcessing(thumb, progressSliderContainer, "progress");

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -2,42 +2,25 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @use '../mixins';
 
-$thumb-height: var(--iui-size-m); // 16px
-$track-height: var(--iui-size-2xs); // 4px
-$tick-height: var(--iui-size-s); // 12px
-
-.iui-slider-component-container {
+.iui-slider-container {
   display: flex;
   align-items: flex-start;
+  gap: var(--iui-size-s);
+
+  &[aria-orientation='horizontal'] {
+    --_iui-slider-container-min-max-direction: row;
+    --_iui-slider-container-min-text-align: end;
+    --_iui-slider-container-max-text-align: start;
+  }
+
+  &[aria-orientation='vertical'] {
+    --_iui-slider-container-min-max-direction: column;
+    --_iui-slider-container-min-text-align: center;
+    --_iui-slider-container-max-text-align: center;
+  }
 
   &.iui-disabled {
     cursor: not-allowed;
-
-    .iui-slider-container {
-      cursor: not-allowed;
-      pointer-events: none;
-    }
-
-    .iui-slider-rail {
-      background-color: var(--iui-color-background-disabled);
-    }
-
-    .iui-slider-thumb {
-      cursor: not-allowed;
-      background-color: var(--iui-color-border);
-      border-color: var(--iui-color-border);
-      @media (forced-colors: active) {
-        background-color: GrayText;
-        border-color: GrayText;
-      }
-    }
-
-    .iui-slider-track {
-      background-color: var(--iui-color-border);
-      @media (forced-colors: active) {
-        background-color: GrayText;
-      }
-    }
 
     .iui-slider-min,
     .iui-slider-max,
@@ -57,196 +40,301 @@ $tick-height: var(--iui-size-s); // 12px
   display: flex;
   justify-content: center;
 
+  min-inline-size: var(--iui-size-l);
+  flex-direction: var(--_iui-slider-container-min-max-direction);
+  //     margin-inline-start: calc(var(--iui-size-3xs) + var(--iui-size-s));
+  //     transform: translate(-50%, 0);
+  //     min-block-size: var(--iui-size-l);
+  //     flex-direction: column;
+
   svg {
     @include mixins.iui-icon-style('m');
     @include mixins.iui-icon-color;
   }
 }
 
-.iui-slider-container {
+.iui-slider-min {
+  text-align: var(--_iui-slider-container-min-text-align);
+}
+
+.iui-slider-max {
+  text-align: var(--_iui-slider-container-max-text-align);
+}
+
+// #region Slider
+.iui-slider {
+  --_iui-slider-placement-horizontal: 0;
+  --_iui-slider-placement-vertical: 0;
+  --_iui-slider-width: 100%;
+  --_iui-slider-height: 100%;
+  --_iui-slider-thumb-border-color: var(--iui-color-border-foreground);
+  --_iui-slider-thumb-color: var(--iui-color-background);
+  --_iui-slider-thumb-cursor: grab;
+  --_iui-slider-thumb-size: var(--iui-size-m);
+  --_iui-slider-thumb-transform: none;
+  --_iui-slider-tick-text-color: var(--iui-color-text);
+  --_iui-slider-tick-width: 1px;
+  --_iui-slider-tick-height: 1px;
+  --_iui-slider-ticks-placement-horizontal: 0;
+  --_iui-slider-ticks-placement-vertical: 0;
+  --_iui-slider-track-color: var(--iui-color-border-accent);
+  --_iui-slider-track-thickness: var(--iui-size-2xs);
+  --_iui-slider-rail-color: var(--iui-color-border);
+
   position: relative;
   flex-grow: 1;
   cursor: pointer;
-  touch-action: pan-y;
+  touch-action: pan-y; // TODO: Should this change based on orientation?
   isolation: isolate;
 
   &.iui-grabbing {
     cursor: grabbing;
   }
-}
 
-.iui-slider-rail {
-  position: absolute;
-  background-color: var(--iui-color-border);
-  @media (forced-colors: active) {
-    background-color: CanvasText;
+  &::before {
+    content: '';
+    position: absolute;
+    background-color: var(--_iui-slider-rail-color);
+    block-size: var(--_iui-slider-height);
+    inline-size: var(--_iui-slider-width);
+    inset-block-start: var(--_iui-slider-placement-vertical);
+    inset-inline-start: var(--_iui-slider-placement-horizontal);
+    @media (forced-colors: active) {
+      --_iui-slider-rail-color: CanvasText;
+    }
+  }
+
+  &[aria-orientation='horizontal'] {
+    --_iui-slider-height: var(--_iui-slider-track-thickness);
+    --_iui-slider-placement-vertical: calc(var(--_iui-slider-thumb-size) * 0.5 - 1px);
+    --_iui-slider-thumb-transform: translateX(-50%);
+    --_iui-slider-tick-height: var(--iui-size-s);
+    --_iui-slider-tick-xyz-width: 1px;
+    --_iui-slider-tick-orientation: column;
+    --_iui-slider-ticks-orientation: row;
+    --_iui-slider-ticks-placement-vertical: calc(
+      var(--_iui-slider-placement-vertical) + var(--_iui-slider-track-thickness)
+    );
+    --_iui-slider-track-height: var(--_iui-slider-track-thickness);
+
+    min-block-size: calc(var(--_iui-slider-thumb-size) + 2px);
+  }
+
+  &[aria-orientation='vertical'] {
+    --_iui-slider-width: var(--_iui-slider-track-thickness);
+    --_iui-slider-placement-horizontal: calc(var(--_iui-slider-thumb-size) * 0.5 - 1px);
+    --_iui-slider-thumb-transform: translateY(50%);
+    --_iui-slider-tick-orientation: row;
+    --_iui-slider-tick-width: var(--iui-size-s);
+    --_iui-slider-tick-xyz-height: 1px;
+    --_iui-slider-ticks-orientation: column-reverse;
+    --_iui-slider-ticks-placement-horizontal: calc(
+      var(--_iui-slider-placement-horizontal) + var(--_iui-slider-track-thickness)
+    );
+    --_iui-slider-track-width: var(--_iui-slider-track-thickness);
+
+    min-inline-size: calc(var(--_iui-slider-thumb-size) + 2px);
+    inline-size: fit-content;
+  }
+
+  &[aria-disabled='true'] {
+    cursor: not-allowed;
+    pointer-events: none;
+
+    --_iui-slider-rail-color: var(--iui-color-background-disabled);
+    --_iui-slider-thumb-border-color: var(--iui-color-border);
+    --_iui-slider-thumb-color: var(--iui-color-border);
+    --_iui-slider-thumb-cursor: not-allowed;
+    --_iui-slider-tick-text-color: var(--iui-color-text-disabled);
+    --_iui-slider-track-color: var(--iui-color-border);
+    @media (forced-colors: active) {
+      --_iui-slider-track-color: GrayText;
+      --_iui-slider-thumb-border-color: GrayText;
+      --_iui-slider-thumb-color: GrayText;
+    }
   }
 }
 
 .iui-slider-thumb {
   box-sizing: content-box;
   position: absolute;
-  block-size: $thumb-height;
-  inline-size: $thumb-height;
+  block-size: var(--_iui-slider-thumb-size);
+  inline-size: var(--_iui-slider-thumb-size);
   border-radius: 100%;
   z-index: 1;
-  cursor: grab;
+  cursor: var(--_iui-slider-thumb-cursor);
   @include mixins.iui-focus($thickness: 2px);
-  background: var(--iui-color-background);
-  border: 1px solid var(--iui-color-border-foreground);
-  @media (forced-colors: active) {
-    background: Canvas;
-    border: 1px solid CanvasText;
-  }
+  background: var(--_iui-slider-thumb-color);
+  border: 1px solid var(--_iui-slider-thumb-border-color);
+  transform: var(--_iui-slider-thumb-transform);
 
   &:active {
-    cursor: grabbing;
+    --_iui-slider-thumb-cursor: grabbing;
   }
 }
 
 .iui-slider-track {
   pointer-events: none;
   position: absolute;
-  inset-block-start: var(--iui-size-s);
-  background-color: var(--iui-color-border-accent);
+  background-color: var(--_iui-slider-track-color);
+  block-size: var(--_iui-slider-track-height);
+  inline-size: var(--_iui-slider-track-width);
+  inset-block-start: var(--_iui-slider-placement-vertical);
+  inset-inline-start: var(--_iui-slider-placement-horizontal);
+
   @media (forced-colors: active) {
-    background-color: Highlight;
+    --_iui-slider-track-color: Highlight;
   }
 }
+// #endregion Slider
 
+// #region Ticks
 .iui-slider-ticks {
   position: relative;
   display: flex;
   pointer-events: none;
   justify-content: space-between;
   user-select: none;
-
-  .iui-slider-tick {
-    position: relative;
-    display: flex;
-    pointer-events: none;
-    justify-content: center;
-    align-items: center;
-
-    &::before {
-      background-color: var(--iui-color-border);
-      @media (forced-colors: active) {
-        background-color: CanvasText;
-      }
-    }
-  }
-}
-
-.iui-slider-horizontal {
-  min-block-size: calc(var(--iui-size-s) * 2);
-
-  .iui-slider-rail {
-    inline-size: 100%;
-    block-size: $track-height;
-    inset-block-start: var(--iui-size-s);
-  }
-
-  .iui-slider-thumb {
-    inset-block-start: calc($track-height + 1px); // position center of thumb in center of track
-    transform: translateX(-50%);
-  }
-
-  .iui-slider-track {
-    block-size: $track-height;
-    inset-inline-start: 0;
-  }
-
-  .iui-slider-ticks {
-    padding-block-start: var(--iui-size-m);
-
-    .iui-slider-tick {
-      flex-direction: column;
-      inline-size: 1px;
-
-      &::before {
-        content: '';
-        inline-size: 1px;
-        block-size: $tick-height;
-      }
-    }
-  }
-
-  .iui-slider-min,
-  .iui-slider-max {
-    margin-block-start: var(--iui-size-3xs);
-    min-inline-size: var(--iui-size-l);
-    flex-direction: row;
-
-    svg {
-      margin-block-start: var(--iui-size-2xs);
-    }
-  }
-
-  .iui-slider-min {
-    margin-inline-end: var(--iui-size-s);
-    text-align: end;
-  }
-
-  .iui-slider-max {
-    margin-inline-start: var(--iui-size-s);
-  }
-}
-
-.iui-slider-vertical {
-  flex-direction: column-reverse;
-  min-inline-size: calc(var(--iui-size-s) * 2);
+  padding-block-start: var(--_iui-slider-ticks-placement-vertical);
+  padding-inline-start: var(--_iui-slider-ticks-placement-horizontal);
+  flex-direction: var(--_iui-slider-ticks-orientation);
+  align-items: flex-start;
   block-size: 100%;
+}
 
-  .iui-slider-rail {
-    inline-size: $track-height;
-    block-size: 100%;
-    inset-inline-start: var(--iui-size-s);
-  }
+.iui-slider-tick {
+  position: relative;
+  display: flex;
+  pointer-events: none;
+  justify-content: center;
+  align-items: center;
+  flex-direction: var(--_iui-slider-tick-orientation);
+  block-size: var(--_iui-slider-tick-xyz-height);
+  inline-size: var(--_iui-slider-tick-xyz-width);
+  color: var(--_iui-slider-tick-text-color);
 
-  .iui-slider-thumb {
-    transform: translateY(50%);
-    inset-inline-start: calc($track-height + 1px);
-  }
-
-  .iui-slider-track {
-    inline-size: $track-height;
-    inset-block-end: 0;
-    inset-inline-start: var(--iui-size-s);
-  }
-
-  .iui-slider-ticks {
-    padding-inline-start: var(--iui-size-m);
-    flex-direction: column-reverse;
-    align-items: flex-start;
-    block-size: 100%;
-
-    .iui-slider-tick {
-      flex: row;
-      block-size: 1px;
-
-      &::before {
-        content: '';
-        inline-size: $tick-height;
-        block-size: 1px;
-        margin-inline-end: $tick-height;
-      }
+  &::before {
+    content: '';
+    block-size: var(--_iui-slider-tick-height);
+    inline-size: var(--_iui-slider-tick-width);
+    background-color: var(--iui-color-border);
+    @media (forced-colors: active) {
+      background-color: CanvasText;
     }
   }
-
-  .iui-slider-min,
-  .iui-slider-max {
-    margin-inline-start: calc(var(--iui-size-3xs) + var(--iui-size-s));
-    text-align: center;
-    transform: translate(-50%, 0);
-    min-block-size: var(--iui-size-l);
-    flex-direction: column;
-  }
-
-  .iui-slider-min {
-    margin-block-start: var(--iui-size-s);
-  }
-
-  .iui-slider-max {
-    margin-block-end: var(--iui-size-s);
-  }
 }
+// #endregion Ticks
+
+// .iui-slider-horizontal {
+//   min-block-size: calc(var(--iui-size-s) * 2);
+
+//   .iui-slider-rail {
+//     inline-size: 100%;
+//     block-size: $track-height;
+//     inset-block-start: var(--iui-size-s);
+//   }
+
+//   .iui-slider-thumb {
+//     inset-block-start: calc($track-height + 1px); // position center of thumb in center of track
+//     transform: translateX(-50%);
+//   }
+
+//   .iui-slider-track {
+//     block-size: $track-height;
+//     inset-inline-start: 0;
+//   }
+
+//   .iui-slider-ticks {
+//     padding-block-start: var(--iui-size-m);
+
+//     .iui-slider-tick {
+//       flex-direction: column;
+//       inline-size: 1px;
+
+//       &::before {
+//         content: '';
+//         inline-size: 1px;
+//         block-size: $tick-height;
+//       }
+//     }
+//   }
+
+//   .iui-slider-min,
+//   .iui-slider-max {
+//     margin-block-start: var(--iui-size-3xs);
+//     min-inline-size: var(--iui-size-l);
+//     flex-direction: row;
+
+//     svg {
+//       margin-block-start: var(--iui-size-2xs);
+//     }
+//   }
+
+//   .iui-slider-min {
+//     margin-inline-end: var(--iui-size-s);
+//     text-align: end;
+//   }
+
+//   .iui-slider-max {
+//     margin-inline-start: var(--iui-size-s);
+//   }
+// }
+
+// .iui-slider-vertical {
+//   flex-direction: column-reverse;
+//   min-inline-size: calc(var(--iui-size-s) * 2);
+//   block-size: 100%;
+
+//   .iui-slider-rail {
+//     inline-size: $track-height;
+//     block-size: 100%;
+//     inset-inline-start: var(--iui-size-s);
+//   }
+
+//   .iui-slider-thumb {
+//     transform: translateY(50%);
+//     inset-inline-start: calc($track-height + 1px);
+//   }
+
+//   .iui-slider-track {
+//     inline-size: $track-height;
+//     inset-block-end: 0;
+//     inset-inline-start: var(--iui-size-s);
+//   }
+
+//   .iui-slider-ticks {
+//     padding-inline-start: var(--iui-size-m);
+//     flex-direction: column-reverse;
+//     align-items: flex-start;
+//     block-size: 100%;
+
+//     .iui-slider-tick {
+//       flex: row;
+//       block-size: 1px;
+
+//       &::before {
+//         content: '';
+//         inline-size: $tick-height;
+//         block-size: 1px;
+//         margin-inline-end: $tick-height;
+//       }
+//     }
+//   }
+
+//   .iui-slider-min,
+//   .iui-slider-max {
+//     margin-inline-start: calc(var(--iui-size-3xs) + var(--iui-size-s));
+//     text-align: center;
+//     transform: translate(-50%, 0);
+//     min-block-size: var(--iui-size-l);
+//     flex-direction: column;
+//   }
+
+//   .iui-slider-min {
+//     margin-block-start: var(--iui-size-s);
+//   }
+
+//   .iui-slider-max {
+//     margin-block-end: var(--iui-size-s);
+//   }
+// }


### PR DESCRIPTION
## Changes

**UNFINISHED**

- Refactor slider so that the track, fill, handle can be used without any of the surrounding wrapper.  When used solo there is no unnecessary space above the slider causing visual misalignment.
- Use `aria-orientation` instead of `.iui-slider-vertical` class modifier.
- What was `.iui-slider-rail` is now a `::before` pseudo element.

## Testing

None yet.

## Docs

None yet.
