### PR TITLE
Fix label bottom margin issue that was introduced with input container rewrite

### DIFF
--- a/apps/storybook/src/ComboBox.stories.tsx
+++ b/apps/storybook/src/ComboBox.stories.tsx
@@ -12,7 +12,7 @@ import {
   StatusMessage,
   SelectOption,
   MenuItemSkeleton,
-  Flex,
+  InputGrid,
 } from '@itwin/itwinui-react';
 import { SvgCamera } from '@itwin/itwinui-icons-react';
 
@@ -383,7 +383,7 @@ export const WithLabel: StoryFn<Partial<ComboBoxProps>> = (args) => {
   const options = React.useMemo(() => countriesList, []);
 
   return (
-    <Flex flexDirection='column' alignItems='unset' gap='2xs'>
+    <InputGrid>
       <Label htmlFor='combo-input'>Country</Label>
       <ComboBox
         options={options}
@@ -394,7 +394,7 @@ export const WithLabel: StoryFn<Partial<ComboBoxProps>> = (args) => {
         }}
         {...args}
       />
-    </Flex>
+    </InputGrid>
   );
 };
 WithLabel.args = {

--- a/apps/storybook/src/Label.stories.tsx
+++ b/apps/storybook/src/Label.stories.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
-import { Input, Label, Text } from '@itwin/itwinui-react';
+import { Input, Label, Text, InputGrid } from '@itwin/itwinui-react';
 
 type LabelProps = React.ComponentProps<typeof Label>;
 
@@ -40,12 +40,12 @@ Basic.args = {};
 
 export const Inline: Story<LabelProps> = (args) => {
   return (
-    <div style={{ display: 'flex' }}>
+    <InputGrid labelPlacement='inline'>
       <Label htmlFor='text-input' displayStyle='inline' required {...args}>
         Name
       </Label>
       <Input id='text-input' defaultValue='James Bond' required />
-    </div>
+    </InputGrid>
   );
 };
 Inline.args = {
@@ -55,12 +55,12 @@ Inline.args = {
 
 export const Polymorphic: Story<LabelProps<'div'>> = (args) => {
   return (
-    <div style={{ display: 'flex' }}>
+    <InputGrid labelPlacement='inline'>
       <Label displayStyle='inline' as='div' {...args}>
         <Text isMuted>Name:</Text>
       </Label>
       <Text>James Bond</Text>
-    </div>
+    </InputGrid>
   );
 };
 Polymorphic.args = {

--- a/examples/ComboBox.label.tsx
+++ b/examples/ComboBox.label.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { ComboBox, Label } from '@itwin/itwinui-react';
+import { ComboBox, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const [breakfast, setBreakfast] = React.useState('');
@@ -31,28 +31,31 @@ export default () => {
   );
 
   return (
-    <div style={{ textAlign: 'left' }}>
-      <Label htmlFor='breakfast-input'>Breakfast</Label>
-      <ComboBox
-        options={breakfastOptions}
-        value={breakfast}
-        onChange={setBreakfast}
-        inputProps={{
-          id: 'breakfast-input', // passing id to inputProps so it can be used in Label htmlFor
-          placeholder: 'Choose your meal',
-        }}
-      />
-      <br />
-      <Label htmlFor='lunch-input'>Lunch</Label>
-      <ComboBox
-        options={lunchOptions}
-        value={lunch}
-        onChange={setLunch}
-        inputProps={{
-          id: 'lunch-input', // passing id to inputProps so it can be used in Label htmlFor
-          placeholder: 'Choose your meal',
-        }}
-      />
-    </div>
+    <>
+      <InputGrid>
+        <Label htmlFor='breakfast-input'>Breakfast</Label>
+        <ComboBox
+          options={breakfastOptions}
+          value={breakfast}
+          onChange={setBreakfast}
+          inputProps={{
+            id: 'breakfast-input', // passing id to inputProps so it can be used in Label htmlFor
+            placeholder: 'Choose your meal',
+          }}
+        />
+      </InputGrid>
+      <InputGrid>
+        <Label htmlFor='lunch-input'>Lunch</Label>
+        <ComboBox
+          options={lunchOptions}
+          value={lunch}
+          onChange={setLunch}
+          inputProps={{
+            id: 'lunch-input', // passing id to inputProps so it can be used in Label htmlFor
+            placeholder: 'Choose your meal',
+          }}
+        />
+      </InputGrid>
+    </>
   );
 };

--- a/examples/ComboBox.multipleSelect.tsx
+++ b/examples/ComboBox.multipleSelect.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { ComboBox, Label } from '@itwin/itwinui-react';
+import { ComboBox, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const options = React.useMemo(
@@ -23,7 +23,7 @@ export default () => {
   ]);
 
   return (
-    <>
+    <InputGrid>
       <Label htmlFor='housing-input'> Select housing type </Label>
       <ComboBox
         options={options}
@@ -34,6 +34,6 @@ export default () => {
           setSelectedOptions(selected);
         }}
       />
-    </>
+    </InputGrid>
   );
 };

--- a/examples/ExpandableBlock.form.tsx
+++ b/examples/ExpandableBlock.form.tsx
@@ -9,17 +9,26 @@ import {
   Input,
   InputGroup,
   Radio,
+  InputGrid,
 } from '@itwin/itwinui-react';
 
 export default () => {
   const nameSection = (
     <>
-      <Label htmlFor='name' required>
-        Name
-      </Label>
-      <Input id='name' key='name' placeholder='Enter name' />
-      <Label htmlFor='occupation'>Occupation</Label>
-      <Input id='occupation' key='occupation' placeholder='Enter occupation' />
+      <InputGrid>
+        <Label htmlFor='name' required>
+          Name
+        </Label>
+        <Input id='name' key='name' placeholder='Enter name' />
+      </InputGrid>
+      <InputGrid>
+        <Label htmlFor='occupation'>Occupation</Label>
+        <Input
+          id='occupation'
+          key='occupation'
+          placeholder='Enter occupation'
+        />
+      </InputGrid>
     </>
   );
 

--- a/examples/InformationPanel.main.tsx
+++ b/examples/InformationPanel.main.tsx
@@ -13,6 +13,7 @@ import {
   Label,
   Table,
   Text,
+  InputGrid,
 } from '@itwin/itwinui-react';
 import * as React from 'react';
 
@@ -48,24 +49,33 @@ export default () => {
         </InformationPanelHeader>
         <InformationPanelBody>
           <InformationPanelContent displayStyle='inline'>
-            <Label htmlFor='name-input'>File name</Label>
-            <Input
-              size='small'
-              id='name-input'
-              value={`Row ${openRowIndex ?? 0}`}
-              readOnly
-            />
-
-            <Label htmlFor='author-input'>Author</Label>
-            <Input
-              size='small'
-              id='author-input'
-              defaultValue='DJ Terry'
-              readOnly
-            />
-
-            <Label htmlFor='year-input'>Year</Label>
-            <Input size='small' id='year-input' defaultValue='2021' readOnly />
+            <InputGrid>
+              <Label htmlFor='name-input'>File name</Label>
+              <Input
+                size='small'
+                id='name-input'
+                value={`Row ${openRowIndex ?? 0}`}
+                readOnly
+              />
+            </InputGrid>
+            <InputGrid>
+              <Label htmlFor='author-input'>Author</Label>
+              <Input
+                size='small'
+                id='author-input'
+                defaultValue='DJ Terry'
+                readOnly
+              />
+            </InputGrid>
+            <InputGrid>
+              <Label htmlFor='year-input'>Year</Label>
+              <Input
+                size='small'
+                id='year-input'
+                defaultValue='2021'
+                readOnly
+              />
+            </InputGrid>
           </InformationPanelContent>
         </InformationPanelBody>
       </InformationPanel>

--- a/examples/Slider.labels.tsx
+++ b/examples/Slider.labels.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Label } from '@itwin/itwinui-react';
+import { Slider, Label, InputGrid } from '@itwin/itwinui-react';
 
 import {
   SvgSmileyHappyVery,
@@ -14,7 +14,7 @@ export default () => {
   const labelId = React.useId();
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose a happiness level
       </Label>
@@ -28,6 +28,6 @@ export default () => {
         max={100}
         step={10}
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Slider.main.tsx
+++ b/examples/Slider.main.tsx
@@ -3,13 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Label } from '@itwin/itwinui-react';
+import { Slider, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose a value
       </Label>
@@ -19,6 +19,6 @@ export default () => {
         min={0}
         max={100}
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Slider.range.tsx
+++ b/examples/Slider.range.tsx
@@ -3,13 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Label } from '@itwin/itwinui-react';
+import { Slider, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose a range
       </Label>
@@ -19,6 +19,6 @@ export default () => {
         min={0}
         max={100}
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Slider.rangemultiple.tsx
+++ b/examples/Slider.rangemultiple.tsx
@@ -3,13 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Label } from '@itwin/itwinui-react';
+import { Slider, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose ranges
       </Label>
@@ -21,6 +21,6 @@ export default () => {
         thumbMode='allow-crossing'
         trackDisplayMode='even-segments'
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Slider.tooltipcustom.tsx
+++ b/examples/Slider.tooltipcustom.tsx
@@ -3,13 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Label } from '@itwin/itwinui-react';
+import { Slider, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose a value
       </Label>
@@ -23,6 +23,6 @@ export default () => {
           return { placement: 'right', content: `\$${val}.00` };
         }}
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Slider.tooltipnone.tsx
+++ b/examples/Slider.tooltipnone.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Slider, Text, Label } from '@itwin/itwinui-react';
+import { Slider, Text, Label, InputGrid } from '@itwin/itwinui-react';
 
 export default () => {
   const labelId = React.useId();
@@ -27,7 +27,7 @@ export default () => {
   }, []);
 
   return (
-    <div style={{ width: 'min(100%, 300px)' }}>
+    <InputGrid style={{ width: 'min(100%, 300px)' }}>
       <Label id={labelId} as='div'>
         Choose a start date
       </Label>
@@ -61,6 +61,6 @@ export default () => {
           </div>
         }
       />
-    </div>
+    </InputGrid>
   );
 };

--- a/examples/Stepper.layout.tsx
+++ b/examples/Stepper.layout.tsx
@@ -10,6 +10,7 @@ import {
   Label,
   Stepper,
   InputGroup,
+  InputGrid,
   Radio,
 } from '@itwin/itwinui-react';
 
@@ -27,7 +28,7 @@ export default () => {
     setDisableProgress(true);
   }, [currentStep]);
   const stepOne = (
-    <>
+    <InputGrid>
       <Label required>Name</Label>
       <Input
         key='name'
@@ -38,7 +39,7 @@ export default () => {
       />
       <Label>Occupation</Label>
       <Input key='occupation' placeholder='Enter occupation' />
-    </>
+    </InputGrid>
   );
 
   const stepTwo = (
@@ -60,7 +61,7 @@ export default () => {
   );
 
   const stepThree = (
-    <>
+    <InputGrid>
       <Label required>Why is this your favorite color</Label>
       <Input
         key='explanation'
@@ -69,7 +70,7 @@ export default () => {
           setDisableProgress(!value);
         }}
       />
-    </>
+    </InputGrid>
   );
 
   const steps = [stepOne, stepTwo, stepThree];


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

#1521 

Added InputGrid in the examples that uses Label.

## Testing

Visual tests pass;
Unit tests pass;
a11y tests pass;

## Docs

N/A