### PR TITLE
move playground reset into layer

### DIFF
--- a/playgrounds/vite/index.html
+++ b/playgrounds/vite/index.html
@@ -11,6 +11,14 @@
       content="dark light"
     />
     <title>iTwinUI-react + vite</title>
+    <style>
+      @layer reset {
+        * {
+          box-sizing: border-box;
+          margin: 0;
+        }
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/playgrounds/vite/src/main.tsx
+++ b/playgrounds/vite/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import styled from '@emotion/styled';
 import { ThemeProvider } from '@itwin/itwinui-react';
 import App from './App';
-import { css, Global } from '@emotion/react';
 import { SvgMoon, SvgSun } from '@itwin/itwinui-icons-react';
 import '@itwin/itwinui-react/styles.css';
 
@@ -14,14 +13,6 @@ const Shell = () => {
 
   return (
     <>
-      <Global
-        styles={css`
-          * {
-            box-sizing: border-box;
-            margin: 0;
-          }
-        `}
-      />
       <ThemeProvider theme={theme}>
         <Main>
           <ThemeButton


### PR DESCRIPTION
## Changes

The `* { margin: 0 }` was overriding any margins from iTwinUI components, so moved it into a layer that comes before the `itwinui` layer. for more details, see https://github.com/iTwin/iTwinUI/wiki/Styling

## Testing

before:

<img width="445" alt="image" src="https://github.com/iTwin/iTwinUI/assets/9084735/7576ec75-0646-4d1c-adf7-5f0fe5da227d">

after:

<img width="439" alt="image" src="https://github.com/iTwin/iTwinUI/assets/9084735/ed3d9183-a250-4111-b1d1-4d0846eba412">


## Docs

n/a.
