### PR TITLE
Fix `--jsx` flag not set error in astro-playground

### DIFF
--- a/playgrounds/astro/tsconfig.json
+++ b/playgrounds/astro/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "astro/tsconfigs/strict"
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

After #1549, I noticed the below error in the Astro playground.

![image](https://github.com/iTwin/iTwinUI/assets/45748283/887a5a1d-3ad4-4b8c-b878-255b52d3226d)

Thus, I set `jsx` to `react-jsx` in the tsconfig to fix this error.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the above error no longer shows. Also confirmed that `yarn build` in the astro-playground works without any errors.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A