### PR TITLE
Removed `setFocus` from JSDocs

### DIFF
--- a/packages/itwinui-react/src/core/Input/Input.tsx
+++ b/packages/itwinui-react/src/core/Input/Input.tsx
@@ -26,7 +26,6 @@ export type InputProps = {
 /**
  * Basic input component
  * @example
- * <Input setFocus />
  * <Input disabled />
  * <Input size='small' />
  */

--- a/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
+++ b/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
@@ -64,7 +64,7 @@ export type LabeledInputProps = {
  * <LabeledInput label='My label' />
  * <LabeledInput disabled label='My label' />
  * <LabeledInput status='positive' label='Positive' />
- * <LabeledInput status='negative' label='Negative' setFocus />
+ * <LabeledInput status='negative' label='Negative' />
  */
 export const LabeledInput = React.forwardRef((props, ref) => {
   const uid = useId();


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

When working on https://github.com/iTwin/iTwinUI-migration-tool/pull/29, I noticed that although `setFocus` was removed from a few components in #1406, the `setFocus` prop was still used in some JSDocs examples.

This PR just updates or deletes those outdated examples.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A