### PR TITLE
fix tooltip reference prop

### DIFF
--- a/apps/storybook/src/AvatarGroup.stories.tsx
+++ b/apps/storybook/src/AvatarGroup.stories.tsx
@@ -183,9 +183,9 @@ export const WithTooltip: Story<AvatarGroupProps> = (args) => {
   ];
 
   /**
-   * Ref is set on the last avatar for tooltip positioning.
+   * Store the last avatar for tooltip positioning.
    */
-  const avatarRef = React.useRef<HTMLDivElement>(null);
+  const [countIcon, setCountIcon] = React.useState<HTMLElement | null>(null);
 
   const arrayLength = args.maxIcons;
   const usersSubArray = userNames.slice(arrayLength);
@@ -193,7 +193,7 @@ export const WithTooltip: Story<AvatarGroupProps> = (args) => {
 
   return (
     <>
-      <AvatarGroup {...args} countIconProps={{ ref: avatarRef }}>
+      <AvatarGroup {...args} countIconProps={{ ref: setCountIcon }}>
         {userNames.map((name, index) => (
           <Avatar
             key={`${name}-${index}`}
@@ -207,7 +207,7 @@ export const WithTooltip: Story<AvatarGroupProps> = (args) => {
         ))}
       </AvatarGroup>
       <Tooltip
-        reference={avatarRef}
+        reference={countIcon}
         content={tooltipContent}
         placement='right'
         style={{ whiteSpace: 'pre' }}

--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -1426,7 +1426,9 @@ ControlledState.argTypes = {
 export const Full: Story<Partial<TableProps>> = (args) => {
   const [hoveredRowIndex, setHoveredRowIndex] = useState(0);
 
-  const rowRefMap = React.useRef<Record<number, HTMLDivElement>>({});
+  const [rowRefMap, setRowRefMap] = React.useState<Record<number, HTMLElement>>(
+    {},
+  );
 
   const isRowDisabled = useCallback(
     (rowData: { name: string; description: string }) => {
@@ -1509,7 +1511,10 @@ export const Full: Story<Partial<TableProps>> = (args) => {
         },
         ref: (el: HTMLDivElement | null) => {
           if (el) {
-            rowRefMap.current[row.index] = el;
+            setRowRefMap((r) => {
+              r[row.index] = el;
+              return r;
+            });
           }
         },
       };
@@ -1533,7 +1538,7 @@ export const Full: Story<Partial<TableProps>> = (args) => {
         {...args}
       />
       <Tooltip
-        reference={rowRefMap.current[hoveredRowIndex]}
+        reference={rowRefMap[hoveredRowIndex]}
         content={`Hovered over ${data[hoveredRowIndex].name}.`}
         placement='bottom'
       />

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -213,7 +213,7 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
     style,
     className,
     visible,
-    reference: referenceProp,
+    reference,
     ariaStrategy = 'description',
     id = uniqueId,
     ...rest
@@ -238,13 +238,13 @@ export const Tooltip = React.forwardRef((props, forwardRef) => {
   const context = useGlobals();
 
   React.useEffect(() => {
-    if (referenceProp) {
-      tooltip.refs.setReference(referenceProp);
+    if (reference) {
+      tooltip.refs.setReference(reference);
       Object.entries(ariaProps).forEach(([key, value]) => {
-        referenceProp.setAttribute(key, value);
+        reference.setAttribute(key, value);
       });
     }
-  }, [ariaProps, referenceProp, tooltip.refs]);
+  }, [ariaProps, reference, tooltip.refs]);
 
   const portalTo =
     typeof portal !== 'boolean'

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -102,7 +102,7 @@ type TooltipOwnProps = {
    * <Button ref={setTrigger} />
    * <Tooltip content='tooltip text' reference={trigger} />
    */
-  reference?: HTMLElement;
+  reference?: HTMLElement | null;
   /**
    * By default, the tooltip will be associated with the reference element
    * using `aria-describedby`.


### PR DESCRIPTION
## Changes

noticed that aria props were not being applied when using `reference` because it is not something we render. fixed by manually copying aria props in a useEffect

## Testing

verified in playground

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->
