### PR TITLE
Removed `{...args}` from Table's Storybook file

### DIFF
--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -37,7 +37,7 @@ import {
   ProgressRadial,
   BaseFilter,
 } from '@itwin/itwinui-react';
-import { Story, Meta } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import { useMemo, useState } from '@storybook/addons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -54,7 +54,7 @@ export default {
   component: Table,
 } as Meta<TableProps>;
 
-export const Basic: Story<Partial<TableProps>> = () => {
+export const Basic = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -101,7 +101,7 @@ export const Basic: Story<Partial<TableProps>> = () => {
   return <Table columns={columns} data={data} emptyTableContent='No data.' />;
 };
 
-export const SelectableSingle: Story<Partial<TableProps>> = () => {
+export const SelectableSingle = () => {
   const onRowClick = useCallback(
     (event: React.MouseEvent, row: Row) =>
       action(`Row clicked: ${JSON.stringify(row.original)}`)(),
@@ -164,7 +164,7 @@ export const SelectableSingle: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const SelectableMulti: Story<Partial<TableProps>> = () => {
+export const SelectableMulti = () => {
   const onSelect = useCallback(
     (rows, state) =>
       action(
@@ -238,7 +238,7 @@ export const SelectableMulti: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Sortable: Story<Partial<TableProps>> = () => {
+export const Sortable = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -305,7 +305,7 @@ export const Sortable: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Filters: Story<Partial<TableProps>> = () => {
+export const Filters = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -469,7 +469,7 @@ export const Filters: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const GlobalFilter: Story<Partial<TableProps>> = () => {
+export const GlobalFilter = () => {
   type TableStoryDataType = {
     name: string;
     description: string;
@@ -546,7 +546,7 @@ export const GlobalFilter: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Expandable: Story<Partial<TableProps>> = () => {
+export const Expandable = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -607,7 +607,7 @@ export const Expandable: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const ExpandableSubrows: Story<Partial<TableProps>> = () => {
+export const ExpandableSubrows = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -703,7 +703,7 @@ export const ExpandableSubrows: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const LazyLoading: Story<Partial<TableProps>> = () => {
+export const LazyLoading = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -779,7 +779,7 @@ export const LazyLoading: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const RowInViewport: Story<Partial<TableProps>> = () => {
+export const RowInViewport = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -862,7 +862,7 @@ export const RowInViewport: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const DisabledRows: Story<Partial<TableProps>> = () => {
+export const DisabledRows = () => {
   const onRowClick = useCallback(
     (event: React.MouseEvent, row: Row) =>
       action(`Row clicked: ${JSON.stringify(row.original)}`)(),
@@ -944,7 +944,7 @@ export const DisabledRows: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Loading: Story<Partial<TableProps>> = () => {
+export const Loading = () => {
   const columns = useMemo(
     () => [
       {
@@ -972,7 +972,7 @@ export const Loading: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const NoData: Story<Partial<TableProps>> = () => {
+export const NoData = () => {
   const columns = useMemo(
     () => [
       {
@@ -1000,7 +1000,7 @@ export const NoData: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const InitialState: Story<Partial<TableProps>> = () => {
+export const InitialState = () => {
   const columns = useMemo(
     () => [
       {
@@ -1045,7 +1045,7 @@ export const InitialState: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const ControlledState: Story<Partial<TableProps>> = () => {
+export const ControlledState = () => {
   type DemoData = {
     id: string;
     name: string;
@@ -1199,7 +1199,7 @@ export const ControlledState: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Full: Story<Partial<TableProps>> = () => {
+export const Full = () => {
   const [hoveredRowIndex, setHoveredRowIndex] = useState(0);
 
   const [rowRefMap, setRowRefMap] = React.useState<Record<number, HTMLElement>>(
@@ -1321,7 +1321,7 @@ export const Full: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Full2: Story<Partial<TableProps>> = () => {
+export const Full2 = () => {
   type TableStoryDataType = {
     product: string;
     price: number;
@@ -1512,7 +1512,7 @@ export const Full2: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Localized: Story<Partial<TableProps>> = () => {
+export const Localized = () => {
   const columns = useMemo(
     () => [
       {
@@ -1602,7 +1602,7 @@ Localized.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const Condensed: Story<Partial<TableProps>> = () => {
+export const Condensed = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -1709,7 +1709,7 @@ export const Condensed: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const Editable: Story<Partial<TableProps>> = () => {
+export const Editable = () => {
   type TableStoryDataType = {
     name: string;
     description: string;
@@ -1789,7 +1789,7 @@ export const Editable: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const WithPaginator: Story<Partial<TableProps>> = () => {
+export const WithPaginator = () => {
   const columns = useMemo(
     () => [
       {
@@ -1876,7 +1876,7 @@ WithPaginator.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const WithManualPaginatorAndFilter: Story<Partial<TableProps>> = () => {
+export const WithManualPaginatorAndFilter = () => {
   type RowData = {
     name: string;
     description: string;
@@ -2085,7 +2085,7 @@ WithManualPaginatorAndFilter.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const CustomFilter: Story<Partial<TableProps>> = () => {
+export const CustomFilter = () => {
   type RowData = {
     name: string;
     description: string;
@@ -2243,7 +2243,7 @@ CustomFilter.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const ResizableColumns: Story<Partial<TableProps>> = () => {
+export const ResizableColumns = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -2368,7 +2368,7 @@ export const ResizableColumns: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const ZebraStripedRows: Story<Partial<TableProps>> = () => {
+export const ZebraStripedRows = () => {
   const columns = useMemo(
     () => [
       {
@@ -2434,7 +2434,7 @@ export const ZebraStripedRows: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const HorizontalScroll: Story<Partial<TableProps>> = () => {
+export const HorizontalScroll = () => {
   const data = useMemo(
     () => [
       {
@@ -2577,7 +2577,7 @@ HorizontalScroll.decorators = [
   ),
 ];
 
-export const Virtualized: Story<Partial<TableProps>> = () => {
+export const Virtualized = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -2634,7 +2634,7 @@ export const Virtualized: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const ScrollToRow: Story<Partial<TableProps>> = () => {
+export const ScrollToRow = () => {
   type TableStoryDataType = {
     id: string;
     name: string;
@@ -2708,7 +2708,7 @@ export const ScrollToRow: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const VirtualizedSubRows: Story<Partial<TableProps>> = () => {
+export const VirtualizedSubRows = () => {
   const columns = useMemo(
     () => [
       {
@@ -2770,7 +2770,7 @@ export const VirtualizedSubRows: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const DraggableColumns: Story<Partial<TableProps>> = () => {
+export const DraggableColumns = () => {
   const data = useMemo(
     () => [
       {
@@ -2896,7 +2896,7 @@ export const DraggableColumns: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const CustomizedColumns: Story<Partial<TableProps>> = () => {
+export const CustomizedColumns = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -2993,7 +2993,7 @@ export const CustomizedColumns: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const ColumnManager: Story<Partial<TableProps>> = () => {
+export const ColumnManager = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -3157,7 +3157,7 @@ export const ColumnManager: Story<Partial<TableProps>> = () => {
   );
 };
 
-export const StickyColumns: Story<Partial<TableProps>> = () => {
+export const StickyColumns = () => {
   const data = useMemo(
     () => [
       {
@@ -3328,7 +3328,7 @@ StickyColumns.decorators = [
   ),
 ];
 
-export const StatusAndCellIcons: Story<Partial<TableProps>> = () => {
+export const StatusAndCellIcons = () => {
   const columns = useMemo(
     () => [
       {

--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -37,7 +37,6 @@ import {
   ProgressRadial,
   BaseFilter,
 } from '@itwin/itwinui-react';
-import { Meta } from '@storybook/react';
 import { useMemo, useState } from '@storybook/addons';
 import { action } from '@storybook/addon-actions';
 import {
@@ -52,7 +51,7 @@ import {
 export default {
   title: 'Core/Table',
   component: Table,
-} as Meta<TableProps>;
+};
 
 export const Basic = () => {
   const onClickHandler = (

--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -52,55 +52,9 @@ import {
 export default {
   title: 'Core/Table',
   component: Table,
-  args: {
-    data: [
-      { name: 'Name1', description: 'Description1' },
-      { name: 'Name2', description: 'Description2' },
-      { name: 'Name3', description: 'Description3' },
-    ],
-    emptyTableContent: 'No data.',
-    density: 'default',
-    emptyFilteredTableContent: 'No results found. Clear or try another filter.',
-  },
-  argTypes: {
-    columns: { control: { disable: true } },
-    isSelectable: { control: { disable: true } },
-    selectionMode: { control: { disable: true } },
-    style: { control: { disable: true } },
-    className: { control: { disable: true } },
-    id: { control: { disable: true } },
-    initialState: { table: { disable: true } },
-    stateReducer: { table: { disable: true } },
-    useControlledState: { table: { disable: true } },
-    defaultColumn: { table: { disable: true } },
-    getSubRows: { table: { disable: true } },
-    getRowId: { table: { disable: true } },
-    manualRowSelectedKey: { table: { disable: true } },
-    autoResetSelectedRows: { table: { disable: true } },
-    selectSubRows: { table: { disable: true } },
-    manualSortBy: { table: { disable: true } },
-    defaultCanSort: { table: { disable: true } },
-    disableMultiSort: { table: { disable: true } },
-    isMultiSortEvent: { table: { disable: true } },
-    maxMultiSortColCount: { table: { disable: true } },
-    disableSortRemove: { table: { disable: true } },
-    disabledMultiRemove: { table: { disable: true } },
-    orderByFn: { table: { disable: true } },
-    sortTypes: { table: { disable: true } },
-    autoResetSortBy: { table: { disable: true } },
-    autoResetHiddenColumns: { table: { disable: true } },
-    autoResetFilters: { table: { disable: true } },
-    filterTypes: { table: { disable: true } },
-    defaultCanFilter: { table: { disable: true } },
-    manualFilters: { table: { disable: true } },
-    paginateExpandedRows: { table: { disable: true } },
-    expandSubRows: { table: { disable: true } },
-    autoResetExpanded: { table: { disable: true } },
-    manualExpandedKey: { table: { disable: true } },
-  },
 } as Meta<TableProps>;
 
-export const Basic: Story<Partial<TableProps>> = (args) => {
+export const Basic: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -144,17 +98,10 @@ export const Basic: Story<Partial<TableProps>> = (args) => {
     [],
   );
 
-  return (
-    <Table
-      columns={columns}
-      data={data}
-      emptyTableContent='No data.'
-      {...args}
-    />
-  );
+  return <Table columns={columns} data={data} emptyTableContent='No data.' />;
 };
 
-export const SelectableSingle: Story<Partial<TableProps>> = (args) => {
+export const SelectableSingle: Story<Partial<TableProps>> = () => {
   const onRowClick = useCallback(
     (event: React.MouseEvent, row: Row) =>
       action(`Row clicked: ${JSON.stringify(row.original)}`)(),
@@ -213,14 +160,11 @@ export const SelectableSingle: Story<Partial<TableProps>> = (args) => {
       isSelectable={true}
       onRowClick={onRowClick}
       selectionMode='single'
-      {...args}
     />
   );
 };
 
-SelectableSingle.args = { isSelectable: true, selectionMode: 'single' };
-
-export const SelectableMulti: Story<Partial<TableProps>> = (args) => {
+export const SelectableMulti: Story<Partial<TableProps>> = () => {
   const onSelect = useCallback(
     (rows, state) =>
       action(
@@ -290,14 +234,11 @@ export const SelectableMulti: Story<Partial<TableProps>> = (args) => {
       onSelect={onSelect}
       onRowClick={onRowClick}
       selectionMode='multi'
-      {...args}
     />
   );
 };
 
-SelectableMulti.args = { isSelectable: true, selectionMode: 'multi' };
-
-export const Sortable: Story<Partial<TableProps>> = (args) => {
+export const Sortable: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -360,21 +301,11 @@ export const Sortable: Story<Partial<TableProps>> = (args) => {
       emptyTableContent='No data.'
       isSortable
       onSort={onSort}
-      {...args}
     />
   );
 };
 
-Sortable.args = {
-  data: [
-    { id: '1', name: 'Name1', description: 'Description1' },
-    { id: '3', name: 'Name3', description: 'Description3' },
-    { id: '2', name: 'Name2', description: 'Description2' },
-  ],
-  isSortable: true,
-};
-
-export const Filters: Story<Partial<TableProps>> = (args) => {
+export const Filters: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -534,41 +465,11 @@ export const Filters: Story<Partial<TableProps>> = (args) => {
       data={data}
       emptyTableContent='No data.'
       onFilter={onFilter}
-      {...args}
     />
   );
 };
 
-Filters.args = {
-  data: [
-    {
-      index: 1,
-      name: 'Name1',
-      description: 'Description1',
-      ids: ['1'],
-      startDate: new Date('May 1, 2021'),
-      endDate: '2021-05-31T21:00:00.000Z',
-    },
-    {
-      index: 2,
-      name: 'Name2',
-      description: 'Description2',
-      ids: ['2', '3', '4'],
-      startDate: new Date('May 2, 2021'),
-      endDate: '2021-06-01T21:00:00.000Z',
-    },
-    {
-      index: 3,
-      name: 'Name3',
-      description: 'Description3',
-      ids: ['3', '4'],
-      startDate: new Date('May 3, 2021'),
-      endDate: '2021-06-02T21:00:00.000Z',
-    },
-  ],
-};
-
-export const GlobalFilter: Story<Partial<TableProps>> = (args) => {
+export const GlobalFilter: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     name: string;
     description: string;
@@ -640,24 +541,12 @@ export const GlobalFilter: Story<Partial<TableProps>> = (args) => {
         data={data}
         emptyTableContent='No data.'
         globalFilterValue={globalFilter}
-        {...args}
       />
     </div>
   );
 };
 
-GlobalFilter.args = {
-  data: [
-    { name: 'Name1', description: 'Description7' },
-    { name: 'Name2', description: 'Description7' },
-    { name: 'Name3', description: 'Description8' },
-    { name: 'Name4', description: 'Description8' },
-    { name: 'Name5', description: 'Description9' },
-    { name: 'Name6', description: 'Description9' },
-  ],
-};
-
-export const Expandable: Story<Partial<TableProps>> = (args) => {
+export const Expandable: Story<Partial<TableProps>> = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -713,16 +602,12 @@ export const Expandable: Story<Partial<TableProps>> = (args) => {
       emptyTableContent='No data.'
       subComponent={expandedSubComponent}
       onExpand={onExpand}
-      {...args}
+      isSelectable
     />
   );
 };
 
-Expandable.args = {
-  isSelectable: true,
-};
-
-export const ExpandableSubrows: Story<Partial<TableProps>> = (args) => {
+export const ExpandableSubrows: Story<Partial<TableProps>> = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -812,64 +697,13 @@ export const ExpandableSubrows: Story<Partial<TableProps>> = (args) => {
         isSortable
         data={data}
         columns={columns}
-        {...args}
         onExpand={onExpand}
       />
     </>
   );
 };
 
-ExpandableSubrows.args = {
-  data: [
-    {
-      name: 'Row 1',
-      description: 'Description 1',
-      subRows: [
-        { name: 'Row 1.1', description: 'Description 1.1', subRows: [] },
-        {
-          name: 'Row 1.2',
-          description: 'Description 1.2',
-          subRows: [
-            {
-              name: 'Row 1.2.1',
-              description: 'Description 1.2.1',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.2',
-              description: 'Description 1.2.2',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.3',
-              description: 'Description 1.2.3',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.4',
-              description: 'Description 1.2.4',
-              subRows: [],
-            },
-          ],
-        },
-        { name: 'Row 1.3', description: 'Description 1.3', subRows: [] },
-        { name: 'Row 1.4', description: 'Description 1.4', subRows: [] },
-      ],
-    },
-    {
-      name: 'Row 2',
-      description: 'Description 2',
-      subRows: [
-        { name: 'Row 2.1', description: 'Description 2.1', subRows: [] },
-        { name: 'Row 2.2', description: 'Description 2.2', subRows: [] },
-        { name: 'Row 2.3', description: 'Description 2.3', subRows: [] },
-      ],
-    },
-    { name: 'Row 3', description: 'Description 3', subRows: [] },
-  ],
-};
-
-export const LazyLoading: Story<Partial<TableProps>> = (args) => {
+export const LazyLoading: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -936,7 +770,6 @@ export const LazyLoading: Story<Partial<TableProps>> = (args) => {
       onBottomReached={onBottomReached}
       isLoading={isLoading}
       isSortable
-      {...args}
       style={{ height: 440, maxHeight: '90vh' }}
       data={data}
       // Prevents from resetting filters and sorting when more data is loaded
@@ -946,15 +779,7 @@ export const LazyLoading: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-LazyLoading.args = {
-  isSortable: true,
-};
-
-LazyLoading.argTypes = {
-  isLoading: { control: { disable: true } },
-};
-
-export const RowInViewport: Story<Partial<TableProps>> = (args) => {
+export const RowInViewport: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -1031,18 +856,13 @@ export const RowInViewport: Story<Partial<TableProps>> = (args) => {
         columns={columns}
         emptyTableContent='No data.'
         onRowInViewport={onRowInViewport}
-        {...args}
         data={data}
       />
     </>
   );
 };
 
-RowInViewport.argTypes = {
-  data: { control: { disable: true } },
-};
-
-export const DisabledRows: Story<Partial<TableProps>> = (args) => {
+export const DisabledRows: Story<Partial<TableProps>> = () => {
   const onRowClick = useCallback(
     (event: React.MouseEvent, row: Row) =>
       action(`Row clicked: ${JSON.stringify(row.original)}`)(),
@@ -1119,21 +939,12 @@ export const DisabledRows: Story<Partial<TableProps>> = (args) => {
       onRowClick={onRowClick}
       subComponent={expandedSubComponent}
       isRowDisabled={isRowDisabled}
-      {...args}
+      isSelectable
     />
   );
 };
 
-DisabledRows.args = {
-  data: [
-    { name: 'Name1', description: 'Description1' },
-    { name: 'Name2', description: 'Description2' },
-    { name: 'Name3', description: 'Description3' },
-  ],
-  isSelectable: true,
-};
-
-export const Loading: Story<Partial<TableProps>> = (args) => {
+export const Loading: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -1157,17 +968,11 @@ export const Loading: Story<Partial<TableProps>> = (args) => {
       data={[]}
       isLoading={true}
       emptyTableContent='No data.'
-      {...args}
     />
   );
 };
 
-Loading.args = {
-  data: [],
-  isLoading: true,
-};
-
-export const NoData: Story<Partial<TableProps>> = (args) => {
+export const NoData: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -1191,16 +996,11 @@ export const NoData: Story<Partial<TableProps>> = (args) => {
       data={[]}
       isLoading={false}
       emptyTableContent='No data.'
-      {...args}
     />
   );
 };
 
-NoData.args = {
-  data: [],
-};
-
-export const InitialState: Story<Partial<TableProps>> = (args) => {
+export const InitialState: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -1241,30 +1041,11 @@ export const InitialState: Story<Partial<TableProps>> = (args) => {
         filters: [{ id: 'name', value: '1' }],
         selectedRowIds: { '0': true, '1': true, '4': true, '5': true },
       }}
-      {...args}
     />
   );
 };
 
-InitialState.args = {
-  data: [
-    { name: 'Name17', description: 'Description17' },
-    { name: 'Name18', description: 'Description18' },
-    { name: 'Name19', description: 'Description19' },
-    { name: 'Name20', description: 'Description20' },
-    { name: 'Name21', description: 'Description21' },
-    { name: 'Name22', description: 'Description22' },
-  ],
-  initialState: {
-    filters: [{ id: 'name', value: '1' }],
-    selectedRowIds: { '0': true, '1': true, '4': true, '5': true },
-  },
-};
-InitialState.argTypes = {
-  initialState: { table: { disable: false } },
-};
-
-export const ControlledState: Story<Partial<TableProps>> = (args) => {
+export const ControlledState: Story<Partial<TableProps>> = () => {
   type DemoData = {
     id: string;
     name: string;
@@ -1412,18 +1193,13 @@ export const ControlledState: Story<Partial<TableProps>> = (args) => {
           setExpandedRows(expanded);
         }, [])}
         getRowId={useCallback((rowData) => rowData.id, [])}
-        {...args}
         data={data}
       />
     </>
   );
 };
 
-ControlledState.argTypes = {
-  data: { control: { disable: true } },
-};
-
-export const Full: Story<Partial<TableProps>> = (args) => {
+export const Full: Story<Partial<TableProps>> = () => {
   const [hoveredRowIndex, setHoveredRowIndex] = useState(0);
 
   const [rowRefMap, setRowRefMap] = React.useState<Record<number, HTMLElement>>(
@@ -1535,7 +1311,6 @@ export const Full: Story<Partial<TableProps>> = (args) => {
         isSortable
         isResizable
         enableColumnReordering
-        {...args}
       />
       <Tooltip
         reference={rowRefMap[hoveredRowIndex]}
@@ -1546,19 +1321,7 @@ export const Full: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-Full.args = {
-  data: [
-    { name: 'Name1', description: 'Description1' },
-    { name: 'Name2', description: 'Description2' },
-    { name: 'Name3', description: 'Description3' },
-  ],
-  isSelectable: true,
-  isSortable: true,
-  isResizable: true,
-  enableColumnReordering: true,
-};
-
-export const Full2: Story<Partial<TableProps>> = (args) => {
+export const Full2: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     product: string;
     price: number;
@@ -1738,7 +1501,6 @@ export const Full2: Story<Partial<TableProps>> = (args) => {
           isSortable
           isResizable
           enableColumnReordering
-          {...args}
           data={data}
           style={{ height: '100%' }}
           enableVirtualization
@@ -1750,18 +1512,7 @@ export const Full2: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-Full2.args = {
-  isSelectable: true,
-  isSortable: true,
-  isResizable: true,
-  enableColumnReordering: true,
-};
-
-Full2.argTypes = {
-  data: { control: { disable: true } },
-};
-
-export const Localized: Story<Partial<TableProps>> = (args) => {
+export const Localized: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -1829,7 +1580,6 @@ export const Localized: Story<Partial<TableProps>> = (args) => {
         emptyTableContent='No localized data.'
         isSelectable
         isSortable
-        {...args}
         columns={columns}
         data={generateData(0, 100)}
         pageSize={25}
@@ -1848,14 +1598,11 @@ Localized.decorators = [
   ),
 ];
 
-Localized.argTypes = {
-  data: { control: { disable: true } },
-};
 Localized.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const Condensed: Story<Partial<TableProps>> = (args) => {
+export const Condensed: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -1957,63 +1704,12 @@ export const Condensed: Story<Partial<TableProps>> = (args) => {
       data={data}
       emptyTableContent='No data.'
       density='condensed'
-      {...args}
       onExpand={onExpand}
     />
   );
 };
-Condensed.args = {
-  density: 'condensed',
-  data: [
-    {
-      name: 'Row 1',
-      description: 'Description 1',
-      subRows: [
-        { name: 'Row 1.1', description: 'Description 1.1', subRows: [] },
-        {
-          name: 'Row 1.2',
-          description: 'Description 1.2',
-          subRows: [
-            {
-              name: 'Row 1.2.1',
-              description: 'Description 1.2.1',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.2',
-              description: 'Description 1.2.2',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.3',
-              description: 'Description 1.2.3',
-              subRows: [],
-            },
-            {
-              name: 'Row 1.2.4',
-              description: 'Description 1.2.4',
-              subRows: [],
-            },
-          ],
-        },
-        { name: 'Row 1.3', description: 'Description 1.3', subRows: [] },
-        { name: 'Row 1.4', description: 'Description 1.4', subRows: [] },
-      ],
-    },
-    {
-      name: 'Row 2',
-      description: 'Description 2',
-      subRows: [
-        { name: 'Row 2.1', description: 'Description 2.1', subRows: [] },
-        { name: 'Row 2.2', description: 'Description 2.2', subRows: [] },
-        { name: 'Row 2.3', description: 'Description 2.3', subRows: [] },
-      ],
-    },
-    { name: 'Row 3', description: 'Description 3', subRows: [] },
-  ],
-};
 
-export const Editable: Story<Partial<TableProps>> = (args) => {
+export const Editable: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     name: string;
     description: string;
@@ -2081,7 +1777,6 @@ export const Editable: Story<Partial<TableProps>> = (args) => {
   return (
     <Table
       emptyTableContent='No data.'
-      {...args}
       columns={columns}
       data={data}
       isRowDisabled={isRowDisabled}
@@ -2094,11 +1789,7 @@ export const Editable: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-Editable.argTypes = {
-  data: { control: { disable: true } },
-};
-
-export const WithPaginator: Story<Partial<TableProps>> = (args) => {
+export const WithPaginator: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -2163,7 +1854,6 @@ export const WithPaginator: Story<Partial<TableProps>> = (args) => {
         emptyTableContent='No data.'
         isSelectable
         isSortable
-        {...args}
         columns={columns}
         data={data}
         pageSize={25}
@@ -2174,11 +1864,6 @@ export const WithPaginator: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-WithPaginator.args = {
-  isSelectable: true,
-  isSortable: true,
-};
-
 WithPaginator.decorators = [
   (Story) => (
     <div style={{ height: '90vh' }}>
@@ -2187,16 +1872,11 @@ WithPaginator.decorators = [
   ),
 ];
 
-WithPaginator.argTypes = {
-  data: { control: { disable: true } },
-};
 WithPaginator.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const WithManualPaginatorAndFilter: Story<Partial<TableProps>> = (
-  args,
-) => {
+export const WithManualPaginatorAndFilter: Story<Partial<TableProps>> = () => {
   type RowData = {
     name: string;
     description: string;
@@ -2379,7 +2059,6 @@ export const WithManualPaginatorAndFilter: Story<Partial<TableProps>> = (
     <>
       <Table
         emptyTableContent='No data.'
-        {...args}
         isLoading={isLoading}
         columns={columns}
         data={data}
@@ -2402,14 +2081,11 @@ WithManualPaginatorAndFilter.decorators = [
   ),
 ];
 
-WithManualPaginatorAndFilter.argTypes = {
-  data: { control: { disable: true } },
-};
 WithManualPaginatorAndFilter.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const CustomFilter: Story<Partial<TableProps>> = (args) => {
+export const CustomFilter: Story<Partial<TableProps>> = () => {
   type RowData = {
     name: string;
     description: string;
@@ -2543,7 +2219,6 @@ export const CustomFilter: Story<Partial<TableProps>> = (args) => {
     <>
       <Table
         emptyTableContent='No data.'
-        {...args}
         isLoading={isLoading}
         columns={columns}
         data={data}
@@ -2564,14 +2239,11 @@ CustomFilter.decorators = [
   ),
 ];
 
-CustomFilter.argTypes = {
-  data: { control: { disable: true } },
-};
 CustomFilter.parameters = {
   docs: { source: { excludeDecorators: true } },
 };
 
-export const ResizableColumns: Story<Partial<TableProps>> = (args) => {
+export const ResizableColumns: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -2690,44 +2362,13 @@ export const ResizableColumns: Story<Partial<TableProps>> = (args) => {
         emptyTableContent='No data.'
         isResizable
         isSortable
-        {...args}
         columnResizeMode={columnResizeMode}
       />
     </>
   );
 };
 
-ResizableColumns.args = {
-  isResizable: true,
-  data: [
-    {
-      index: 1,
-      name: 'Name1',
-      description: 'Description1',
-      id: '111',
-      startDate: new Date('May 1, 2021'),
-      endDate: new Date('Jun 1, 2021'),
-    },
-    {
-      index: 2,
-      name: 'Name2',
-      description: 'Description2',
-      id: '222',
-      startDate: new Date('May 2, 2021'),
-      endDate: new Date('Jun 2, 2021'),
-    },
-    {
-      index: 3,
-      name: 'Name3',
-      description: 'Description3',
-      id: '333',
-      startDate: new Date('May 3, 2021'),
-      endDate: new Date('Jun 3, 2021'),
-    },
-  ],
-};
-
-export const ZebraStripedRows: Story<Partial<TableProps>> = (args) => {
+export const ZebraStripedRows: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -2785,7 +2426,6 @@ export const ZebraStripedRows: Story<Partial<TableProps>> = (args) => {
         isSelectable
         isSortable
         styleType='zebra-rows'
-        {...args}
         columns={columns}
         data={data}
         style={{ height: '100%' }}
@@ -2794,13 +2434,7 @@ export const ZebraStripedRows: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-ZebraStripedRows.args = {
-  isSelectable: true,
-  isSortable: true,
-  styleType: 'zebra-rows',
-};
-
-export const HorizontalScroll: Story<Partial<TableProps>> = (args) => {
+export const HorizontalScroll: Story<Partial<TableProps>> = () => {
   const data = useMemo(
     () => [
       {
@@ -2925,84 +2559,8 @@ export const HorizontalScroll: Story<Partial<TableProps>> = (args) => {
       data={data}
       emptyTableContent='No data.'
       style={{ height: '100%' }}
-      {...args}
     />
   );
-};
-
-HorizontalScroll.args = {
-  data: [
-    {
-      product: 'Product 1',
-      price: 5,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 2',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 3',
-      price: 2.99,
-      quantity: 1500,
-      rating: '3/5',
-      deliveryTime: 7,
-    },
-    {
-      product: 'Product 4',
-      price: 20,
-      quantity: 50,
-      rating: '4/5',
-      deliveryTime: 2,
-    },
-    {
-      product: 'Product 5',
-      price: 1.99,
-      quantity: 700,
-      rating: '5/5',
-      deliveryTime: 1,
-    },
-    {
-      product: 'Product 6',
-      price: 499,
-      quantity: 30,
-      rating: '5/5',
-      deliveryTime: 20,
-    },
-    {
-      product: 'Product 7',
-      price: 13.99,
-      quantity: 130,
-      rating: '1/5',
-      deliveryTime: 30,
-    },
-    {
-      product: 'Product 8',
-      price: 5.99,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 9',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 10',
-      price: 2.99,
-      quantity: 200,
-      rating: '3/5',
-      deliveryTime: 17,
-    },
-  ],
 };
 
 HorizontalScroll.decorators = [
@@ -3019,7 +2577,7 @@ HorizontalScroll.decorators = [
   ),
 ];
 
-export const Virtualized: Story<Partial<TableProps>> = (args) => {
+export const Virtualized: Story<Partial<TableProps>> = () => {
   const onClickHandler = (
     props: CellProps<{ name: string; description: string }>,
   ) => action(props.row.original.name)();
@@ -3070,19 +2628,13 @@ export const Virtualized: Story<Partial<TableProps>> = (args) => {
       enableVirtualization
       columns={columns}
       emptyTableContent='No data.'
-      {...args}
       style={{ maxHeight: '90vh' }}
       data={data}
     />
   );
 };
 
-Virtualized.argTypes = {
-  isLoading: { control: { disable: true } },
-  data: { control: { disable: true } },
-};
-
-export const ScrollToRow: Story<Partial<TableProps>> = (args) => {
+export const ScrollToRow: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     id: string;
     name: string;
@@ -3145,7 +2697,6 @@ export const ScrollToRow: Story<Partial<TableProps>> = (args) => {
       columns={columns}
       emptyTableContent='No data.'
       isSortable
-      {...args}
       style={{ maxHeight: '90vh' }}
       data={data}
       scrollToRow={React.useCallback(
@@ -3157,12 +2708,7 @@ export const ScrollToRow: Story<Partial<TableProps>> = (args) => {
   );
 };
 
-ScrollToRow.argTypes = {
-  isLoading: { control: { disable: true } },
-  data: { control: { disable: true } },
-};
-
-export const VirtualizedSubRows: Story<Partial<TableProps>> = (args) => {
+export const VirtualizedSubRows: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -3218,19 +2764,13 @@ export const VirtualizedSubRows: Story<Partial<TableProps>> = (args) => {
       enableVirtualization
       columns={columns}
       emptyTableContent='No data.'
-      {...args}
       style={{ maxHeight: '90vh' }}
       data={data}
     />
   );
 };
 
-VirtualizedSubRows.argTypes = {
-  isLoading: { control: { disable: true } },
-  data: { control: { disable: true } },
-};
-
-export const DraggableColumns: Story<Partial<TableProps>> = (args) => {
+export const DraggableColumns: Story<Partial<TableProps>> = () => {
   const data = useMemo(
     () => [
       {
@@ -3352,89 +2892,11 @@ export const DraggableColumns: Story<Partial<TableProps>> = (args) => {
       data={data}
       emptyTableContent='No data.'
       isSelectable
-      {...args}
     />
   );
 };
 
-DraggableColumns.args = {
-  data: [
-    {
-      product: 'Product 1',
-      price: 5,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 2',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 3',
-      price: 2.99,
-      quantity: 1500,
-      rating: '3/5',
-      deliveryTime: 7,
-    },
-    {
-      product: 'Product 4',
-      price: 20,
-      quantity: 50,
-      rating: '4/5',
-      deliveryTime: 2,
-    },
-    {
-      product: 'Product 5',
-      price: 1.99,
-      quantity: 700,
-      rating: '5/5',
-      deliveryTime: 1,
-    },
-    {
-      product: 'Product 6',
-      price: 499,
-      quantity: 30,
-      rating: '5/5',
-      deliveryTime: 20,
-    },
-    {
-      product: 'Product 7',
-      price: 13.99,
-      quantity: 130,
-      rating: '1/5',
-      deliveryTime: 30,
-    },
-    {
-      product: 'Product 8',
-      price: 5.99,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 9',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 10',
-      price: 2.99,
-      quantity: 200,
-      rating: '3/5',
-      deliveryTime: 17,
-    },
-  ],
-  enableColumnReordering: true,
-  isSelectable: true,
-};
-
-export const CustomizedColumns: Story<Partial<TableProps>> = (args) => {
+export const CustomizedColumns: Story<Partial<TableProps>> = () => {
   const onExpand = useCallback(
     (rows, state) =>
       action(
@@ -3527,22 +2989,11 @@ export const CustomizedColumns: Story<Partial<TableProps>> = (args) => {
       rowProps={({ index }) => ({
         onClick: (e) => index === 0 && e.preventDefault(),
       })}
-      {...args}
     />
   );
 };
 
-CustomizedColumns.args = {
-  isSelectable: true,
-  data: [
-    { name: 'Name1', description: 'Description1' },
-    { name: 'Name2', description: 'Description2' },
-    { name: 'Name3', description: 'Description3' },
-    { name: 'Name4', description: 'Description4' },
-  ],
-};
-
-export const ColumnManager: Story<Partial<TableProps>> = (args) => {
+export const ColumnManager: Story<Partial<TableProps>> = () => {
   type TableStoryDataType = {
     index: number;
     name: string;
@@ -3702,82 +3153,11 @@ export const ColumnManager: Story<Partial<TableProps>> = (args) => {
       columns={columns}
       data={data}
       emptyTableContent='No data.'
-      {...args}
     />
   );
 };
 
-ColumnManager.args = {
-  data: [
-    {
-      index: 1,
-      name: 'Name1',
-      description: 'Description1',
-      id: '111',
-      startDate: new Date('May 1, 2021'),
-      endDate: new Date('Jun 1, 2021'),
-      price: '$1.00',
-      color: 'Red',
-      stock: 10,
-      rating: '5/5',
-      location: 'Philadelphia, Pennsylvania',
-    },
-    {
-      index: 2,
-      name: 'Name2',
-      description: 'Description2',
-      id: '222',
-      startDate: new Date('May 2, 2021'),
-      endDate: new Date('Jun 2, 2021'),
-      price: '$2.00',
-      color: 'Green',
-      stock: 20,
-      rating: '4/5',
-      location: 'Philadelphia, Pennsylvania',
-    },
-    {
-      index: 3,
-      name: 'Name3',
-      description: 'Description3',
-      id: '333',
-      startDate: new Date('May 3, 2021'),
-      endDate: new Date('Jun 3, 2021'),
-      price: '$3.00',
-      color: 'Green',
-      stock: 30,
-      rating: '3/5',
-      location: 'Philadelphia, Pennsylvania',
-    },
-    {
-      index: 4,
-      name: 'Name4',
-      description: 'Description4',
-      id: '444',
-      startDate: new Date('May 4, 2021'),
-      endDate: new Date('Jun 4, 2021'),
-      price: '$4.00',
-      color: 'Yellow',
-      stock: 40,
-      rating: '2/5',
-      location: 'Philadelphia, Pennsylvania',
-    },
-    {
-      index: 5,
-      name: 'Name5',
-      description: 'Description5',
-      id: '555',
-      startDate: new Date('May 5, 2021'),
-      endDate: new Date('Jun 5, 2021'),
-      price: '$5.00',
-      color: 'Purple',
-      stock: 50,
-      rating: '1/5',
-      location: 'Philadelphia, Pennsylvania',
-    },
-  ],
-};
-
-export const StickyColumns: Story<Partial<TableProps>> = (args) => {
+export const StickyColumns: Story<Partial<TableProps>> = () => {
   const data = useMemo(
     () => [
       {
@@ -3930,84 +3310,8 @@ export const StickyColumns: Story<Partial<TableProps>> = (args) => {
       emptyTableContent='No data.'
       style={{ height: '100%' }}
       isResizable
-      {...args}
     />
   );
-};
-
-StickyColumns.args = {
-  data: [
-    {
-      product: 'Product 1',
-      price: 5,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 2',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 3',
-      price: 2.99,
-      quantity: 1500,
-      rating: '3/5',
-      deliveryTime: 7,
-    },
-    {
-      product: 'Product 4',
-      price: 20,
-      quantity: 50,
-      rating: '4/5',
-      deliveryTime: 2,
-    },
-    {
-      product: 'Product 5',
-      price: 1.99,
-      quantity: 700,
-      rating: '5/5',
-      deliveryTime: 1,
-    },
-    {
-      product: 'Product 6',
-      price: 499,
-      quantity: 30,
-      rating: '5/5',
-      deliveryTime: 20,
-    },
-    {
-      product: 'Product 7',
-      price: 13.99,
-      quantity: 130,
-      rating: '1/5',
-      deliveryTime: 30,
-    },
-    {
-      product: 'Product 8',
-      price: 5.99,
-      quantity: 500,
-      rating: '4/5',
-      deliveryTime: 5,
-    },
-    {
-      product: 'Product 9',
-      price: 12,
-      quantity: 1200,
-      rating: '1/5',
-      deliveryTime: 25,
-    },
-    {
-      product: 'Product 10',
-      price: 2.99,
-      quantity: 200,
-      rating: '3/5',
-      deliveryTime: 17,
-    },
-  ],
 };
 
 StickyColumns.decorators = [
@@ -4024,7 +3328,7 @@ StickyColumns.decorators = [
   ),
 ];
 
-export const StatusAndCellIcons: Story<Partial<TableProps>> = (args) => {
+export const StatusAndCellIcons: Story<Partial<TableProps>> = () => {
   const columns = useMemo(
     () => [
       {
@@ -4142,7 +3446,6 @@ export const StatusAndCellIcons: Story<Partial<TableProps>> = (args) => {
 
   return (
     <Table
-      {...args}
       columns={columns}
       data={data}
       emptyTableContent='No data.'
@@ -4151,9 +3454,4 @@ export const StatusAndCellIcons: Story<Partial<TableProps>> = (args) => {
       rowProps={rowProps}
     />
   );
-};
-
-StatusAndCellIcons.args = {
-  isSelectable: true,
-  selectionMode: 'multi',
 };


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Solves part of #886 . Helper PR for #1514 .

Passing `{...args}` to `<Table>` in Table stories could hide TS errors (as mentioned in #886). Thus:

* Removed `{...args}` and Storybook controls from all Table Storybook stories.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Tested that all stories are still working as before.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A