### PR TITLE
added misMatchThreshold for table CSS test.

### DIFF
--- a/packages/itwinui-css/backstop/scenarios/table.js
+++ b/packages/itwinui-css/backstop/scenarios/table.js
@@ -11,6 +11,7 @@ module.exports = [
   }),
   scenario('Type Extras', {
     selectors: ['#demo-extras'],
+    misMatchThreshold: 0.1,
   }),
   scenario('Type Expandable Rows', {
     selectors: ['#demo-expandable-rows'],


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes
 There was a slight difference in the image inside parts of the table test. Logs were showing errors in this specific image :

![Screenshot 2023-10-31 114959](https://github.com/iTwin/iTwinUI/assets/128523557/f866630d-fb3a-491f-9b85-d451705fcc65)

Added misMatchThreshold: 0.1, to avoid causing the breakdown of tests (The above example shows only 0.79 difference).

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
Ran it multiple times locally and it passed properly. Passing on GitHub as well.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->
