### PR TITLE
add `FloatingDelayGroup` to `ButtonGroup`

### DIFF
--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { useOverflow, useMergedRefs, Box } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
+import { FloatingDelayGroup } from '@floating-ui/react';
 
 type ButtonGroupProps = {
   /**
@@ -88,46 +89,48 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
   const refs = useMergedRefs(overflowRef, ref);
 
   return (
-    <Box
-      className={cx(
-        {
-          'iui-button-group': orientation === 'horizontal',
-          'iui-button-group-vertical': orientation === 'vertical',
-          'iui-button-group-overflow-x':
-            !!overflowButton && orientation === 'horizontal',
-        },
-        className,
-      )}
-      ref={refs}
-      {...rest}
-    >
-      {(() => {
-        if (!(visibleCount < items.length)) {
-          return items;
-        }
+    <FloatingDelayGroup delay={50}>
+      <Box
+        className={cx(
+          {
+            'iui-button-group': orientation === 'horizontal',
+            'iui-button-group-vertical': orientation === 'vertical',
+            'iui-button-group-overflow-x':
+              !!overflowButton && orientation === 'horizontal',
+          },
+          className,
+        )}
+        ref={refs}
+        {...rest}
+      >
+        {(() => {
+          if (!(visibleCount < items.length)) {
+            return items;
+          }
 
-        const overflowStart =
-          overflowPlacement === 'start'
-            ? items.length - visibleCount
-            : visibleCount - 1;
+          const overflowStart =
+            overflowPlacement === 'start'
+              ? items.length - visibleCount
+              : visibleCount - 1;
 
-        return (
-          <>
-            {overflowButton && overflowPlacement === 'start' && (
-              <div>{overflowButton(overflowStart)}</div>
-            )}
+          return (
+            <>
+              {overflowButton && overflowPlacement === 'start' && (
+                <div>{overflowButton(overflowStart)}</div>
+              )}
 
-            {overflowPlacement === 'start'
-              ? items.slice(overflowStart + 1)
-              : items.slice(0, Math.max(0, overflowStart))}
+              {overflowPlacement === 'start'
+                ? items.slice(overflowStart + 1)
+                : items.slice(0, Math.max(0, overflowStart))}
 
-            {overflowButton && overflowPlacement === 'end' && (
-              <div>{overflowButton(overflowStart)}</div>
-            )}
-          </>
-        );
-      })()}
-    </Box>
+              {overflowButton && overflowPlacement === 'end' && (
+                <div>{overflowButton(overflowStart)}</div>
+              )}
+            </>
+          );
+        })()}
+      </Box>
+    </FloatingDelayGroup>
   );
 }) as PolymorphicForwardRefComponent<'div', ButtonGroupProps>;
 

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -89,7 +89,7 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
   const refs = useMergedRefs(overflowRef, ref);
 
   return (
-    <FloatingDelayGroup delay={50}>
+    <FloatingDelayGroup delay={{ open: 50, close: 250 }}>
       <Box
         className={cx(
           {

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -21,6 +21,8 @@ import {
   autoPlacement,
   hide,
   inline,
+  useDelayGroupContext,
+  useDelayGroup,
 } from '@floating-ui/react';
 import type { Placement } from '@floating-ui/react';
 import {
@@ -28,6 +30,7 @@ import {
   getDocument,
   mergeRefs,
   useGlobals,
+  useId,
   useMergedRefs,
 } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
@@ -150,12 +153,11 @@ const useTooltip = (options: TooltipOptions = {}) => {
 
   const context = data.context;
 
+  const { delay } = useDelayGroupContext();
+
   const hover = useHover(context, {
     enabled: controlledOpen == null,
-    delay: {
-      open: 50,
-      close: 250,
-    },
+    delay: delay ?? { open: 50, close: 250 },
     handleClose: safePolygon({ buffer: -Infinity }),
   });
 
@@ -170,6 +172,8 @@ const useTooltip = (options: TooltipOptions = {}) => {
   const dismiss = useDismiss(context, {
     enabled: controlledOpen == null,
   });
+
+  useDelayGroup(context, { id: useId() });
 
   const role = useRole(context, { role: 'tooltip' });
 


### PR DESCRIPTION
## Changes

improves the experience by sharing the delay, so that there is no delay between buttons within a group.

see https://floating-ui.com/docs/floatingdelaygroup and https://github.com/iTwin/iTwinUI/pull/1311#pullrequestreview-1505237337

## Testing

Before:

https://github.com/iTwin/iTwinUI/assets/9084735/e9922f21-36e8-47ed-8c04-f273dee773ba

After:

https://github.com/iTwin/iTwinUI/assets/9084735/d4aa4770-5736-4498-88f8-921efb36766e


## Docs

not needed i think