### PR TITLE
fix toggle-switch popout styles

### DIFF
--- a/.changeset/eighty-squids-protect.md
+++ b/.changeset/eighty-squids-protect.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue with toggle-switch border styles not working in popout windows.

--- a/packages/itwinui-css/src/toggle-switch/toggle-switch.scss
+++ b/packages/itwinui-css/src/toggle-switch/toggle-switch.scss
@@ -68,7 +68,7 @@
   border-radius: var(--iui-border-radius-round);
   transition: background-color var(--iui-duration-1) ease-out, border-color var(--iui-duration-1) ease-out;
   background-color: var(--iui-color-background);
-  border: $iui-toggle-switch-border-thickness solid var(--iui-color-border-foreground);
+  border: $iui-toggle-switch-border-thickness solid;
 
   &-label {
     grid-area: label;


### PR DESCRIPTION
## Changes

fixes #1584. don't ask why.

## Testing

tested in vite playground using this code:

<details>
<summary>App.tsx</summary>

```tsx
import * as React from 'react';
import * as ReactDOM from 'react-dom';
import { Button, ThemeProvider, ToggleSwitch } from '@itwin/itwinui-react';

let childWindow: Window | null;

export default () => {
  const [isPoppedOut, setIsPoppedOut] = React.useState(false);

  return (
    <>
      <ToggleSwitch label='hello' />
      <br />
      <Button
        disabled={isPoppedOut}
        onClick={() => {
          childWindow = window.open(
            '',
            '',
            'menubar=no,resizable=yes,scrollbars=no,status=no,location=no',
          );
          if (!childWindow) return;

          setIsPoppedOut(true);
          copyStyles(childWindow!.document);
        }}
      >
        Open window
      </Button>
      {isPoppedOut &&
        ReactDOM.createPortal(
          <ThemeProvider>
            <ToggleSwitch label='world' />
            <br />
            <Button>button for comparison</Button>
          </ThemeProvider>,
          childWindow!.document.body,
        )}
    </>
  );
};

// ----------------------------------------------------------------------------

function copyStyles(
  targetDoc: Document,
  sourceDoc: Document = document,
) {
  const stylesheets = Array.from([
    ...sourceDoc.styleSheets,
    ...sourceDoc.adoptedStyleSheets,
  ]);
  // istanbul ignore next
  stylesheets.forEach((stylesheet) => {
    const css = stylesheet;
    if (stylesheet.href) {
      const newStyleElement = targetDoc.createElement('link');
      newStyleElement.rel = 'stylesheet';
      newStyleElement.href = stylesheet.href;
      targetDoc.head.appendChild(newStyleElement);
    } else {
      if (css && css.cssRules && css.cssRules.length > 0) {
        const newStyleElement = targetDoc.createElement('style');
        Array.from(css.cssRules).forEach((rule) => {
          newStyleElement.appendChild(targetDoc.createTextNode(rule.cssText));
        });
        targetDoc.head.appendChild(newStyleElement);
      }
    }
  });
}

```

</details>

the main difference is there are no invalid border styles anymore.

| Before | After |
| --- | --- |
| <img width="382" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/a2d5fdc0-d906-4c0f-b197-240f12603d1e"> | <img width="368" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/5a4a21ee-dfa2-4bce-8fa5-e6b81c2a9016"> |
| <img width="75" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/5da59b9a-49ba-40d4-9f31-74f7d838bd63"> | <img width="65" alt="" src="https://github.com/iTwin/iTwinUI/assets/9084735/2e14ce09-04da-4826-a34a-46f30d9e6efc"> |

## Docs

n/a