### PR TITLE
don't run stylelint on html files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   },
   "lint-staged": {
     "*.{scss}": [
-      "prettier --write"
-    ],
-    "*.{scss,html}": [
+      "prettier --write",
       "stylelint --fix"
     ],
     "*.{scss,html,js}": [


### PR DESCRIPTION
## Changes

fixes pre-commit hook part of #1571

## Testing

tested that html files can be committed without `no-verify`.

## Docs

n/a