### PR TITLE
fix v2 modals/toasts conflicting with v1

### DIFF
--- a/.changeset/early-hats-divide.md
+++ b/.changeset/early-hats-divide.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where v2 toasts and modals were being added to v1 containers.

--- a/packages/itwinui-react/src/core/Modal/Modal.tsx
+++ b/packages/itwinui-react/src/core/Modal/Modal.tsx
@@ -39,7 +39,7 @@ export type ModalProps = {
   onKeyDown?: React.KeyboardEventHandler;
   /**
    * Id of the root where the modal will be rendered in.
-   * @default 'iui-react-portal-container'
+   * @default 'iui2-react-portal-container'
    */
   modalRootId?: string;
   /**
@@ -85,7 +85,7 @@ export const Modal = (props: ModalProps) => {
     onClose,
     title,
     children,
-    modalRootId = 'iui-react-portal-container',
+    modalRootId = 'iui2-react-portal-container',
     ownerDocument = getDocument(),
     ...rest
   } = props;

--- a/packages/itwinui-react/src/core/Toast/Toaster.test.tsx
+++ b/packages/itwinui-react/src/core/Toast/Toaster.test.tsx
@@ -69,7 +69,7 @@ afterEach(() => {
   // This is the only thing I found to help with
   // warning for calling `createRoot` on element, which already had it.
   // Something is not fully reset in tests (this happens between multiple tests, not in single one)
-  const container = document.querySelector('#iui-toasts-container');
+  const container = document.querySelector('#iui2-toasts-container');
   if (!!container) {
     container.remove();
   }

--- a/packages/itwinui-react/src/core/Toast/Toaster.tsx
+++ b/packages/itwinui-react/src/core/Toast/Toaster.tsx
@@ -9,7 +9,7 @@ import type { ToastCategory, ToastProps } from './Toast.js';
 import { ToastWrapper } from './ToastWrapper.js';
 import type { ToastWrapperHandle } from './ToastWrapper.js';
 
-const TOASTS_CONTAINER_ID = 'iui-toasts-container';
+const TOASTS_CONTAINER_ID = 'iui2-toasts-container';
 
 export type ToasterSettings = {
   /**


### PR DESCRIPTION
## Changes

changed the portal container ids in v2 so that they don't conflict with v1. fixes #1582

reason: html `id`s need to be globally unique so if both v1 and v2 are used together with same ids, the v1 portal containers were being reused for v2 components and therefore not getting styled (since they are outside the "v2 boundary" created by ThemeProvider).

## Testing

tested by recreating the sandbox from the bug report.

https://github.com/iTwin/iTwinUI/assets/9084735/675ba0f8-1f84-4904-98b0-11fb902cfbdc

## Docs

n/a