### PR TITLE
use swc to generate cjs styles

### DIFF
--- a/.changeset/thirty-beds-mate.md
+++ b/.changeset/thirty-beds-mate.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue with styles not getting included in CommonJS environments.

--- a/.changeset/thirty-beds-mate.md
+++ b/.changeset/thirty-beds-mate.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed an issue with styles not getting included in CommonJS environments.
+Fixed an issue where styles were not included in CommonJS environments.


### PR DESCRIPTION
## Changes

Previously we were generating `cjs/styles.js` by hand. Turns out mixed default+named exports in CommonJS are complicated and need more work than simply using `module.exports=` and `exports.whatever=`. See [playground](https://play.swc.rs/?version=1.3.74&code=H4sIAAAAAAAAA0utKMgvKlFISU1LLM0pUVAvycgsVgCikoxUmKC6NVcqRFVyfl5xiUJafr6CLUJlXmJuaoq6NQDsn8KpSQAAAA%3D%3D&config=H4sIAAAAAAAAA1VPOw7DIAzdOQXy3KHN2Dv0EIg6EYifMJGKoty9QCBtNr%2B%2FvDHOQZOEJ9%2FKWUAQkTCeuDCUXRKfwgBKK0hGFRLchqqpSrMwhI3aDwWSiAumlqLpPj16Aoz3hCPROaucmvP%2FpvQ2RCS6GqtVuMXgdZH1VbD%2BvTax%2F5JyqKi2We80wc85Fs92UPQa8RRXZPsXM%2FmJHxwBAAA%3D).

So now, I'm using `swc` to transform the ESM exports into CJS.

Unrelated: I'm auto-deleting the `styles.js` that gets left behind when switching between `dev`/`main` branches, as it messes up build sometimes.

## Testing

Confirmed that correct output is generated after build. Confirmed that it works in CJS by testing locally in a CRA test app and also testing in a real project with @veekeys.

## Docs

N/A