### PR TITLE
remove special handling for iphone notch

### DIFF
--- a/.changeset/serious-mice-repair.md
+++ b/.changeset/serious-mice-repair.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-css': patch
+---
+
+Removed special handling of iPhone notch in Header and SideNavigation.

--- a/packages/itwinui-css/src/header/header.scss
+++ b/packages/itwinui-css/src/header/header.scss
@@ -18,7 +18,6 @@
   background-color: var(--iui-color-background);
   border-block-end: 2px solid var(--iui-color-border);
   color: var(--iui-color-text);
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0 env(safe-area-inset-left); // iPhone notch support
   @media (prefers-reduced-motion: no-preference) {
     transition: height var(--iui-duration-1) ease-out;
   }

--- a/packages/itwinui-css/src/side-navigation/side-navigation.scss
+++ b/packages/itwinui-css/src/side-navigation/side-navigation.scss
@@ -62,16 +62,6 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
 
     min-inline-size: calc($icon-large + $iui-side-navigation-icon-margins * 2);
     max-inline-size: calc($icon-large + $iui-side-navigation-icon-margins * 2);
-
-    // iPhone notch support
-    @supports (min-width: string.unquote('max(0px)')) {
-      min-inline-size: string.unquote(
-        'max(#{$icon-large} + #{$iui-side-navigation-icon-margins} * 2, #{$icon-large} + #{$iui-side-navigation-icon-margins} * 2 + env(safe-area-inset-left))'
-      );
-      max-inline-size: string.unquote(
-        'max(#{$icon-large} + #{$iui-side-navigation-icon-margins} * 2, #{$icon-large} + #{$iui-side-navigation-icon-margins} * 2 + env(safe-area-inset-left))'
-      );
-    }
   }
 
   &.iui-expanded,


### PR DESCRIPTION
## Changes

removed safe area insets that were added for iphone notch support because they cause issues when used with RTL or vertical languages.

by default, applications do not fill up the full viewport, so they are already safe from getting clipped by the notch.

if a user wants to override the default behavior using `viewport-fit=cover`, they can also manually add the safe-area-insets to header/side-nav.

## Testing

Was testing it together with @FlyersPh9 in https://github.com/iTwin/iTwinUI/pull/1489#discussion_r1293949164 and found two issues in vertical writing modes:
- when using physical padding (current approach) in header, it results in the header becoming too thick:
   <img width="773" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/e72f45de-508c-4e75-afda-30cb8757ad82">
- when using logical properties, it results in extra gap at the bottom:
   <img width="952" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/019878b7-2808-4f51-87f3-1ea3ec94f0b5">

removing special handling of notch should avoid both issues.

## Docs

n/a