### PR TITLE
add `label` to Input Button example

### DIFF
--- a/examples/Input.button.tsx
+++ b/examples/Input.button.tsx
@@ -3,13 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import {
-  LabeledInput,
-  IconButton,
-  InputGrid,
-  Label,
-  InputWithDecorations,
-} from '@itwin/itwinui-react';
+import { InputGrid, Label, InputWithDecorations } from '@itwin/itwinui-react';
 import { SvgCloseSmall } from '@itwin/itwinui-icons-react';
 
 export default () => {
@@ -22,7 +16,7 @@ export default () => {
             id='input-1'
             defaultValue='1051 Faribault Road'
           />
-          <InputWithDecorations.Button>
+          <InputWithDecorations.Button label='Clear'>
             <SvgCloseSmall />
           </InputWithDecorations.Button>
         </InputWithDecorations>


### PR DESCRIPTION
## Changes

similar to #1532 and #1533

## Testing

Before:
<img width="670" alt="failing" src="https://github.com/iTwin/iTwinUI/assets/9084735/a5739e42-3d58-4c88-9e81-e38ecc5e3714">

After:
<img width="348" alt="passing" src="https://github.com/iTwin/iTwinUI/assets/9084735/a0bb7701-c278-4f46-af06-a93e4fa40784">

## Docs

n/a
