### PR TITLE
make ThemeProvider inherit `portalContainer`

### DIFF
--- a/.changeset/four-cherries-wash.md
+++ b/.changeset/four-cherries-wash.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+ThemeProvider will now inherit `portalContainer` if also inheriting theme.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -188,10 +188,9 @@ it('should respect the portalContainer prop', async () => {
 
   const InPortal = () => {
     const { portalContainer } = React.useContext(ThemeContext) || {};
-    return (
-      portalContainer &&
-      ReactDOM.createPortal(<div>in portal!</div>, portalContainer)
-    );
+    return portalContainer
+      ? ReactDOM.createPortal(<div>in portal!</div>, portalContainer)
+      : null;
   };
 
   const { getByText } = render(
@@ -204,4 +203,27 @@ it('should respect the portalContainer prop', async () => {
   getByText('not in portal');
   expect(document.querySelector('my-portals .iui-toast-wrapper')).toBeTruthy();
   expect(document.querySelector('my-portals')).toHaveTextContent('in portal!');
+});
+
+it('should inherit the portalContainer if inheriting theme', async () => {
+  const InPortal = () => {
+    const { portalContainer } = React.useContext(ThemeContext) || {};
+    return portalContainer
+      ? ReactDOM.createPortal(<div>in portal!</div>, portalContainer)
+      : null;
+  };
+
+  render(
+    <ThemeProvider data-outer>
+      <ThemeProvider data-inner>
+        <InPortal />
+      </ThemeProvider>
+    </ThemeProvider>,
+  );
+
+  const outer = document.querySelector('[data-outer]');
+  const inner = document.querySelector('[data-inner]');
+
+  expect(outer).toHaveTextContent('in portal!');
+  expect(inner).not.toHaveTextContent('in portal!');
 });

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -35,9 +35,10 @@ type RootProps = {
    * This can cause a flash of incorrect theme on first render.
    *
    * The 'inherit' option is intended to be used by packages, to enable incremental adoption
-   * of iTwinUI v2 in app that might be using v1 in other places.
+   * of iTwinUI while respecting the theme set by the consuming app. It will fall back to 'light'
+   * if no parent theme is found. Additionally, it will attempt to inherit the `portalContainer` if possible.
    *
-   * @default 'light'
+   * @default 'inherit'
    */
   theme?: ThemeType | 'inherit';
   themeOptions?: Pick<ThemeOptions, 'highContrast'> & {
@@ -120,13 +121,21 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
     ...rest
   } = props;
 
+  const [parentTheme, rootRef, parentContext] = useParentTheme();
+  const theme = themeProp === 'inherit' ? parentTheme || 'light' : themeProp;
+
+  /**
+   * We will portal our portal container into `portalContainer` prop (if specified),
+   * or inherit `portalContainer` from context (if also inheriting theme).
+   */
+  const portaledPortalContainer =
+    portalContainerProp ||
+    (themeProp === 'inherit' ? parentContext?.portalContainer : undefined);
+
   const [portalContainer, setPortalContainer] = useControlledState(
     null,
-    portalContainerProp,
+    portaledPortalContainer,
   );
-
-  const [parentTheme, rootRef] = useParentTheme();
-  const theme = themeProp === 'inherit' ? parentTheme || 'light' : themeProp;
 
   const shouldApplyBackground = themeOptions?.applyBackground ?? !parentTheme;
 
@@ -149,10 +158,10 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
         <ToastProvider>
           {children}
 
-          {portalContainerProp ? (
-            ReactDOM.createPortal(<Toaster />, portalContainerProp)
+          {portaledPortalContainer ? (
+            ReactDOM.createPortal(<Toaster />, portaledPortalContainer)
           ) : (
-            <div ref={setPortalContainer}>
+            <div ref={setPortalContainer} style={{ display: 'contents' }}>
               <Toaster />
             </div>
           )}
@@ -221,5 +230,9 @@ const useParentTheme = () => {
     );
   }, []);
 
-  return [parentContext?.theme ?? parentThemeState, rootRef] as const;
+  return [
+    parentContext?.theme ?? parentThemeState,
+    rootRef,
+    parentContext,
+  ] as const;
 };


### PR DESCRIPTION
## Changes

based on user feedback, `portalContainer` will now be inherited when `theme` is set to `"inherit"`.

unrelated: added `display: contents` to portal container div, to exclude it from layout. this is useful when setting something like `display: grid` on the root div.

## Testing

added unit test.

also tested in vite playground with this code and inspected devtools to ensure that tooltip is portaled into outer ThemeProvider:

<details>
<summary>App.tsx</summary>

```tsx
import { Tooltip, ThemeProvider } from '@itwin/itwinui-react';

const App = () => {
  return (
    <>
      <ThemeProvider data-inner>
        <Tooltip content='world'>
          <button>hello</button>
        </Tooltip>
      </ThemeProvider>
    </>
  );
};

export default App;

```

</details>

## Docs

updated jsdocs and added changeset.