### PR TITLE
add `ariaStrategy` prop to `Tooltip`

### DIFF
--- a/.changeset/nice-crabs-explode.md
+++ b/.changeset/nice-crabs-explode.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': major
+---
+
+Removed `iui-tooltip-container` and `iui-tooltip-visible` classes. The display is now toggled using the `hidden` HTML attribute, and the positioning should be managed using custom JS/CSS.

--- a/.changeset/yellow-shirts-fix.md
+++ b/.changeset/yellow-shirts-fix.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added `ariaStrategy` prop to Tooltip. Can be used to change how the tooltip is associated with the trigger element.

--- a/packages/itwinui-css/backstop/tests/avatar.html
+++ b/packages/itwinui-css/backstop/tests/avatar.html
@@ -39,6 +39,10 @@
         margin-right: 4px;
       }
 
+      .demo-tooltip-container {
+        position: relative;
+      }
+
       .demo-right {
         top: -5px;
         left: 100%;
@@ -490,7 +494,7 @@
           5
         </span>
 
-        <div class="iui-tooltip-container">
+        <div class="demo-tooltip-container">
           <span class="iui-tooltip demo-right">Terry Rivers<br />Robin Mercer<br />Terry Rivers<br />Robin
             Mercer<br />Terry
             Rivers</span>
@@ -537,7 +541,7 @@
           5
         </span>
 
-        <div class="iui-tooltip-container">
+        <div class="demo-tooltip-container">
           <span class="iui-tooltip demo-right">Terry Rivers<br />Robin Mercer<br />Terry Rivers<br />Robin
             Mercer<br />Terry
             Rivers</span>
@@ -584,7 +588,7 @@
           5
         </span>
 
-        <div class="iui-tooltip-container">
+        <div class="demo-tooltip-container">
           <span class="iui-tooltip demo-right">Terry Rivers<br />Robin Mercer<br />Terry Rivers<br />Robin
             Mercer<br />Terry
             Rivers</span>
@@ -631,7 +635,7 @@
           5
         </span>
 
-        <div class="iui-tooltip-container">
+        <div class="demo-tooltip-container">
           <span class="iui-tooltip demo-right">Terry Rivers<br />Robin Mercer<br />Terry Rivers<br />Robin
             Mercer<br />Terry
             Rivers</span>
@@ -805,7 +809,7 @@
           5
         </span>
 
-        <div class="iui-tooltip-container">
+        <div class="demo-tooltip-container">
           <span class="iui-tooltip demo-right">Terry Rivers<br />Robin Mercer<br />Terry Rivers<br />Robin
             Mercer<br />Terry
             Rivers</span>
@@ -973,9 +977,9 @@
       document.querySelectorAll('#demo-list .iui-avatar-list').forEach((list) => {
         const lastIcon = list.querySelector('.iui-avatar:nth-last-child(2)');
         const tooltip = list.querySelector('.iui-tooltip');
-        tooltip.style.visibility = 'visible';
-        lastIcon.addEventListener('mouseenter', () => { tooltip.style.opacity = 1; });
-        lastIcon.addEventListener('mouseleave', () => { tooltip.style.opacity = 0; });
+        tooltip.hidden = true;
+        lastIcon.addEventListener('mouseenter', () => { tooltip.hidden = false; });
+        lastIcon.addEventListener('mouseleave', () => { tooltip.hidden = true; });
       });
     </script>
   </body>

--- a/packages/itwinui-css/backstop/tests/radio-tile.html
+++ b/packages/itwinui-css/backstop/tests/radio-tile.html
@@ -39,6 +39,9 @@
         gap: 12px;
         margin-bottom: 12px;
       }
+      .demo-tooltip-container {
+        position: relative;
+      }
       .demo-right {
         top: 0;
         left: 100%;
@@ -582,7 +585,7 @@
           id="radio-tile-with-tooltips"
         >
 
-          <div class="iui-tooltip-container">
+          <div class="demo-tooltip-container">
             <label class="iui-radio-tile">
               <input
                 class="iui-radio-tile-input"
@@ -602,7 +605,7 @@
               assets</span>
           </div>
 
-          <div class="iui-tooltip-container">
+          <div class="demo-tooltip-container">
             <label class="iui-radio-tile">
               <input
                 class="iui-radio-tile-input"
@@ -622,7 +625,7 @@
               assets</span>
           </div>
 
-          <div class="iui-tooltip-container">
+          <div class="demo-tooltip-container">
             <label class="iui-radio-tile">
               <input
                 class="iui-radio-tile-input"
@@ -641,7 +644,7 @@
             <span class="iui-tooltip demo-right">Dimensions in dp/sp,<br />XML export,<br />PNG and SVG assets</span>
           </div>
 
-          <div class="iui-tooltip-container">
+          <div class="demo-tooltip-container">
             <label class="iui-radio-tile">
               <input
                 class="iui-radio-tile-input"
@@ -867,5 +870,14 @@
         </div>
       </div>
     </section>
+
+    <script>
+      document.querySelectorAll('.demo-tooltip-container').forEach((container) => {
+        const tooltip = container.querySelector('.iui-tooltip');
+        tooltip.hidden = true;
+        container.addEventListener('mouseenter', () => { tooltip.hidden = false; });
+        container.addEventListener('mouseleave', () => { tooltip.hidden = true; });
+      });
+    </script>
   </body>
 </html>

--- a/packages/itwinui-css/backstop/tests/tooltip.html
+++ b/packages/itwinui-css/backstop/tests/tooltip.html
@@ -122,7 +122,7 @@
 
       <div class="demo-tooltip-container">
         Hover here (permanent)
-        <span class="iui-tooltip bottom iui-tooltip-visible">
+        <span class="iui-tooltip bottom">
           This tooltip will not disappear.
         </span>
       </div>

--- a/packages/itwinui-css/backstop/tests/tooltip.html
+++ b/packages/itwinui-css/backstop/tests/tooltip.html
@@ -21,7 +21,10 @@
       @import url("./assets/demo.css") layer(demo);
       @import url('@itwin/itwinui-variables') layer(variables);
       @import url("@itwin/itwinui-css/css/all.css") layer(itwinui);
-      .iui-tooltip-container {
+      .demo-tooltip-container {
+        inline-size: fit-content;
+        block-size: fit-content;
+        position: relative;
         margin-left: 90px;
         margin-bottom: 35px;
       }
@@ -69,29 +72,44 @@
     <br />
 
     <section id="demo-tooltip">
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (top)
-        <span class="iui-tooltip top">Hello, I'm a tooltip!</span>
+        <span
+          class="iui-tooltip top"
+          hidden
+        >Hello, I'm a tooltip!</span>
       </div>
 
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (right)
-        <span class="iui-tooltip right">Hello, I'm a tooltip!</span>
+        <span
+          class="iui-tooltip right"
+          hidden
+        >Hello, I'm a tooltip!</span>
       </div>
 
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (bottom)
-        <span class="iui-tooltip bottom">Hello, I'm a tooltip!</span>
+        <span
+          class="iui-tooltip bottom"
+          hidden
+        >Hello, I'm a tooltip!</span>
       </div>
 
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (left)
-        <span class="iui-tooltip left">Hello, I'm a tooltip!</span>
+        <span
+          class="iui-tooltip left"
+          hidden
+        >Hello, I'm a tooltip!</span>
       </div>
 
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (Lorem ipsum)
-        <span class="iui-tooltip top">
+        <span
+          class="iui-tooltip top"
+          hidden
+        >
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
           tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
           veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -102,12 +120,20 @@
         </span>
       </div>
 
-      <div class="iui-tooltip-container">
+      <div class="demo-tooltip-container">
         Hover here (permanent)
         <span class="iui-tooltip bottom iui-tooltip-visible">
           This tooltip will not disappear.
         </span>
       </div>
     </section>
+
+    <script>
+      document.querySelectorAll('.demo-tooltip-container:not(:last-child)').forEach((container) => {
+        const tooltip = container.querySelector('.iui-tooltip');
+        container.addEventListener('mouseenter', () => { tooltip.hidden = false; });
+        container.addEventListener('mouseleave', () => { tooltip.hidden = true; });
+      });
+    </script>
   </body>
 </html>

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -2,31 +2,9 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @use '../mixins';
 
-// Statics version of hidden/visible animation handling
-.iui-tooltip-container {
-  inline-size: fit-content;
-  block-size: fit-content;
-  position: relative;
-
-  > .iui-tooltip {
-    position: absolute;
-    visibility: hidden;
-    user-select: none;
-    opacity: 0;
-    /// Following this guide for animation on exit hover: https://greywyvern.com/?post=337
-    transition: visibility var(--iui-duration-0) linear var(--iui-duration-1), opacity var(--iui-duration-1) ease-out;
-  }
-
-  > .iui-tooltip.iui-tooltip-visible,
-  &:hover > .iui-tooltip {
-    visibility: visible;
-    opacity: 1;
-  }
-}
-
-// Styling tooltip only
 .iui-tooltip {
   @include mixins.iui-reset;
+  position: absolute;
   display: block;
   text-align: center;
   border-radius: var(--iui-border-radius-1);

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -44,4 +44,8 @@
   border: 1px solid rgba(255, 255, 255, var(--iui-opacity-4));
 
   @include mixins.iui-blur($hsl: 0 0% 0%, $opacity: 3);
+
+  &[hidden] {
+    display: none !important;
+  }
 }

--- a/packages/itwinui-react/src/core/Buttons/IconButton/IconButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton/IconButton.tsx
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import * as React from 'react';
-import { VisuallyHidden, Popover, Box, ButtonBase } from '../../utils/index.js';
+import { VisuallyHidden, Box, ButtonBase } from '../../utils/index.js';
+import { Tooltip } from '../../Tooltip/Tooltip.js';
 import type { ButtonProps } from '../Button/Button.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
@@ -46,53 +47,35 @@ export const IconButton = React.forwardRef((props, ref) => {
     ...rest
   } = props;
 
-  return (
-    <IconButtonTooltip label={label}>
-      <ButtonBase
-        ref={ref}
-        className={cx('iui-button', className)}
-        data-iui-variant={styleType !== 'default' ? styleType : undefined}
-        data-iui-size={size}
-        data-iui-active={isActive}
-        aria-pressed={isActive}
-        {...rest}
+  const button = (
+    <ButtonBase
+      ref={ref}
+      className={cx('iui-button', className)}
+      data-iui-variant={styleType !== 'default' ? styleType : undefined}
+      data-iui-size={size}
+      data-iui-active={isActive}
+      aria-pressed={isActive}
+      {...rest}
+    >
+      <Box
+        as='span'
+        aria-hidden
+        {...iconProps}
+        className={cx('iui-button-icon', iconProps?.className)}
       >
-        <Box
-          as='span'
-          aria-hidden
-          {...iconProps}
-          className={cx('iui-button-icon', iconProps?.className)}
-        >
-          {children}
-        </Box>
-        {label ? <VisuallyHidden>{label}</VisuallyHidden> : null}
-      </ButtonBase>
-    </IconButtonTooltip>
+        {children}
+      </Box>
+      {label ? <VisuallyHidden>{label}</VisuallyHidden> : null}
+    </ButtonBase>
   );
-}) as PolymorphicForwardRefComponent<'button', IconButtonProps>;
-
-const IconButtonTooltip = (props: {
-  label?: React.ReactNode;
-  children: React.ReactElement;
-}) => {
-  const { label, children } = props;
 
   return label ? (
-    <Popover
-      interactive={false}
-      offset={[0, 4]}
-      aria={{ content: null }}
-      content={
-        <Box aria-hidden='true' className='iui-tooltip'>
-          {label}
-        </Box>
-      }
-    >
-      {children}
-    </Popover>
+    <Tooltip content={label} ariaStrategy='none'>
+      {button}
+    </Tooltip>
   ) : (
-    children
+    button
   );
-};
+}) as PolymorphicForwardRefComponent<'button', IconButtonProps>;
 
 export default IconButton;

--- a/packages/itwinui-react/src/core/SideNavigation/SideNavigation.test.tsx
+++ b/packages/itwinui-react/src/core/SideNavigation/SideNavigation.test.tsx
@@ -184,12 +184,14 @@ it('should only add tooltips to items when collapsed', async () => {
   mainItems.forEach((item, index) => {
     expect(
       queryByText(`mockbutton ${index}`, { selector: '.iui-tooltip' }),
-    ).toBeFalsy();
+    ).not.toBeVisible();
     jest.useFakeTimers();
     fireEvent.mouseEnter(item);
     act(() => void jest.advanceTimersByTime(50));
     jest.useRealTimers();
-    getByText(`mockbutton ${index}`, { selector: '.iui-tooltip' });
+    expect(
+      getByText(`mockbutton ${index}`, { selector: '.iui-tooltip' }),
+    ).toBeVisible();
   });
 
   // expanded

--- a/packages/itwinui-react/src/core/Slider/Slider.test.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.test.tsx
@@ -196,7 +196,7 @@ it('should show tooltip when focused', async () => {
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
-  expect(document.querySelector('.iui-tooltip')?.textContent).toBe('50');
+  expect(document.querySelector('.iui-tooltip')).toBeVisible();
 });
 
 it('should not show tooltip if visibility is overridden', async () => {
@@ -213,7 +213,7 @@ it('should not show tooltip if visibility is overridden', async () => {
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
-  expect(document.querySelector('.iui-tooltip')).toBeFalsy();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
 });
 
 it('should show custom tooltip when focused', async () => {
@@ -232,7 +232,9 @@ it('should show custom tooltip when focused', async () => {
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
-  expect(document.querySelector('.iui-tooltip')?.textContent).toBe('$50.00');
+  const tooltip = document.querySelector('.iui-tooltip');
+  expect(tooltip).toBeVisible();
+  expect(tooltip).toHaveTextContent('$50.00');
 });
 
 it('should take class and style', () => {
@@ -511,14 +513,16 @@ it('should show tooltip on thumb hover', async () => {
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-  expect(document.querySelector('.iui-tooltip')).toBeFalsy();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
 
   jest.useFakeTimers();
   fireEvent.mouseEnter(thumb);
   act(() => void jest.advanceTimersByTime(50));
   jest.useRealTimers();
 
-  expect(document.querySelector('.iui-tooltip')?.textContent).toBe('50');
+  const tooltip = document.querySelector('.iui-tooltip');
+  expect(tooltip).toBeVisible();
+  expect(tooltip).toHaveTextContent('50');
 });
 
 it('should show tooltip on thumb focus', async () => {
@@ -526,12 +530,13 @@ it('should show tooltip on thumb focus', async () => {
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-  expect(document.querySelector('.iui-tooltip')).toBeFalsy();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
 
   await userEvent.tab();
-  expect(
-    (document.querySelector('.iui-tooltip') as HTMLDivElement).textContent,
-  ).toBe('50');
+
+  const tooltip = document.querySelector('.iui-tooltip');
+  expect(tooltip).toBeVisible();
+  expect(tooltip).toHaveTextContent('50');
 });
 
 it('should apply thumb props', () => {

--- a/packages/itwinui-react/src/core/Slider/Thumb.tsx
+++ b/packages/itwinui-react/src/core/Slider/Thumb.tsx
@@ -151,6 +151,7 @@ export const Thumb = (props: ThumbProps) => {
     <Tooltip
       placement='top'
       autoUpdateOptions={{ animationFrame: true }}
+      ariaStrategy='none'
       {...tooltipProps}
     >
       <Box

--- a/packages/itwinui-react/src/core/Stepper/Stepper.test.tsx
+++ b/packages/itwinui-react/src/core/Stepper/Stepper.test.tsx
@@ -233,8 +233,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   render(stepper);
 
-  expect(document.querySelector('.iui-tooltip')).toBeNull();
-  expect(screen.queryByText('Step one tooltip')).toBeNull();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
   fireEvent.mouseEnter(screen.getByText('Step One'), { bubbles: true });
   act(() => void jest.advanceTimersByTime(50));
   const tooltip = document.querySelector('.iui-tooltip') as HTMLElement;
@@ -246,7 +245,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   fireEvent.mouseEnter(screen.getByText('Step Three'), { bubbles: true });
   act(() => void jest.advanceTimersByTime(50));
-  expect(document.querySelector('.iui-tooltip')).toBeNull();
+  expect(tooltip).not.toBeVisible();
 
   jest.useRealTimers();
 });

--- a/packages/itwinui-react/src/core/Stepper/WorkflowDiagram.test.tsx
+++ b/packages/itwinui-react/src/core/Stepper/WorkflowDiagram.test.tsx
@@ -80,8 +80,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   render(workflowDiagram);
 
-  expect(document.querySelector('.iui-tooltip')).toBeNull();
-  expect(screen.queryByText('Step one tooltip')).toBeNull();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
   fireEvent.mouseEnter(screen.getByText('Step One'), { bubbles: true });
   act(() => void jest.advanceTimersByTime(50));
   const tooltip = document.querySelector('.iui-tooltip') as HTMLElement;
@@ -93,7 +92,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   fireEvent.mouseEnter(screen.getByText('Step Three'), { bubbles: true });
   act(() => void jest.advanceTimersByTime(50));
-  expect(document.querySelector('.iui-tooltip')).toBeNull();
+  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
 
   jest.useRealTimers();
 });

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -87,3 +87,27 @@ it('should allow button clicks and hovers', () => {
   expect(mouseEnterHandler).toBeCalledTimes(1);
   expect(mouseLeaveHandler).toBeCalledTimes(1);
 });
+
+it.each(['description', 'label', 'none'] as const)(
+  'should respect ariaStrategy=%s',
+  (strategy) => {
+    const { getByText } = render(
+      <Tooltip content='some text' ariaStrategy={strategy}>
+        <button>hi</button>
+      </Tooltip>,
+    );
+
+    const trigger = getByText('hi');
+
+    if (strategy === 'description') {
+      expect(trigger).toHaveAccessibleName('hi');
+      expect(trigger).toHaveAccessibleDescription('some text');
+    } else if (strategy === 'label') {
+      expect(trigger).toHaveAccessibleName('some text');
+      expect(trigger).not.toHaveAccessibleDescription();
+    } else {
+      expect(trigger).toHaveAccessibleName('hi');
+      expect(trigger).not.toHaveAccessibleDescription();
+    }
+  },
+);

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -42,7 +42,7 @@ it('should be visible', () => {
 it('should respect visible prop', () => {
   const { queryByText, rerender } = render(
     <Tooltip content='some text' visible={false}>
-      <div>Visible!</div>
+      <div>Not visible!</div>
     </Tooltip>,
   );
 
@@ -50,7 +50,7 @@ it('should respect visible prop', () => {
 
   rerender(
     <Tooltip content='some text' visible>
-      <div>Not visible!</div>
+      <div>Visible!</div>
     </Tooltip>,
   );
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -15,16 +15,16 @@ it('should toggle the visibility of tooltip on hover', async () => {
     </Tooltip>,
   );
 
-  expect(queryByText('some text')).toBeNull();
+  expect(queryByText('some text')).not.toBeVisible();
 
   fireEvent.mouseEnter(getByText('Hover Here'));
   act(() => void jest.advanceTimersByTime(50));
-  getByText('some text');
+  expect(getByText('some text')).toBeVisible();
 
   fireEvent.mouseLeave(getByText('Hover Here'));
   act(() => void jest.advanceTimersByTime(250));
 
-  expect(queryByText('some text')).not.toBeInTheDocument();
+  expect(queryByText('some text')).not.toBeVisible();
 
   jest.useRealTimers();
 });
@@ -39,14 +39,22 @@ it('should be visible', () => {
   getByText('some text');
 });
 
-it('should not be visible', () => {
-  const { queryByText } = render(
+it('should respect visible prop', () => {
+  const { queryByText, rerender } = render(
     <Tooltip content='some text' visible={false}>
       <div>Visible!</div>
     </Tooltip>,
   );
 
-  expect(queryByText('some text')).toBeNull();
+  expect(queryByText('some text')).not.toBeVisible();
+
+  rerender(
+    <Tooltip content='some text' visible>
+      <div>Not visible!</div>
+    </Tooltip>,
+  );
+
+  expect(queryByText('some text')).toBeVisible();
 });
 
 it('should allow button clicks and hovers', () => {

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -107,7 +107,7 @@ type TooltipOwnProps = {
    *
    * Pass "label" if you want to use `aria-labelledby` instead, or pass "none"
    * if you don't want any association.
-   * 
+   *
    * @default 'description'
    */
   ariaStrategy?: 'description' | 'label' | 'none';
@@ -268,6 +268,7 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
               ...(ariaStrategy === 'label' && {
                 'aria-labelledby': tooltip.getFloatingProps().id,
               }),
+              // override aria-describedby that comes from floating-ui
               'aria-describedby':
                 ariaStrategy === 'description'
                   ? tooltip.getFloatingProps().id

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -209,7 +209,7 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
     className,
     visible,
     reference,
-    ariaStrategy,
+    ariaStrategy = 'description',
     ...rest
   } = props;
   const tooltip = useTooltip({

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -107,6 +107,8 @@ type TooltipOwnProps = {
    *
    * Pass "label" if you want to use `aria-labelledby` instead, or pass "none"
    * if you don't want any association.
+   * 
+   * @default 'description'
    */
   ariaStrategy?: 'description' | 'label' | 'none';
 };

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -101,6 +101,14 @@ type TooltipOwnProps = {
    * <Tooltip content='tooltip text' reference={buttonRef} />
    */
   reference?: React.RefObject<HTMLElement>;
+  /**
+   * By default, the tooltip will be associated with the reference element
+   * using `aria-describedby`.
+   *
+   * Pass "label" if you want to use `aria-labelledby` instead, or pass "none"
+   * if you don't want any association.
+   */
+  ariaStrategy?: 'description' | 'label' | 'none';
 };
 
 const useTooltip = (options: TooltipOptions = {}) => {
@@ -201,6 +209,7 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
     className,
     visible,
     reference,
+    ariaStrategy,
     ...rest
   } = props;
   const tooltip = useTooltip({
@@ -230,6 +239,9 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
       ref={useMergedRefs(tooltip.refs.setFloating, forwardRef)}
       style={{ ...tooltip.floatingStyles, ...style }}
       {...tooltip.getFloatingProps()}
+      role={undefined}
+      aria-hidden
+      hidden={!tooltip.open}
       {...rest}
     >
       {content}
@@ -251,15 +263,18 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
             children as JSX.Element,
             tooltip.getReferenceProps({
               ref: childrenRef,
+              ...(ariaStrategy === 'label' && {
+                'aria-labelledby': tooltip.getFloatingProps().id,
+              }),
+              'aria-describedby':
+                ariaStrategy === 'description'
+                  ? tooltip.getFloatingProps().id
+                  : undefined,
               ...(children as JSX.Element).props,
             }),
           )
         : null}
-      {tooltip.open
-        ? portalTo
-          ? ReactDOM.createPortal(contentBox, portalTo)
-          : contentBox
-        : null}
+      {portalTo ? ReactDOM.createPortal(contentBox, portalTo) : contentBox}
     </>
   );
 }) as PolymorphicForwardRefComponent<'div', TooltipOwnProps & TooltipOptions>;


### PR DESCRIPTION
## Changes

*This PR is a follow-up to #1311 and precursor to #1506.*

- Added new `ariaStrategy` prop to `Tooltip` to allow switching between `aria-describedby`, `aria-labelledby` and nothing (see https://github.com/iTwin/iTwinUI/pull/1311#pullrequestreview-1505237337).
  - This prop is used in `IconButton` to replace the custom Popover-based tooltip implementation.
  - This prop is also used in `Slider` thumb because (1) the tooltip value keeps updating but is not reflected in screen-readers, and (2) the slider already has its value exposed through `aria-valuenow`.
- Added `aria-hidden` to Tooltip to prevent duplicate announcements (the text should already be exposed through `aria-describedby`/`aria-labelledby`/visuallyhidden text) and removed `role=tooltip` because of [poor support](https://a11ysupport.io/tech/aria/tooltip_role).
- Instead of conditionally rendering the tooltip when it's open, it will now *always* be rendered and its display will be toggled using the `hidden` property.
  - The intention is to make `aria-describedby` available to screen reader users, even when the tooltip is not open (see testing note in https://github.com/iTwin/iTwinUI/pull/1461#issue-1829866396).
  - Only works in VoiceOver (see screen-recording below). I checked that the description was exposed in the accessibility tree in both Chrome and Firefox devtools, so it looks like a bug in NVDA ([more info](https://adrianroselli.com/2022/04/accessible-description-exposure.html)). This behavior is not worse than before and the description is still accessible by tabbing, so I'm fine with it.
- Removed unused `.iui-tooltip-visible`/`.iui-tooltip-container` and added CSS for `[hidden]`. I believe these classes were designed to make animation work, but are not useful in practice; we can explore animation in the future.

## Testing

Tested functionality of all components in storybook.

<details>

<summary>NVDA 2023.1 + Firefox 114 (Windows 11)</summary>

Traversing ButtonGroup using virtual cursor (in both directions):

https://github.com/iTwin/iTwinUI/assets/9084735/05e1e601-e831-4d22-a77b-73094e10eb3b

Traversing buttons (regular and disabled) that have tooltips with default `ariaStrategy`, first using virtual cursor then tabbing:

https://github.com/iTwin/iTwinUI/assets/9084735/7d5bcf4a-9d40-4b51-b1bd-2d927ed18c03

</details>

<details>

<summary>VoiceOver + Safari 16.6 (macOS 13.5)</summary>

Traversing ButtonGroup using virtual cursor (in both directions):

https://github.com/iTwin/iTwinUI/assets/9084735/7ada1244-fa6f-4c9f-ace0-a5c59665369a

Traversing buttons (regular and disabled) that have tooltips with default `ariaStrategy`, using virtual cursor:

https://github.com/iTwin/iTwinUI/assets/9084735/0efafc37-2870-48b9-b130-980a13b4dd0b

</details>

Updated affected unit/visual tests, and added a unit test for `ariaStrategy`.

## Docs

Added changesets. No other doc updates needed I think.