### PR TITLE
Tile legacy: Thumbnail area is not rendered if no prop passed

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -41,6 +41,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
     }
 
     > :where(.iui-tile-name) {
+      margin-block-start: var(--iui-size-s);
       margin-block-end: calc(var(--iui-size-s) * 0.5);
     }
   }
@@ -291,7 +292,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   display: grid;
   background-color: var(--iui-color-background-zebra);
   border-block-end: 1px solid var(--iui-color-border);
-  margin-block-end: var(--iui-size-s);
 
   > * {
     grid-area: 1 / 1 / -1 / -1;

--- a/packages/itwinui-react/src/core/Tile/Tile.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.tsx
@@ -552,16 +552,18 @@ const TileComponent = React.forwardRef((props, forwardedRef) => {
         </TileNameLabel>
       </TileName>
 
-      <TileThumbnailArea>
-        {typeof thumbnail !== 'string' ? (
-          <TileThumbnailPicture>{thumbnail}</TileThumbnailPicture>
-        ) : (
-          <TileThumbnailPicture url={thumbnail} />
-        )}
-        {badge && <TileBadgeContainer>{badge}</TileBadgeContainer>}
-        {leftIcon && <TileTypeIndicator>{leftIcon}</TileTypeIndicator>}
-        {rightIcon && <TileQuickAction>{rightIcon}</TileQuickAction>}
-      </TileThumbnailArea>
+      {thumbnail && (
+        <TileThumbnailArea>
+          {typeof thumbnail !== 'string' ? (
+            <TileThumbnailPicture>{thumbnail}</TileThumbnailPicture>
+          ) : (
+            <TileThumbnailPicture url={thumbnail} />
+          )}
+          {badge && <TileBadgeContainer>{badge}</TileBadgeContainer>}
+          {leftIcon && <TileTypeIndicator>{leftIcon}</TileTypeIndicator>}
+          {rightIcon && <TileQuickAction>{rightIcon}</TileQuickAction>}
+        </TileThumbnailArea>
+      )}
 
       <TileContentArea>
         {description && <TileDescription>{description}</TileDescription>}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Added a check in Tile legacy to not render thumbnail area if thumbnail is not provided.
Changed name area to have top margin instead of thumbnail area bottom margin - keep the correct spacing even if thumbnail is not provided.

## Testing

Visual tests pass

## Docs

N/A
