### PR TITLE
Fixed a11y violations for Tile examples

### DIFF
--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Fixed `aria-owns` syntax for `TreeNode`'s `<ul>` `subNodes`
+Fixed `aria-owns` syntax for `TreeNode`

--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Fixed `aria-owns` value for `TreeNode`

--- a/.changeset/mighty-fireants-check.md
+++ b/.changeset/mighty-fireants-check.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Fixed `aria-owns` value for `TreeNode`
+Fixed `aria-owns` syntax for `TreeNode`'s `<ul>` `subNodes`

--- a/examples/Tile.main.tsx
+++ b/examples/Tile.main.tsx
@@ -13,12 +13,12 @@ export default () => {
       <Tile.ThumbnailArea>
         <Tile.ThumbnailPicture url='https://itwinplatformcdn.azureedge.net/iTwinUI/stadium.png' />
         <Tile.TypeIndicator>
-          <Tile.IconButton>
+          <Tile.IconButton aria-label='Favorite'>
             <SvgStar />
           </Tile.IconButton>
         </Tile.TypeIndicator>
         <Tile.QuickAction>
-          <Tile.IconButton>
+          <Tile.IconButton aria-label='More info'>
             <SvgInfo />
           </Tile.IconButton>
         </Tile.QuickAction>

--- a/packages/itwinui-react/src/core/Tree/TreeNode.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.tsx
@@ -276,7 +276,7 @@ export const TreeNode = (props: TreeNodeProps) => {
           as='ul'
           className='iui-sub-tree'
           role='group'
-          aria-owns={subNodeIds.join(',')}
+          aria-owns={subNodeIds.join(' ')}
         />
       )}
     </Box>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Added `aria-label` to `<Tile.IconButton>` in `TileMainExample`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the cypress-axe `TileMainExample` test passes.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A