### PR TITLE
Table Ctrl+Shift click logic improved

### DIFF
--- a/.changeset/curly-peas-peel.md
+++ b/.changeset/curly-peas-peel.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Table's Ctrl+Shift click implementation more consistent with Windows Explorer's implementation.
+Made Table's Ctrl+Shift click implementation more consistent with Windows Explorer's implementation.

--- a/.changeset/curly-peas-peel.md
+++ b/.changeset/curly-peas-peel.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-react': minor
+'@itwin/itwinui-react': patch
 ---
 
 Made Table's Ctrl+Shift click implementation more consistent with Windows Explorer's implementation.

--- a/.changeset/curly-peas-peel.md
+++ b/.changeset/curly-peas-peel.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-react': patch
+'@itwin/itwinui-react': minor
 ---
 
 Made Table's Ctrl+Shift click implementation more consistent with Windows Explorer's implementation.

--- a/.changeset/curly-peas-peel.md
+++ b/.changeset/curly-peas-peel.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Table's Ctrl+Shift click implementation more consistent with Windows Explorer's implementation.

--- a/.changeset/new-wolves-jump.md
+++ b/.changeset/new-wolves-jump.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed occasional mismatch between the Table's visually selected rows and Table state's selected rows

--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -1850,12 +1850,7 @@ export const WithPaginator = () => {
       return {
         name: `Name ${keyValue}`,
         description: `Description ${keyValue}`,
-        subRows:
-          depth < 2
-            ? Array(Math.round(index % 5))
-                .fill(null)
-                .map((_, index) => generateItem(index, keyValue, depth + 1))
-            : [],
+        subRows: depth < 2 ? [] : [],
       };
     },
     [],
@@ -1886,6 +1881,9 @@ export const WithPaginator = () => {
         columns={columns}
         data={data}
         pageSize={25}
+        onSelect={(selectedData, tableState) => {
+          console.log(selectedData, tableState);
+        }}
         paginatorRenderer={paginator}
         style={{ height: '100%' }}
       />

--- a/apps/storybook/src/Table.stories.tsx
+++ b/apps/storybook/src/Table.stories.tsx
@@ -1850,7 +1850,12 @@ export const WithPaginator = () => {
       return {
         name: `Name ${keyValue}`,
         description: `Description ${keyValue}`,
-        subRows: depth < 2 ? [] : [],
+        subRows:
+          depth < 2
+            ? Array(Math.round(index % 5))
+                .fill(null)
+                .map((_, index) => generateItem(index, keyValue, depth + 1))
+            : [],
       };
     },
     [],
@@ -1881,9 +1886,6 @@ export const WithPaginator = () => {
         columns={columns}
         data={data}
         pageSize={25}
-        onSelect={(selectedData, tableState) => {
-          console.log(selectedData, tableState);
-        }}
         paginatorRenderer={paginator}
         style={{ height: '100%' }}
       />

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -463,12 +463,15 @@ it('should handle row clicks', async () => {
   expect(onSelect).toHaveBeenCalledTimes(8);
   expect(onRowClick).toHaveBeenCalledTimes(7);
 
+  // Shift click special case test #3
+  // Shift click makes makes all rows from lastSelectedRowId to clicked row to have the same selection state as the clicked row
+  // So when lastSelectedRowId is un-selected, all rows in the shift select range are also unselected.
   await user.keyboard('{Shift>}'); // Hold Shift
   await user.click(getByText(data[0].name));
 
-  expect(rows[0]).toHaveAttribute('aria-selected', 'true');
-  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
-  expect(rows[2]).toHaveAttribute('aria-selected', 'true');
+  expect(rows[0]).not.toHaveAttribute('aria-selected');
+  expect(rows[1]).not.toHaveAttribute('aria-selected');
+  expect(rows[2]).not.toHaveAttribute('aria-selected');
   expect(rows[3]).not.toHaveAttribute('aria-selected');
   expect(rows[4]).not.toHaveAttribute('aria-selected');
   expect(onSelect).toHaveBeenCalledTimes(9);
@@ -477,34 +480,36 @@ it('should handle row clicks', async () => {
   await user.keyboard('{/Shift}{Control>}'); // Release Shift and Hold Control
   await user.click(getByText(data[4].name)); // lastSelectedRowId = 2 -> 4 (Ctrl click updates lastSelectedRowId)
   await user.keyboard('{Control>}'); // Keep holding Control
-  await user.click(getByText(data[7].name)); // lastSelectedRowId = 4 -> 7 (Ctrl click updates lastSelectedRowId)
+  await user.click(getByText(data[2].name)); // lastSelectedRowId = 4 -> 2 (Ctrl click updates lastSelectedRowId)
+  await user.keyboard('{Control>}'); // Keep holding Control
+  await user.click(getByText(data[7].name)); // lastSelectedRowId = 2-> 7 (Ctrl click updates lastSelectedRowId)
 
-  expect(rows[0]).toHaveAttribute('aria-selected', 'true');
-  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
+  expect(rows[0]).not.toHaveAttribute('aria-selected');
+  expect(rows[1]).not.toHaveAttribute('aria-selected');
   expect(rows[2]).toHaveAttribute('aria-selected', 'true');
   expect(rows[3]).not.toHaveAttribute('aria-selected');
   expect(rows[4]).toHaveAttribute('aria-selected', 'true');
   expect(rows[5]).not.toHaveAttribute('aria-selected');
   expect(rows[6]).not.toHaveAttribute('aria-selected');
   expect(rows[7]).toHaveAttribute('aria-selected', 'true');
-  expect(onSelect).toHaveBeenCalledTimes(11);
-  expect(onRowClick).toHaveBeenCalledTimes(10);
+  expect(onSelect).toHaveBeenCalledTimes(12);
+  expect(onRowClick).toHaveBeenCalledTimes(11);
 
   // Ctrl + Shift click test
-  // Previous selection (0, 1, 2, 4) should be preserved and added to new shift click selection (7 to 5)
+  // Previous selection (2, 4) should be preserved and added to new shift click selection (7 to 5)
   await user.keyboard('{Control>}{Shift>}'); // Hold Ctrl and Shift
   await user.click(getByText(data[5].name));
 
-  expect(rows[0]).toHaveAttribute('aria-selected', 'true');
-  expect(rows[1]).toHaveAttribute('aria-selected', 'true');
+  expect(rows[0]).not.toHaveAttribute('aria-selected');
+  expect(rows[1]).not.toHaveAttribute('aria-selected');
   expect(rows[2]).toHaveAttribute('aria-selected', 'true');
   expect(rows[3]).not.toHaveAttribute('aria-selected');
   expect(rows[4]).toHaveAttribute('aria-selected', 'true');
   expect(rows[5]).toHaveAttribute('aria-selected', 'true');
   expect(rows[6]).toHaveAttribute('aria-selected', 'true');
   expect(rows[7]).toHaveAttribute('aria-selected', 'true');
-  expect(onSelect).toHaveBeenCalledTimes(12);
-  expect(onRowClick).toHaveBeenCalledTimes(11);
+  expect(onSelect).toHaveBeenCalledTimes(13);
+  expect(onRowClick).toHaveBeenCalledTimes(12);
 });
 
 it('should handle sub-rows shift click selection', async () => {

--- a/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -156,7 +156,7 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
   // If ctrl + shift click, do not lose previous selection
   // If shift click, start new selection
   const selectedRowIds: Record<string, boolean> = !!action.ctrlPressed
-    ? state.selectedRowIds
+    ? { ...state.selectedRowIds }
     : {};
 
   // 1. All rows between start and end are assigned the state of the last selected row

--- a/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -152,7 +152,7 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
   const isLastSelectedRowIdSelected =
     state.lastSelectedRowId != null
       ? !!state.selectedRowIds[state.lastSelectedRowId]
-      : false;
+      : true; // When no row is selected before shift click, start selecting from first row to clicked row
 
   // If ctrl + shift click, do not lose previous selection
   // If shift click, start new selection

--- a/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -150,9 +150,8 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
   }
 
   const isLastSelectedRowIdSelected =
-    state.lastSelectedRowId != null
-      ? !!state.selectedRowIds[state.lastSelectedRowId]
-      : true; // When no row is selected before shift click, start selecting from first row to clicked row
+    state.lastSelectedRowId == null || // When no row is selected before shift click, start selecting from first row to clicked row
+    !!state.selectedRowIds[state.lastSelectedRowId];
 
   // If ctrl + shift click, do not lose previous selection
   // If shift click, start new selection

--- a/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -7,10 +7,12 @@ import type {
   Row,
   TableInstance,
   TableState,
+  // IdType,
 } from '../../../react-table/react-table.js';
 
 /**
  * Handles subrow selection and validation.
+ * - Calls onSelect callback with selected data
  * - Subrow selection: Selecting a row and calling this method automatically selects all the subrows that can be selected
  * - Validation: Ensures that any disabled/unselectable row/subrow is not selected
  */
@@ -28,36 +30,45 @@ const onSelectHandler = <T extends Record<string, unknown>>(
     return;
   }
 
-  const newSelectedRowIds = {} as Record<string, boolean>;
+  isRowDisabled?.(instance.initialRows.at(0)?.original as T);
 
-  const handleRow = (row: Row<T>) => {
-    if (isRowDisabled?.(row.original)) {
-      return false;
-    }
+  const newSelectedRowIds = newState.selectedRowIds;
+  // const newSelectedRowIds = {} as Record<IdType<T>, boolean>;
 
-    let isAllSubSelected = true;
-    row.initialSubRows.forEach((subRow) => {
-      const result = handleRow(subRow);
-      if (!result) {
-        isAllSubSelected = false;
-      }
-    });
+  // const handleRow = (row: Row<T>) => {
+  //   if (isRowDisabled?.(row.original)) {
+  //     return false;
+  //   }
 
-    // If `selectSubRows` is false, then no need to select sub-rows and just check current selection state.
-    // If a row doesn't have sub-rows then check its selection state.
-    // If it has sub-rows then check whether all of them are selected.
-    if (
-      (!instance.selectSubRows && newState.selectedRowIds[row.id]) ||
-      (!row.initialSubRows.length && newState.selectedRowIds[row.id]) ||
-      (row.initialSubRows.length && isAllSubSelected)
-    ) {
-      newSelectedRowIds[row.id] = true;
-    }
-    return !!newSelectedRowIds[row.id];
-  };
-  instance.initialRows.forEach((row) => handleRow(row));
+  //   let isAllSubSelected = true;
+  //   row.initialSubRows.forEach((subRow) => {
+  //     const result = handleRow(subRow);
+  //     if (!result) {
+  //       isAllSubSelected = false;
+  //     }
+  //   });
+
+  //   // If `selectSubRows` is false, then no need to select sub-rows and just check current selection state.
+  //   // If a row doesn't have sub-rows then check its selection state.
+  //   // If it has sub-rows then check whether all of them are selected.
+  //   if (
+  //     (!instance.selectSubRows && newState.selectedRowIds[row.id]) ||
+  //     (!row.initialSubRows.length && newState.selectedRowIds[row.id]) ||
+  //     (row.initialSubRows.length && isAllSubSelected)
+  //   ) {
+  //     newSelectedRowIds[row.id as IdType<T>] = true;
+  //   }
+  //   return !!newSelectedRowIds[row.id];
+  // };
+  // instance.initialRows.forEach((row) => handleRow(row));
 
   const selectedData = getSelectedData(newSelectedRowIds, instance);
+  // const selectedData = [] as any;
+  // console.log(
+  //   'new selected data',
+  //   newSelectedRowIds,
+  //   // selectedData.map((d) => (d.name as string).split(' ')[1]),
+  // );
 
   newState.selectedRowIds = newSelectedRowIds;
   onSelect?.(selectedData, newState);
@@ -128,6 +139,8 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
   ) => void,
   isRowDisabled?: (rowData: T) => boolean,
 ) => {
+  // console.log('onShiftSelectHandler', state, action);
+
   if (instance == null) {
     return state;
   }
@@ -147,24 +160,38 @@ export const onShiftSelectHandler = <T extends Record<string, unknown>>(
     endIndex = temp;
   }
 
+  const isLastSelectedRowIdSelected =
+    state.lastSelectedRowId != null
+      ? !!state.selectedRowIds[state.lastSelectedRowId]
+      : false;
+
   // If ctrl + shift click, do not lose previous selection
   // If shift click, start new selection
   const selectedRowIds: Record<string, boolean> = !!action.ctrlPressed
     ? state.selectedRowIds
     : {};
 
-  // 1. Select all rows between start and end
+  // 1. All rows between start and end are assigned the state of the last selected row
   instance.flatRows
     .slice(startIndex, endIndex + 1)
-    .forEach((r) => (selectedRowIds[r.id] = true));
+    .forEach((r) => (selectedRowIds[r.id] = isLastSelectedRowIdSelected));
 
   // 2. Select all children of the last row (endIndex)
   // Since lastRow's children come after endIndex + 1 (not selected in step 1)
   const handleRow = (row: Row<T>) => {
-    selectedRowIds[row.id] = true;
+    selectedRowIds[row.id] = isLastSelectedRowIdSelected;
     row.subRows.forEach((r) => handleRow(r));
   };
   handleRow(instance.flatRows[endIndex]);
+
+  console.log({
+    startIndex,
+    endIndex,
+    lastSelectedRowId: state.lastSelectedRowId,
+    isLastSelectedRowIdSelected,
+    new: selectedRowIds,
+    old: state.selectedRowIds,
+  });
 
   const newState = {
     ...state,


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

* Ctrl + Shift click behavior matches that of Windows explorer

<details>
<summary>Screen recordings</summary>

Actions taken:
* Click row 0
* Ctrl click row 2
* Ctrl + Shift click row 6
* Ctrl click row 5
* Ctrl + Shift click row 3

Before:

[Before](https://github.com/iTwin/iTwinUI/assets/45748283/9d850e0b-34d0-413c-bbcc-f81e8304fa21)

After:

[After](https://github.com/iTwin/iTwinUI/assets/45748283/7c5781bf-897f-4328-9d98-1d56fdc9855e)

</details>

* Fix mismatch between Table state and the table that is shown (https://github.com/iTwin/iTwinUI/pull/1660#issuecomment-1791567011)

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Updated unit test

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

Added changeset