### PR TITLE
add missing alt to Tile avatar example

### DIFF
--- a/examples/Tile.avatar.tsx
+++ b/examples/Tile.avatar.tsx
@@ -26,7 +26,10 @@ export default () => {
             abbreviation='TR'
             backgroundColor={getUserColor('Terry Rivers')}
             image={
-              <img src='https://itwinplatformcdn.azureedge.net/iTwinUI/user-placeholder.png' />
+              <img
+                src='https://itwinplatformcdn.azureedge.net/iTwinUI/user-placeholder.png'
+                alt=''
+              />
             }
             title='Terry Rivers'
           />


### PR DESCRIPTION
## Changes

added empty alt to ignore the image, because the tile already has the name of the user.

## Testing

axe passes now

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/bf13dbe5-6a0a-4d1c-857d-47db753db931) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/638ef1c7-5a6b-43b9-9a66-e8ea77ab78cb) |

## Docs

n/a