### PR TITLE
make dropdown menus scrollable by default 

### DIFF
--- a/.changeset/famous-geese-approve.md
+++ b/.changeset/famous-geese-approve.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Dropdown menus will now automatically become wscrollable if there are too many menu items.
+Dropdown menus will now automatically become scrollable if there are too many menu items.

--- a/.changeset/famous-geese-approve.md
+++ b/.changeset/famous-geese-approve.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Dropdown menus will now automatically become wscrollable if there are too many menu items.

--- a/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import cx from 'classnames';
 import { useTheme, Popover, mergeRefs } from '../utils/index.js';
 import type {
   CommonProps,
@@ -96,7 +97,12 @@ export const DropdownMenu = (props: DropdownMenuProps) => {
   return (
     <Popover
       content={
-        <Menu className={className} style={style} role={role} id={id}>
+        <Menu
+          className={cx('iui-scroll', className)}
+          style={style}
+          role={role}
+          id={id}
+        >
           {React.useMemo(() => menuItems(close), [menuItems, close])}
         </Menu>
       }

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -203,7 +203,9 @@ export const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
                   setIsSubmenuVisible(false);
               }}
             >
-              <Menu ref={subMenuRef}>{subMenuItems}</Menu>
+              <Menu ref={subMenuRef} className='iui-scroll'>
+                {subMenuItems}
+              </Menu>
             </div>
           }
         >

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -193,6 +193,7 @@ export const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
           placement='right-start'
           visible={isSubmenuVisible}
           appendTo='parent'
+          delay={100}
           content={
             <div
               onMouseLeave={() => setIsSubmenuVisible(false)}


### PR DESCRIPTION
## Changes

this PR fixes #1301 in two steps:
- added `iui-scroll` by default to regular `DropdownMenu`s and submenus.
- added 100ms delay to submenu.

in #1577: `iui-scroll` will be removed and the overflow css will be moved into base styling in v3.

## Testing

| Before | After |
| --- | --- |
| <img width="294" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/9b0ff5ff-142f-4c1c-958d-d9b46ecea1b6"> | <img width="179" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/f194459c-61ef-463c-b862-1e0b11275d79"> |

## Docs

n/a