### PR TITLE
Fix `useScrollToRow` crash on property access of undefined `pageRef.current[scrollToIndex]` object

### DIFF
--- a/.changeset/bright-onions-draw.md
+++ b/.changeset/bright-onions-draw.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed undefined property access in `useScrollToRow`.

--- a/packages/itwinui-react/src/core/Table/hooks/useScrollToRow.ts
+++ b/packages/itwinui-react/src/core/Table/hooks/useScrollToRow.ts
@@ -54,7 +54,7 @@ export function useScrollToRow<T extends Record<string, unknown>>({
       return;
     }
 
-    rowRefs.current[pageRef.current[scrollToIndex].id]?.scrollIntoView();
+    rowRefs.current[pageRef.current[scrollToIndex]?.id]?.scrollIntoView();
   }, [enableVirtualization, scrollToIndex]);
 
   const tableRowRef = React.useCallback((row: Row<T>) => {


### PR DESCRIPTION
## Changes
Fixes `useScrollToRow` crash on property access of undefined `pageRef.current[scrollToIndex]` object
## Testing
N/A

## Docs

N/A
