### PR TITLE
useOverflow: fix visibleCount when item is too big for the space

### DIFF
--- a/.changeset/dull-scissors-flash.md
+++ b/.changeset/dull-scissors-flash.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fix overflow visible items count when item is larger than container.

--- a/packages/itwinui-react/src/core/utils/hooks/useOverflow.test.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useOverflow.test.tsx
@@ -211,3 +211,27 @@ it('should hide items and then show them all when overflow is disabled', async (
     expect(container.querySelectorAll('span')).toHaveLength(100);
   });
 });
+
+it('should return 1 when item is bigger than the container', () => {
+  jest
+    .spyOn(HTMLDivElement.prototype, 'scrollWidth', 'get')
+    .mockReturnValueOnce(50)
+    .mockReturnValueOnce(100)
+    .mockReturnValue(50);
+  jest
+    .spyOn(HTMLDivElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(50);
+  jest
+    .spyOn(HTMLSpanElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(60);
+
+  const { container } = render(
+    <MockComponent>
+      {[...Array(5)].map((_, i) => (
+        <span key={i}>Test {i}</span>
+      ))}
+    </MockComponent>,
+  );
+
+  expect(container.querySelectorAll('span')).toHaveLength(1);
+});

--- a/packages/itwinui-react/src/core/utils/hooks/useOverflow.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useOverflow.tsx
@@ -78,7 +78,7 @@ export const useOverflow = <T extends HTMLElement>(
     if (availableSize < requiredSize) {
       const avgItemSize = requiredSize / visibleCount;
       const visibleItems = Math.floor(availableSize / avgItemSize);
-      setVisibleCount(visibleItems);
+      setVisibleCount(visibleItems > 0 ? visibleItems : 1);
     } else if (needsFullRerender.current) {
       const childrenSize = Array.from(containerRef.current.children).reduce(
         (sum: number, child: HTMLElement) => sum + child[`offset${dimension}`],

--- a/packages/itwinui-react/src/core/utils/hooks/useOverflow.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useOverflow.tsx
@@ -78,6 +78,8 @@ export const useOverflow = <T extends HTMLElement>(
     if (availableSize < requiredSize) {
       const avgItemSize = requiredSize / visibleCount;
       const visibleItems = Math.floor(availableSize / avgItemSize);
+      /* When first item is larger than the container - visibleItems count is 0, 
+      We can assume that at least some part of the first item is visible and return 1. */
       setVisibleCount(visibleItems > 0 ? visibleItems : 1);
     } else if (needsFullRerender.current) {
       const childrenSize = Array.from(containerRef.current.children).reduce(


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Suggesting a fix for #1633.

Our `useOverflow` hook returns `visibleCount: 0` when item is bigger when space available. I think that should be '1'.

## Testing

Using user provided code in vite sandbox.

Added unit test.

## Docs

TBD
