### PR TITLE
Fixed a11y violations for Slider examples

### DIFF
--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -19,11 +19,7 @@ export default () => {
         Choose a happiness level
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-          };
-        }}
+        thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}
         minLabel={<SvgSmileySadVery />}
         maxLabel={<SvgSmileyHappyVery />}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -15,7 +15,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose a happiness level</Label>
+      <Label id={labelId} as='div'>
+        Choose a happiness level
+      </Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -13,6 +13,11 @@ export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
       <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
         values={[50]}
         minLabel={<SvgSmileySadVery />}
         maxLabel={<SvgSmileyHappyVery />}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Label } from '@itwin/itwinui-react';
 
 import {
   SvgSmileyHappyVery,
@@ -15,9 +15,7 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose a happiness level
-      </Text>
+      <Label id={labelId}>Choose a happiness level</Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -15,7 +15,7 @@ export default () => {
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-label': `Choose a rating`,
           };
         }}
         values={[50]}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -3,19 +3,25 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider } from '@itwin/itwinui-react';
+import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 import {
   SvgSmileyHappyVery,
   SvgSmileySadVery,
 } from '@itwin/itwinui-icons-react';
 
 export default () => {
+  const labelId = useId();
+
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose a happiness level
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a rating`,
+            'aria-labelledby': labelId,
           };
         }}
         values={[50]}

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
+
 import {
   SvgSmileyHappyVery,
   SvgSmileySadVery,
 } from '@itwin/itwinui-icons-react';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -3,15 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider } from '@itwin/itwinui-react';
+import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
+  const labelId = useId();
+
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose a value
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-labelledby': labelId,
           };
         }}
         values={[50]}

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -14,11 +14,7 @@ export default () => {
         Choose a value
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-          };
-        }}
+        thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}
         min={0}
         max={100}

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -3,16 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Label } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose a value
-      </Text>
+      <Label id={labelId}>Choose a value</Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -10,7 +10,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose a value</Label>
+      <Label id={labelId} as='div'>
+        Choose a value
+      </Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -8,7 +8,16 @@ import { Slider } from '@itwin/itwinui-react';
 export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Slider values={[50]} min={0} max={100} />
+      <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
+        values={[50]}
+        min={0}
+        max={100}
+      />
     </div>
   );
 };

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -8,7 +8,16 @@ import { Slider } from '@itwin/itwinui-react';
 export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Slider values={[25, 75]} min={0} max={100} />
+      <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
+        values={[25, 75]}
+        min={0}
+        max={100}
+      />
     </div>
   );
 };

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -11,7 +11,7 @@ export default () => {
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-label': `Choose a range`,
           };
         }}
         values={[25, 75]}

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -3,15 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider } from '@itwin/itwinui-react';
+import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
+  const labelId = useId();
+
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose a range
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a range`,
+            'aria-labelledby': labelId,
           };
         }}
         values={[25, 75]}

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -10,7 +10,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose a range</Label>
+      <Label id={labelId} as='div'>
+        Choose a range
+      </Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[25, 75]}

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -3,16 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Label } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose a range
-      </Text>
+      <Label id={labelId}>Choose a range</Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[25, 75]}

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -14,11 +14,7 @@ export default () => {
         Choose a range
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-          };
-        }}
+        thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[25, 75]}
         min={0}
         max={100}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -11,7 +11,7 @@ export default () => {
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-label': `Choose ranges`,
           };
         }}
         values={[20, 40, 60, 80]}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -9,6 +9,11 @@ export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
       <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
         values={[20, 40, 60, 80]}
         min={0}
         max={100}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -3,15 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider } from '@itwin/itwinui-react';
+import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
+  const labelId = useId();
+
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose ranges
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose ranges`,
+            'aria-labelledby': labelId,
           };
         }}
         values={[20, 40, 60, 80]}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -10,7 +10,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose ranges</Label>
+      <Label id={labelId} as='div'>
+        Choose ranges
+      </Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[20, 40, 60, 80]}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -14,11 +14,7 @@ export default () => {
         Choose ranges
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-          };
-        }}
+        thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[20, 40, 60, 80]}
         min={0}
         max={100}

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -3,16 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Label } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose ranges
-      </Text>
+      <Label id={labelId}>Choose ranges</Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[20, 40, 60, 80]}

--- a/examples/Slider.thumbcustom.tsx
+++ b/examples/Slider.thumbcustom.tsx
@@ -14,6 +14,7 @@ export default () => {
         max={100}
         thumbProps={() => {
           return {
+            'aria-label': `Choose a value`,
             style: {
               display: 'flex',
               justifyContent: 'center',

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -9,6 +9,11 @@ export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
       <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
         values={[50]}
         min={0}
         max={100}

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -3,15 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider } from '@itwin/itwinui-react';
+import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
+  const labelId = useId();
+
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose a value
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-labelledby': labelId,
           };
         }}
         values={[50]}

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -14,11 +14,7 @@ export default () => {
         Choose a value
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-          };
-        }}
+        thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}
         min={0}
         max={100}

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -3,16 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Label } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose a value
-      </Text>
+      <Label id={labelId}>Choose a value</Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -10,7 +10,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose a value</Label>
+      <Label id={labelId} as='div'>
+        Choose a value
+      </Label>
       <Slider
         thumbProps={() => ({ 'aria-labelledby': labelId })}
         values={[50]}

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -29,7 +29,7 @@ export default () => {
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a value`,
+            'aria-label': `Choose a date`,
           };
         }}
         values={[currentValue.number]}

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
-import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
-  const labelId = useId();
+  const labelId = React.useId();
 
   const dateFormatter = React.useMemo(() => {
     return new Intl.DateTimeFormat('default', {

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text } from '@itwin/itwinui-react';
+import { Slider, Text, Label } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
@@ -28,9 +28,7 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Text id={labelId} as='label' variant='leading'>
-        Choose a start date
-      </Text>
+      <Label id={labelId}>Choose a start date</Label>
       <Slider
         thumbProps={() => ({
           'aria-labelledby': labelId,

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -4,8 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Slider, Text } from '@itwin/itwinui-react';
+import { useId } from '../packages/itwinui-react/src/core/utils/hooks/index.js';
 
 export default () => {
+  const labelId = useId();
+
   const dateFormatter = React.useMemo(() => {
     return new Intl.DateTimeFormat('default', {
       month: 'short',
@@ -26,10 +29,14 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
+      <Text id={labelId} as='label' variant='leading'>
+        Choose a start date
+      </Text>
       <Slider
         thumbProps={() => {
           return {
-            'aria-label': `Choose a date`,
+            'aria-labelledby': labelId,
+            'aria-valuetext': dateFormatter.format(currentValue.date),
           };
         }}
         values={[currentValue.number]}

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -28,7 +28,9 @@ export default () => {
 
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
-      <Label id={labelId}>Choose a start date</Label>
+      <Label id={labelId} as='div'>
+        Choose a start date
+      </Label>
       <Slider
         thumbProps={() => ({
           'aria-labelledby': labelId,

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -32,12 +32,10 @@ export default () => {
         Choose a start date
       </Text>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-labelledby': labelId,
-            'aria-valuetext': dateFormatter.format(currentValue.date),
-          };
-        }}
+        thumbProps={() => ({
+          'aria-labelledby': labelId,
+          'aria-valuetext': dateFormatter.format(currentValue.date),
+        })}
         values={[currentValue.number]}
         min={1}
         max={365}

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -27,6 +27,11 @@ export default () => {
   return (
     <div style={{ width: 'min(100%, 300px)' }}>
       <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
         values={[currentValue.number]}
         min={1}
         max={365}

--- a/examples/Slider.vertical.tsx
+++ b/examples/Slider.vertical.tsx
@@ -9,11 +9,7 @@ export default () => {
   return (
     <div style={{ height: '300px' }}>
       <Slider
-        thumbProps={() => {
-          return {
-            'aria-label': `Choose a value`,
-          };
-        }}
+        thumbProps={() => ({ 'aria-label': `Choose a value` })}
         values={[50]}
         orientation='vertical'
       />

--- a/examples/Slider.vertical.tsx
+++ b/examples/Slider.vertical.tsx
@@ -8,7 +8,15 @@ import { Slider } from '@itwin/itwinui-react';
 export default () => {
   return (
     <div style={{ height: '300px' }}>
-      <Slider values={[50]} orientation='vertical' />
+      <Slider
+        thumbProps={() => {
+          return {
+            'aria-label': `Choose a value`,
+          };
+        }}
+        values={[50]}
+        orientation='vertical'
+      />
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Added `aria-label` prop to all thumbs in all `Slider` examples. But no change was needed in component code.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Ensured that the cypress tests for Slider reported no more violations.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A