### PR TITLE
fix styles being adopted from different window

### DIFF
--- a/.changeset/cyan-mice-dress.md
+++ b/.changeset/cyan-mice-dress.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where components rendered in a popout window were throwing a stylesheet-related error.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -134,8 +134,12 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
   const theme =
     themeProp === 'inherit' ? parentContext?.theme ?? 'light' : themeProp;
 
+  const stylesLoaded = React.useRef(
+    parentContext?.stylesLoaded.current ?? false,
+  );
+
   const contextValue = React.useMemo(
-    () => ({ theme, themeOptions, rootRef, includeCss }),
+    () => ({ theme, themeOptions, rootRef, includeCss, stylesLoaded }),
     [theme, themeOptions, includeCss],
   );
 
@@ -179,6 +183,7 @@ export const ThemeContext = React.createContext<
       themeOptions?: ThemeOptions;
       rootRef: React.RefObject<HTMLElement>;
       includeCss?: IncludeCssProps['includeCss'];
+      stylesLoaded: React.MutableRefObject<boolean>;
     }
   | undefined
 >(undefined);

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -134,13 +134,24 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
   const theme =
     themeProp === 'inherit' ? parentContext?.theme ?? 'light' : themeProp;
 
-  const stylesLoaded = React.useRef(
-    parentContext?.stylesLoaded.current ?? false,
-  );
+  const newStylesLoaded = React.useRef(false);
+  const stylesLoaded = parentContext?.stylesLoaded ?? newStylesLoaded;
 
   const contextValue = React.useMemo(
-    () => ({ theme, themeOptions, rootRef, includeCss, stylesLoaded }),
-    [theme, themeOptions, includeCss],
+    () => ({
+      theme,
+      themeOptions,
+      rootRef,
+      includeCss,
+      stylesLoaded,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- we do include themeOptions below (indirectly)
+    [
+      theme,
+      JSON.stringify(themeOptions), // eslint-disable-line react-hooks/exhaustive-deps -- we want to stringify themeOptions as it's a new object each time
+      includeCss,
+      stylesLoaded,
+    ],
   );
 
   // if no children, then fallback to this wrapper component which calls useTheme

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -145,11 +145,12 @@ export const ThemeProvider = React.forwardRef((props, ref) => {
       includeCss,
       stylesLoaded,
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- we do include themeOptions below (indirectly)
+    // we do include all dependencies below, but we want to stringify the objects as they could be different on each render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       theme,
-      JSON.stringify(themeOptions), // eslint-disable-line react-hooks/exhaustive-deps -- we want to stringify themeOptions as it's a new object each time
-      includeCss,
+      JSON.stringify(themeOptions), // eslint-disable-line react-hooks/exhaustive-deps
+      JSON.stringify(includeCss), // eslint-disable-line react-hooks/exhaustive-deps
       stylesLoaded,
     ],
   );

--- a/packages/itwinui-react/src/core/utils/hooks/useStyles.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useStyles.ts
@@ -16,6 +16,9 @@ const _React = React;
 const useIsomorphicInsertionEffect =
   _React.useInsertionEffect ?? useIsomorphicLayoutEffect;
 
+/** This lives outside the hook, because we only want to load styles once, no matter what.  */
+let loaded = false;
+
 /**
  * Dynamically loads the iTwinUI styles as a constructed stylesheet,
  * falling back to a regular `<style>` tag in `<head>`.
@@ -25,13 +28,12 @@ export const useStyles = (options?: {
   document?: () => Document | undefined;
 }) => {
   const context = _React.useContext(ThemeContext);
-  const loaded = _React.useRef(false);
 
   const includeCss = options?.includeCss ??
     context?.includeCss ?? { withLayer: true };
 
   useIsomorphicInsertionEffect(() => {
-    if (loaded.current || !includeCss) {
+    if (loaded || !includeCss) {
       return;
     }
 
@@ -44,7 +46,7 @@ export const useStyles = (options?: {
 
     loadStyles({ withLayer, document });
 
-    loaded.current = true;
+    loaded = true;
   }, [context, options, includeCss]);
 };
 

--- a/packages/itwinui-react/src/core/utils/hooks/useStyles.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useStyles.ts
@@ -16,6 +16,9 @@ const _React = React;
 const useIsomorphicInsertionEffect =
   _React.useInsertionEffect ?? useIsomorphicLayoutEffect;
 
+/** This lives outside the hook because we only want to load styles once even when context is not provided. */
+let globalLoaded = false;
+
 /**
  * Dynamically loads the iTwinUI styles as a constructed stylesheet,
  * falling back to a regular `<style>` tag in `<head>`.
@@ -27,16 +30,10 @@ export const useStyles = (options?: {
   const context = _React.useContext(ThemeContext);
 
   useIsomorphicInsertionEffect(() => {
-    if (!context) {
-      return;
-    }
-
-    const loaded = context.stylesLoaded;
-
     const includeCss = options?.includeCss ??
       context?.includeCss ?? { withLayer: true };
 
-    if (loaded.current || !includeCss) {
+    if (context?.stylesLoaded.current || globalLoaded || !includeCss) {
       return;
     }
 
@@ -49,7 +46,11 @@ export const useStyles = (options?: {
 
     loadStyles({ withLayer, document });
 
-    loaded.current = true;
+    if (context) {
+      context.stylesLoaded.current = true;
+    } else {
+      globalLoaded = true;
+    }
   }, [context, options]);
 };
 


### PR DESCRIPTION
## Changes

fixes #1624 (v2 bug)

after debugging together with Gerardus, we found that the main problem was `loaded` being stored in a ref that gets initialized for every single component. this means `DropdownMenu` was calling `new CSSStyleSheet()` (from default `window`) and then trying to adopt it into the child window.

so i:
- moved loaded state out of the hook and into `ThemeProvider`, ensuring that it's shared across components.
- used [`document.defaultView`](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView) to get child window and call `CSSStyleSheet()` from there.

slightly unrelated: i optimized ThemeContext value to be correctly memoized. This reduces the number of times the useEffect inside `useStyles` is called (and the number of re-renders in general).

## Testing

tested with this code in vite playground:

<details>
<summary>App.tsx</summary>

```tsx
import {
  Button,
  DropdownMenu,
  MenuItem,
  ThemeProvider,
} from '@itwin/itwinui-react';
import * as ReactDOM from 'react-dom';

const DummyComponent = () => {
  return (
    <div>
      <DropdownMenu
        menuItems={(close) => [
          <MenuItem key='1' onClick={close}>
            Item 1
          </MenuItem>,
          <MenuItem key='2' onClick={close}>
            Item 2
          </MenuItem>,
        ]}
      >
        <Button>DropdownMenu</Button>
      </DropdownMenu>
    </div>
  );
};

const childHtml = `<!DOCTYPE html>
<html lang="en-ie" data-child>
<head>
  <meta charset="utf-8" />
</head>
<body>
  <div id="root"></div>
</body>
</html>`;

function renderChildWindow(container: Element | DocumentFragment) {
  ReactDOM.render(
    <ThemeProvider className='child'>
      <DummyComponent />
    </ThemeProvider>,
    container,
  );
}

function popout() {
  const childWindow = window.open(
    '',
    '',
    'menubar=no,resizable=yes,scrollbars=no,status=no,location=no',
  )!;
  childWindow.document.title = 'Popout window!';
  childWindow.document.write(childHtml);

  setTimeout(() => {
    copyStyles(childWindow.document);
    setTimeout(() => {
      const reactConnectionDiv = childWindow.document.getElementById('root')!;
      renderChildWindow(reactConnectionDiv);
    });
  });
}

export default function App() {
  return (
    <ThemeProvider>
      <div>
        <DummyComponent />
        <button onClick={() => popout()}>Pop me out</button>
      </div>
    </ThemeProvider>
  );
}

// ----------------------------------------------------------------------------

function copyStyles(targetDoc: Document, sourceDoc: Document = document) {
  const stylesheets = Array.from([
    ...sourceDoc.styleSheets,
    ...sourceDoc.adoptedStyleSheets,
  ]);
  stylesheets.forEach((stylesheet) => {
    const css = stylesheet;
    if (stylesheet.href) {
      const newStyleElement = targetDoc.createElement('link');
      newStyleElement.rel = 'stylesheet';
      newStyleElement.href = stylesheet.href;
      targetDoc.head.appendChild(newStyleElement);
    } else {
      if (css && css.cssRules && css.cssRules.length > 0) {
        const newStyleElement = targetDoc.createElement('style');
        Array.from(css.cssRules).forEach((rule) => {
          newStyleElement.appendChild(targetDoc.createTextNode(rule.cssText));
        });
        targetDoc.head.appendChild(newStyleElement);
      }
    }
  });
}
```

</details>

## Docs

n/a
