### PR TITLE
Fixed Algolia search box styling

### DIFF
--- a/apps/website/src/components/AlgoliaSearch.astro
+++ b/apps/website/src/components/AlgoliaSearch.astro
@@ -24,7 +24,7 @@
   });
 </script>
 
-<style lang='scss'>
+<style lang='scss' is:global>
   @import '@docsearch/css' layer(thirdparty.algolia);
 
   body {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

The broken Algolia styles were because of some unnecessary astro scoping in the Algolia styles. I fixed this by adding [`is:global`](https://docs.astro.build/en/guides/styling/#global-styles).

|Old|New|
|-|-|
|![image](https://github.com/iTwin/iTwinUI/assets/45748283/cc287143-4c0c-4d01-914c-d0ce6849909a)|![image](https://github.com/iTwin/iTwinUI/assets/45748283/2b6d55d2-78fc-42a7-9d0c-67a1edd308ed)|

<details>
<summary>The problem was the unnecessary astro scoping</summary>

![image](https://github.com/iTwin/iTwinUI/assets/45748283/c571d740-3ec7-458b-931b-a8e619bfe456)

</details>

---

I am not sure why didn't this "missing styles" issue happen in the dev version. I suspect it has something to do with the bug in astro where importing styles into a layer also duplicates those styles outside the layer (as mentioned in https://github.com/iTwin/iTwinUI/pull/1365#discussion_r1262621490).

But what I'm confused about is why when running `yarn dev` before this PR shows this order of styles/stylesheets in the browser inspect pane:

* `body` in no layer
* `:root` in no layer
* `:root` in the `thirdparty.algolia` layer

i.e., what surprises me is that even though `body` has a lower specificity (`(0, 0, 1)`) than `:root` (`(0, 1, 0)`), `body`'s styles get preference over `:root`.

<details>
<summary>screenshots</summary>

![image](https://github.com/iTwin/iTwinUI/assets/45748283/20f6cd15-2c98-4f2d-bcda-fd5962f2c726)
![image](https://github.com/iTwin/iTwinUI/assets/45748283/de6fd233-795e-471c-9070-605517fe2a8e)

</details>

---

Regardless, making sure the Algolia styles are global solves the styling issue in the `prod` and `dev` builds. So this PR is good as-is.

<!-- ![image](https://github.com/iTwin/iTwinUI/assets/45748283/88d5eb1f-7920-4f90-b987-6a6289555746) -->
<!-- ![image](https://github.com/iTwin/iTwinUI/assets/45748283/f964241d-16fc-482a-8ff4-2131db675f4b)| -->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Ran `yarn build` and `yarn preview` in the `website` workspace to confirm that the styles show up correctly in the production build.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A