### PR TITLE
preserve legacy folder in `gh-pages`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'
-            })).data.map(pr => pr.number).join(','))]
+            })).data.map(pr => pr.number))].join('\n')
 
       - name: Host portal under / or /legacy
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'
-            })).data.map(pr => pr.number).join('\n'))]
+            })).data.map(pr => pr.number).join(','))]
 
       - name: Host portal under / or /legacy
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Changes

any pushes to `main` branch were deleting the `legacy/v2` folder which hosts the v2 storybook.

found that this was because some typo in the workflow. the `.join('\n')` needs to be outside the array, not inside.

the `clean-exclude` option expects a newline separated list.

| Before | After |
| --- | --- |
| `legacy,1,6,5,5` | `legacy\n1655` |

## Testing

Tested by manually creating a dummy file in `gh-pages` branch inside [this PR's deployment folder](https://github.com/iTwin/iTwinUI/tree/gh-pages/1655), then pushing a commit to this PR to trigger CI.
![](https://github.com/iTwin/iTwinUI/assets/9084735/ae805856-979b-496b-a0b7-d83aa83383e1) 

the `legacy` folder was correctly preserved after automatic deployment.
![](https://github.com/iTwin/iTwinUI/assets/9084735/8520d8a8-92bb-4b43-b6ae-58a55a29e917)

## Docs

n/a
