### PR TITLE
restore old `Alert` api

### DIFF
--- a/.changeset/odd-crabs-approve.md
+++ b/.changeset/odd-crabs-approve.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-react': major
+'@itwin/itwinui-react': minor
 ---
 
-Alert composition has been updated such that it is now made up of customizable subcomponents, thus removing the `onClose`, `clickableText`, and `clickableTextProps` props from `Alert`.
+Alert can now be used through customizable subcomponents. The `onClose`, `clickableText`, and `clickableTextProps` props have been deprecated.

--- a/apps/storybook/src/Alert.stories.tsx
+++ b/apps/storybook/src/Alert.stories.tsx
@@ -21,7 +21,7 @@ export default {
 
 export const Informational: Story<AlertProps> = (args) => {
   return (
-    <Alert type='informational' {...args}>
+    <Alert.Wrapper type='informational' {...args}>
       <Alert.Icon />
       <Alert.Message>
         This is an informational message.
@@ -30,7 +30,7 @@ export const Informational: Story<AlertProps> = (args) => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={action('Close!')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 
@@ -41,7 +41,7 @@ Informational.args = {
 
 export const Positive: Story<AlertProps> = (args) => {
   return (
-    <Alert type='positive' {...args}>
+    <Alert.Wrapper type='positive' {...args}>
       <Alert.Icon />
       <Alert.Message>
         This is a positive message.
@@ -50,7 +50,7 @@ export const Positive: Story<AlertProps> = (args) => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={action('Close!')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 
@@ -61,7 +61,7 @@ Positive.args = {
 
 export const Warning: Story<AlertProps> = (args) => {
   return (
-    <Alert type='warning' {...args}>
+    <Alert.Wrapper type='warning' {...args}>
       <Alert.Icon />
       <Alert.Message>
         This is a warning message.
@@ -70,7 +70,7 @@ export const Warning: Story<AlertProps> = (args) => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={action('Close!')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 
@@ -81,7 +81,7 @@ Warning.args = {
 
 export const Negative: Story<AlertProps> = (args) => {
   return (
-    <Alert type='negative' {...args}>
+    <Alert.Wrapper type='negative' {...args}>
       <Alert.Icon />
       <Alert.Message>
         This is a negative message.
@@ -90,7 +90,7 @@ export const Negative: Story<AlertProps> = (args) => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={action('Close!')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 
@@ -109,7 +109,7 @@ export const Sticky: Story<AlertProps> = (args) => {
         border: 'solid 0.5px',
       }}
     >
-      <Alert type='informational' isSticky={true} {...args}>
+      <Alert.Wrapper type='informational' isSticky={true} {...args}>
         <Alert.Icon />
         <Alert.Message>
           This is sticky!
@@ -118,7 +118,7 @@ export const Sticky: Story<AlertProps> = (args) => {
           </Alert.Action>
         </Alert.Message>
         <Alert.CloseButton onClick={action('Close!')} />
-      </Alert>
+      </Alert.Wrapper>
       <p style={{ margin: 0, padding: '8px' }}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -171,10 +171,10 @@ Sticky.args = {
 
 export const Empty: Story<AlertProps> = (args) => {
   return (
-    <Alert type='informational' {...args}>
+    <Alert.Wrapper type='informational' {...args}>
       <Alert.Icon />
       <Alert.Message>This is an empty info message.</Alert.Message>
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 
@@ -185,7 +185,7 @@ Empty.args = {
 
 export const CustomIcon: Story<AlertProps> = (args) => {
   return (
-    <Alert type='informational' {...args}>
+    <Alert.Wrapper type='informational' {...args}>
       <Alert.Icon>
         <SvgSmileyHappy />
       </Alert.Icon>
@@ -193,7 +193,7 @@ export const CustomIcon: Story<AlertProps> = (args) => {
       <Alert.CloseButton onClick={action('Close!')}>
         <SvgPlaceholder />
       </Alert.CloseButton>
-    </Alert>
+    </Alert.Wrapper>
   );
 };
 

--- a/apps/website/src/demos/Alert.demo.tsx
+++ b/apps/website/src/demos/Alert.demo.tsx
@@ -8,14 +8,14 @@ import { Alert, ThemeProvider } from '@itwin/itwinui-react';
 export default function AlertDemo() {
   return (
     <ThemeProvider theme='dark'>
-      <Alert style={{ minWidth: 'min(100%, 350px)' }}>
+      <Alert.Wrapper style={{ minWidth: 'min(100%, 350px)' }}>
         <Alert.Icon />
         <Alert.Message>
           This is an alert
           <Alert.Action onClick={() => console.log('Clicked more info!')}>Learn more</Alert.Action>
         </Alert.Message>
         <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-      </Alert>
+      </Alert.Wrapper>
     </ThemeProvider>
   );
 }

--- a/examples/Alert.informational.tsx
+++ b/examples/Alert.informational.tsx
@@ -7,7 +7,10 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Alert type='informational' style={{ minWidth: 'min(100%, 350px)' }}>
+    <Alert.Wrapper
+      type='informational'
+      style={{ minWidth: 'min(100%, 350px)' }}
+    >
       <Alert.Icon />
       <Alert.Message>
         This is an informational alert
@@ -16,6 +19,6 @@ export default () => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };

--- a/examples/Alert.inline.tsx
+++ b/examples/Alert.inline.tsx
@@ -9,9 +9,9 @@ export default () => {
   return (
     <div>
       <p style={{ marginBottom: 12 }}>Page content before alert.</p>
-      <Alert style={{ minWidth: 'min(100%, 280px)' }}>
+      <Alert.Wrapper style={{ minWidth: 'min(100%, 280px)' }}>
         <Alert.Message>This is a inline alert.</Alert.Message>
-      </Alert>
+      </Alert.Wrapper>
       <p style={{ marginTop: 12 }}>Page content after alert.</p>
     </div>
   );

--- a/examples/Alert.main.tsx
+++ b/examples/Alert.main.tsx
@@ -7,7 +7,7 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Alert style={{ minWidth: 'min(100%, 350px)' }}>
+    <Alert.Wrapper style={{ minWidth: 'min(100%, 350px)' }}>
       <Alert.Icon />
       <Alert.Message>
         This is an alert
@@ -16,6 +16,6 @@ export default () => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };

--- a/examples/Alert.negative.tsx
+++ b/examples/Alert.negative.tsx
@@ -7,7 +7,7 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Alert type='negative' style={{ minWidth: 'min(100%, 350px)' }}>
+    <Alert.Wrapper type='negative' style={{ minWidth: 'min(100%, 350px)' }}>
       <Alert.Icon />
       <Alert.Message>
         This is a negative alert
@@ -16,6 +16,6 @@ export default () => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };

--- a/examples/Alert.positive.tsx
+++ b/examples/Alert.positive.tsx
@@ -7,7 +7,7 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Alert type='positive' style={{ minWidth: 'min(100%, 350px)' }}>
+    <Alert.Wrapper type='positive' style={{ minWidth: 'min(100%, 350px)' }}>
       <Alert.Icon />
       <Alert.Message>
         This is a positive alert
@@ -16,6 +16,6 @@ export default () => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };

--- a/examples/Alert.sticky.tsx
+++ b/examples/Alert.sticky.tsx
@@ -8,7 +8,7 @@ import { Alert } from '@itwin/itwinui-react';
 export default () => {
   return (
     <div>
-      <Alert isSticky>
+      <Alert.Wrapper isSticky>
         <Alert.Icon />
         <Alert.Message>
           This is a sticky alert
@@ -17,7 +17,7 @@ export default () => {
           </Alert.Action>
         </Alert.Message>
         <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-      </Alert>
+      </Alert.Wrapper>
       <p>Page content.</p>
     </div>
   );

--- a/examples/Alert.warning.tsx
+++ b/examples/Alert.warning.tsx
@@ -7,7 +7,7 @@ import { Alert } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Alert type='warning' style={{ minWidth: 'min(100%, 350px)' }}>
+    <Alert.Wrapper type='warning' style={{ minWidth: 'min(100%, 350px)' }}>
       <Alert.Icon />
       <Alert.Message>
         This is a warning alert
@@ -16,6 +16,6 @@ export default () => {
         </Alert.Action>
       </Alert.Message>
       <Alert.CloseButton onClick={() => console.log('CLOSED')} />
-    </Alert>
+    </Alert.Wrapper>
   );
 };

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -75,6 +75,7 @@ const AlertComponent = React.forwardRef((props, forwardedRef) => {
     </Alert.Wrapper>
   );
 }) as PolymorphicForwardRefComponent<'div', AlertOwnProps & AlertLegacyProps>;
+AlertComponent.displayName = 'Alert';
 
 // ----------------------------------------------------------------------------
 // Alert.Wrapper component

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -11,6 +11,7 @@ import {
   StatusIconMap,
   SvgCloseSmall,
   Box,
+  ButtonBase,
 } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { IconButton } from '../Buttons/index.js';
@@ -25,9 +26,6 @@ const AlertContext = React.createContext<
   | undefined
 >(undefined);
 
-// ----------------------------------------------------------------------------
-// Alert component
-
 type AlertOwnProps = {
   /**
    * Type of the alert.
@@ -41,7 +39,47 @@ type AlertOwnProps = {
   isSticky?: boolean;
 };
 
-const AlertComponent = React.forwardRef((props, ref) => {
+type AlertLegacyProps = {
+  /** @deprecated - Use `Alert.Action` subcomponent. */
+  clickableText?: React.ReactNode;
+  /** @deprecated - Use `Alert.Action` subcomponent. */
+  clickableTextProps?: React.ComponentPropsWithoutRef<'a'>;
+  /** @deprecated - Use `Alert.CloseButton` subcomponent. */
+  onClose?: () => void;
+};
+
+// ----------------------------------------------------------------------------
+// Alert component
+
+const AlertComponent = React.forwardRef((props, forwardedRef) => {
+  const {
+    children,
+    type = 'informational',
+    isSticky = false,
+    clickableText,
+    clickableTextProps,
+    onClose,
+    ...rest
+  } = props;
+
+  return (
+    <Alert.Wrapper type={type} isSticky={isSticky} ref={forwardedRef} {...rest}>
+      <Alert.Icon />
+      <Alert.Message>
+        {children}
+        {clickableText ? (
+          <Alert.Action {...clickableTextProps}>{clickableText}</Alert.Action>
+        ) : null}
+      </Alert.Message>
+      {onClose ? <Alert.CloseButton onClick={onClose} /> : null}
+    </Alert.Wrapper>
+  );
+}) as PolymorphicForwardRefComponent<'div', AlertOwnProps & AlertLegacyProps>;
+
+// ----------------------------------------------------------------------------
+// Alert.Wrapper component
+
+const AlertWrapper = React.forwardRef((props, ref) => {
   const {
     children,
     className,
@@ -62,7 +100,7 @@ const AlertComponent = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', AlertOwnProps>;
-AlertComponent.displayName = 'Alert';
+AlertWrapper.displayName = 'Alert.Wrapper';
 
 // ----------------------------------------------------------------------------
 // Alert.Icon component
@@ -95,14 +133,14 @@ const AlertAction = React.forwardRef((props, ref) => {
   const { children, className, ...rest } = props;
 
   return (
-    <Box
+    <ButtonBase
       as={(!!props.href ? 'a' : 'button') as 'a'}
       className={cx('iui-alert-link', className)}
       ref={ref}
       {...rest}
     >
       {children}
-    </Box>
+    </ButtonBase>
   );
 }) as PolymorphicForwardRefComponent<'a'>;
 AlertAction.displayName = 'Alert.Action';
@@ -154,6 +192,10 @@ AlertCloseButton.displayName = 'Alert.CloseButton';
  * </Alert>
  */
 export const Alert = Object.assign(AlertComponent, {
+  /**
+   *  Alert wrapper subcomponent
+   */
+  Wrapper: AlertWrapper,
   /**
    * 	Alert icon subcomponent
    */

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -169,17 +169,15 @@ AlertCloseButton.displayName = 'Alert.CloseButton';
 /**
  * A small box to quickly grab user attention and communicate a brief message
  * @example
- * <Alert>
- *  <Alert.Message>This is an alert.</Alert.Message>
- * </Alert>
+ * <Alert>This is an alert.</Alert>
  * @example
- * <Alert type='informational'>
+ * <Alert.Wrapper type='informational'>
  *  <Alert.Icon />
  *  <Alert.Message>This is an informational alert.</Alert.Message>
  *  <Alert.CloseButton onClick={() => {}} />
- * </Alert>
+ * </Alert.Wrapper>
  * @example
- * <Alert type='positive'>
+ * <Alert.Wrapper type='positive'>
  *  <Alert.Icon>
  *    <SvgSmileyHappy />
  *  </Alert.Icon>
@@ -190,7 +188,7 @@ AlertCloseButton.displayName = 'Alert.CloseButton';
  *  <Alert.CloseButton onClick={() => {}}>
  *    <SvgCollapse />
  *  </Alert.CloseButton>
- * </Alert>
+ * </Alert.Wrapper>
  */
 export const Alert = Object.assign(AlertComponent, {
   /**

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -40,11 +40,11 @@ type AlertOwnProps = {
 };
 
 type AlertLegacyProps = {
-  /** @deprecated - Use `Alert.Action` subcomponent. */
+  /** @deprecated Use `Alert.Action` subcomponent. */
   clickableText?: React.ReactNode;
-  /** @deprecated - Use `Alert.Action` subcomponent. */
+  /** @deprecated Use `Alert.Action` subcomponent. */
   clickableTextProps?: React.ComponentPropsWithoutRef<'a'>;
-  /** @deprecated - Use `Alert.CloseButton` subcomponent. */
+  /** @deprecated Use `Alert.CloseButton` subcomponent. */
   onClose?: () => void;
 };
 


### PR DESCRIPTION
## Changes

similar to #1502, brought back the old Alert api, reverting the breaking change from #1247.

the following two snippets are now equivalent:
```jsx
<Alert
  type='positive'
  onClose={onClose}
  clickableText='Click me'
  clickableTextProps={{ href: '/' }}
>
  This is an alert.
</Alert>
```
```jsx
<Alert.Wrapper type='positive'>
  <Alert.Icon />
  <Alert.Message>
    This is an alert.
    <Alert.Action href='/'>Click me</Alert.Action>
  </Alert.Message>
  <Alert.CloseButton onClick={onClose} />
</Alert.Wrapper>

```

Other notes:
- added missing `ButtonBase` (from #1461) to `Alert.Action`
- the `clickableText`, `clickableTextProps` and `onClose` props have been brought back but are still deprecated to encourage use of new api.
  - the purpose of restoring the old api in this case is just to make migration easier. `clickableText` is not a good api so it should be avoided.

## Testing

Tested in playground, and added one unit test for legacy api.

## Docs

Updated old changeset and old examples in website. Didn't add legacy api example to docs, to encourage new api. 

Will update migration guide.