### PR TITLE
improve website sidebar

### DIFF
--- a/apps/website/src/components/LeftSidebar.astro
+++ b/apps/website/src/components/LeftSidebar.astro
@@ -70,6 +70,7 @@ import LeftSidebarContent from './LeftSidebarContent.astro';
       overflow-y: overlay;
       overflow-x: hidden;
       overflow-x: clip;
+      scroll-snap-type: y mandatory;
       --scrollbar-right-offset: 5px;
 
       &:not(:hover, :focus-within) {

--- a/apps/website/src/components/LeftSidebarContent.astro
+++ b/apps/website/src/components/LeftSidebarContent.astro
@@ -68,8 +68,6 @@ sections.set(
   </ul>
 </nav>
 
-<script></script>
-
 <style lang='scss'>
   @layer components {
     nav {

--- a/apps/website/src/components/LeftSidebarContent.astro
+++ b/apps/website/src/components/LeftSidebarContent.astro
@@ -68,6 +68,8 @@ sections.set(
   </ul>
 </nav>
 
+<script></script>
+
 <style lang='scss'>
   @layer components {
     nav {
@@ -123,13 +125,14 @@ sections.set(
     }
 
     .nav-group-subtitle {
-      margin-top: var(--space-3);
+      margin-top: var(--space-6);
       color: var(--color-mutedtext);
       font-size: var(--type--1);
       font-weight: 600;
       padding-inline: var(--space-5);
       margin-bottom: var(--space-2);
       text-transform: uppercase;
+      letter-spacing: 0.1ex;
 
       @media (max-width: 50em) {
         color: var(--color-mutedtext);
@@ -168,6 +171,19 @@ sections.set(
       background-color: var(--color-active);
       color: var(--color-text);
       position: relative;
+
+      // scroll to current link when page loads, without any JS.
+      // based on https://oh-snap.netlify.app/#scroll-start-trick
+      animation: scroll-into-view 1.5s;
+
+      @keyframes scroll-into-view {
+        from {
+          scroll-snap-align: center;
+        }
+        to {
+          scroll-snap-align: unset;
+        }
+      }
 
       &::before {
         content: '';


### PR DESCRIPTION
## Changes

two changes to sidebar:
- increased separation between nav groups.
- used scroll snapping to scroll to the currently active link when page loads.

both of these were based on user feedback.

## Testing

before:

https://github.com/iTwin/iTwinUI/assets/9084735/7f0a0191-59c3-4ffe-9a64-76d813f6d756

after:

https://github.com/iTwin/iTwinUI/assets/9084735/b3d4d1b8-def1-4aaf-940f-23e6a1678b37


## Docs

n/a