### PR TITLE
 Fixed a11y violations for Tree examples

### DIFF
--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Fixed `aria-owns` syntax for `TreeNode`'s `<ul>` `subNodes`
+Fixed `aria-owns` syntax for `TreeNode`

--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Fixed `aria-owns` value for `TreeNode`

--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Fixed `aria-owns` value for `TreeNode`
+Fixed `aria-owns` syntax for `TreeNode`'s `<ul>` `subNodes`

--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-react': minor
+'@itwin/itwinui-react': patch
 ---
 
 Fixed `aria-owns` syntax for `TreeNode`

--- a/packages/itwinui-react/src/core/Tree/TreeNode.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.tsx
@@ -276,7 +276,7 @@ export const TreeNode = (props: TreeNodeProps) => {
           as='ul'
           className='iui-sub-tree'
           role='group'
-          aria-owns={subNodeIds.join(',')}
+          aria-owns={subNodeIds.join(' ')}
         />
       )}
     </Box>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

`aria-owns` expects a *space* separated list of ids ([MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns#values)). However, we were passing a *comma* separated list of ids. I corrected this mistake and added a short changeset.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the cypress-axe `TreeMainExample` test passes.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A