### PR TITLE
add `'use client'` directive

### DIFF
--- a/.changeset/chatty-flowers-clean.md
+++ b/.changeset/chatty-flowers-clean.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added `'use client'` directive for React Server Components support.

--- a/packages/itwinui-react/src/index.ts
+++ b/packages/itwinui-react/src/index.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+'use client';
+
 export { Alert } from './core/Alert/Alert.js';
 
 export { Avatar } from './core/Avatar/Avatar.js';


### PR DESCRIPTION
## Changes

added `"use client"` to barrel file, since this is the only place where components can be imported from.

this makes it possible to use our library in Nextjs App Router without hacks.

see https://react.dev/reference/react/use-client

while not all of our components (for example `Text`) necessarily need to be Client Components, we use context in every single one, so they kinda have to be.

## Testing

n/a.

we can test it in migration tool once released.

## Docs

n/a