### PR TITLE
fix `highContrast` theme not getting inherited

### DIFF
--- a/.changeset/rich-spiders-draw.md
+++ b/.changeset/rich-spiders-draw.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed `ThemeProvider` to correctly inherit `highContrast` option when using `theme="inherit"`.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.test.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.test.tsx
@@ -158,13 +158,14 @@ it('should default applyBackground to false when inheriting theme', () => {
 
 it('should inherit theme by default', () => {
   const { container } = render(
-    <ThemeProvider theme='dark'>
+    <ThemeProvider theme='dark' themeOptions={{ highContrast: true }}>
       <ThemeProvider id='nested'>Test</ThemeProvider>
     </ThemeProvider>,
   );
 
   const nested = container.querySelector('#nested');
   expect(nested).toHaveAttribute('data-iui-theme', 'dark');
+  expect(nested).toHaveAttribute('data-iui-contrast', 'high');
 });
 
 it('should inherit theme from data attribute if no context found', () => {

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -36,7 +36,8 @@ type RootProps = {
    *
    * The 'inherit' option is intended to be used by packages, to enable incremental adoption
    * of iTwinUI while respecting the theme set by the consuming app. It will fall back to 'light'
-   * if no parent theme is found. Additionally, it will attempt to inherit the `portalContainer` if possible.
+   * if no parent theme is found. Additionally, it will attempt to inherit `themeOptions.highContrast`
+   * and `portalContainer` (if possible).
    *
    * @default 'inherit'
    */
@@ -127,7 +128,7 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
   // default apply background only for topmost ThemeProvider
   themeOptions.applyBackground ??= !parentTheme;
 
-  // inherit highContrast option from parent if also inheriting base theme
+  // default inherit highContrast option from parent if also inheriting base theme
   themeOptions.highContrast ??=
     themeProp === 'inherit'
       ? parentContext?.themeOptions?.highContrast

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -116,13 +116,22 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
   const {
     theme: themeProp = 'inherit',
     children,
-    themeOptions,
+    themeOptions = {},
     portalContainer: portalContainerProp,
     ...rest
   } = props;
 
   const [parentTheme, rootRef, parentContext] = useParentTheme();
   const theme = themeProp === 'inherit' ? parentTheme || 'light' : themeProp;
+
+  // default apply background only for topmost ThemeProvider
+  themeOptions.applyBackground ??= !parentTheme;
+
+  // inherit highContrast option from parent if also inheriting base theme
+  themeOptions.highContrast ??=
+    themeProp === 'inherit'
+      ? parentContext?.themeOptions?.highContrast
+      : undefined;
 
   /**
    * We will portal our portal container into `portalContainer` prop (if specified),
@@ -137,8 +146,6 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
     portaledPortalContainer,
   );
 
-  const shouldApplyBackground = themeOptions?.applyBackground ?? !parentTheme;
-
   const contextValue = React.useMemo(
     () => ({ theme, themeOptions, portalContainer }),
     // we do include all dependencies below, but we want to stringify the objects as they could be different on each render
@@ -150,7 +157,6 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
     <ThemeContext.Provider value={contextValue}>
       <Root
         theme={theme}
-        shouldApplyBackground={shouldApplyBackground}
         themeOptions={themeOptions}
         ref={useMergedRefs(forwardedRef, rootRef)}
         {...rest}
@@ -176,19 +182,13 @@ export default ThemeProvider;
 // ----------------------------------------------------------------------------
 
 const Root = React.forwardRef((props, forwardedRef) => {
-  const {
-    theme,
-    children,
-    themeOptions,
-    shouldApplyBackground,
-    className,
-    ...rest
-  } = props;
+  const { theme, children, themeOptions, className, ...rest } = props;
 
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
   const prefersHighContrast = useMediaQuery('(prefers-contrast: more)');
   const shouldApplyDark = theme === 'dark' || (theme === 'os' && prefersDark);
   const shouldApplyHC = themeOptions?.highContrast ?? prefersHighContrast;
+  const shouldApplyBackground = themeOptions?.applyBackground;
 
   return (
     <Box


### PR DESCRIPTION
## Changes

fixes #1653

the [`??=` operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment) is being used to provide a conditional default value to `themeOptions.highContrast` when `theme` prop is set to `"inherit"`.

**note**: this fix will also be backported to v2.

## Testing

tested this scenario in vite playground:
```tsx
<ThemeProvider theme='dark' themeOptions={{ highContrast: true }}>
  <ThemeProvider>
    […]
  </ThemeProvider>
</ThemeProvider>
```

updated one of the existing unit tests to also cover this scenario.

## Docs

added changesets.