### PR TITLE
simplify ColorPalette for a11y

### DIFF
--- a/examples/ColorPicker.basic.tsx
+++ b/examples/ColorPicker.basic.tsx
@@ -8,6 +8,8 @@ import {
   ColorPicker,
   ColorValue,
   ColorSwatch,
+  Button,
+  Popover,
 } from '@itwin/itwinui-react';
 
 export default () => {
@@ -44,6 +46,7 @@ export default () => {
     { color: '#ffc335', name: 'RISE-N-SHINE' },
   ];
 
+  const [isOpen, setIsOpen] = React.useState(false);
   const [activeColor, setActiveColor] = React.useState(ColorsList[5]);
   const [colorName, setColorName] = React.useState(ColorsList[5].name);
 
@@ -54,23 +57,32 @@ export default () => {
     );
     setActiveColor(ColorsList[index]);
     setColorName(ColorsList[index].name);
+    setIsOpen(false);
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <div style={{ display: 'flex', flexDirection: 'row', gap: 10 }}>
-        <ColorSwatch
-          style={{ pointerEvents: 'none' }}
-          color={activeColor.color}
-        />
-        <span>{colorName}</span>
-      </div>
-      <ColorPicker
-        selectedColor={activeColor.color}
-        onChangeComplete={onColorChanged}
+    <Popover
+      visible={isOpen}
+      onVisibleChange={setIsOpen}
+      content={
+        <ColorPicker
+          selectedColor={activeColor.color}
+          onChangeComplete={onColorChanged}
+        >
+          <ColorPalette colors={ColorsList.map(({ color }) => color)} />
+        </ColorPicker>
+      }
+    >
+      <Button
+        startIcon={
+          <ColorSwatch
+            style={{ pointerEvents: 'none' }}
+            color={activeColor.color}
+          />
+        }
       >
-        <ColorPalette colors={ColorsList.map(({ color }) => color)} />
-      </ColorPicker>
-    </div>
+        {colorName}
+      </Button>
+    </Popover>
   );
 };

--- a/packages/itwinui-react/src/core/ColorPicker/ColorPalette.tsx
+++ b/packages/itwinui-react/src/core/ColorPicker/ColorPalette.tsx
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import {
-  ColorValue,
-  getFocusableElements,
-  useMergedRefs,
-  Box,
-} from '../utils/index.js';
+import { ColorValue, Box } from '../utils/index.js';
 import type {
   ColorType,
   PolymorphicForwardRefComponent,
@@ -50,88 +45,6 @@ export const ColorPalette = React.forwardRef((props, ref) => {
   const { activeColor, setActiveColor, onChangeComplete } =
     useColorPickerContext();
 
-  const [focusedIndex, setFocusedIndex] = React.useState<number>();
-
-  // callback ref to set tabindex=0 on first child if none of the swatches are tabbable
-  const setDefaultTabIndex = (el: HTMLDivElement) => {
-    if (el && !el.querySelector('[tabindex="0"]')) {
-      el.firstElementChild?.setAttribute('tabindex', '0');
-    }
-  };
-
-  const paletteRef = React.useRef<HTMLDivElement>(null);
-  const paletteRefs = useMergedRefs(paletteRef, setDefaultTabIndex);
-
-  // Color palette arrow key navigation
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.altKey) {
-      return;
-    }
-
-    const swatches = getFocusableElements(paletteRef.current) as HTMLElement[];
-
-    if (!swatches.length) {
-      return;
-    }
-
-    const currentIndex = swatches.findIndex(
-      (swatch) => swatch === paletteRef.current?.ownerDocument.activeElement,
-    );
-    if (currentIndex < 0) {
-      return;
-    }
-    let newIndex = -1;
-
-    switch (event.key) {
-      case 'ArrowDown': {
-        // Look for next ColorSwatch with same offsetLeft value
-        newIndex = swatches.findIndex(
-          (swatch, index) =>
-            index > currentIndex &&
-            swatch.offsetLeft === swatches[currentIndex].offsetLeft,
-        );
-        break;
-      }
-      case 'ArrowUp': {
-        // Look backwards for next ColorSwatch with same offsetLeft value
-        for (let i = currentIndex - 1; i >= 0; i--) {
-          if (swatches[i].offsetLeft === swatches[currentIndex].offsetLeft) {
-            newIndex = i;
-            break;
-          }
-        }
-        break;
-      }
-      case 'ArrowLeft':
-        newIndex = Math.max(currentIndex - 1, 0);
-        break;
-      case 'ArrowRight':
-        newIndex = Math.min(currentIndex + 1, swatches.length - 1);
-        break;
-      case 'Enter':
-      case ' ':
-      case 'Spacebar':
-        swatches[currentIndex].click();
-        event.preventDefault();
-        return;
-    }
-
-    if (newIndex >= 0 && newIndex < swatches.length) {
-      setFocusedIndex(newIndex);
-      event.preventDefault();
-    }
-  };
-
-  // call focus() when focusedIndex changes
-  React.useEffect(() => {
-    if (focusedIndex != null) {
-      const swatches = getFocusableElements(
-        paletteRef.current,
-      ) as HTMLElement[];
-      swatches[focusedIndex]?.focus();
-    }
-  }, [focusedIndex]);
-
   return (
     <Box
       className={cx('iui-color-palette-wrapper', className)}
@@ -139,11 +52,7 @@ export const ColorPalette = React.forwardRef((props, ref) => {
       {...rest}
     >
       {label && <Box className='iui-color-picker-section-label'>{label}</Box>}
-      <Box
-        className='iui-color-palette'
-        onKeyDown={handleKeyDown}
-        ref={paletteRefs}
-      >
+      <Box className='iui-color-palette'>
         {children}
         {colors &&
           colors.map((_color, index) => {
@@ -152,8 +61,7 @@ export const ColorPalette = React.forwardRef((props, ref) => {
               <ColorSwatch
                 key={index}
                 color={color}
-                onClick={(event) => {
-                  event.preventDefault();
+                onClick={() => {
                   onChangeComplete?.(color);
                   setActiveColor(color);
                 }}

--- a/packages/itwinui-react/src/core/ColorPicker/ColorSwatch.tsx
+++ b/packages/itwinui-react/src/core/ColorPicker/ColorSwatch.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { ColorValue, Box } from '../utils/index.js';
+import { ColorValue, Box, ButtonBase } from '../utils/index.js';
 import type {
   ColorType,
   PolymorphicForwardRefComponent,
@@ -41,6 +41,7 @@ export const ColorSwatch = React.forwardRef((props, ref) => {
 
   return (
     <Box
+      as={(!!onClick ? ButtonBase : 'span') as 'button'}
       className={cx('iui-color-swatch', { 'iui-active': isActive }, className)}
       style={
         {
@@ -49,12 +50,11 @@ export const ColorSwatch = React.forwardRef((props, ref) => {
         } as React.CSSProperties
       }
       onClick={onClick}
-      tabIndex={isActive ? 0 : -1}
-      aria-selected={isActive}
+      aria-pressed={isActive}
       ref={ref}
       {...rest}
     />
   );
-}) as PolymorphicForwardRefComponent<'div', ColorSwatchProps>;
+}) as PolymorphicForwardRefComponent<'button', ColorSwatchProps>;
 
 export default ColorSwatch;


### PR DESCRIPTION
## Changes

WIP

- removed all keyboard handling from color palette, as it does not make sense on generic items
- change role of color swatch to `button` when `onClick` is passed
- changed `aria-selected` (invalid on button) to `aria-pressed`

refs:
- https://github.com/iTwin/iTwinUI/pull/1470#discussion_r1287646516
- https://github.com/iTwin/iTwinUI/pull/1602#discussion_r1341392106

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->
