### PR TITLE
remove scrollbar styles from docs

### DIFF
--- a/apps/website/src/pages/_global.css
+++ b/apps/website/src/pages/_global.css
@@ -50,37 +50,6 @@
     list-style: none;
     padding: 0;
   }
-
-  @media (pointer: fine) and (hover: hover) {
-    :root {
-      --scrollbar-left-padding: 7px;
-      --scrollbar-right-offset: 7px;
-      --scrollbar-thumb-size: 10px;
-    }
-
-    ::-webkit-scrollbar {
-      /* total = 24px = 7px (left padding) + 10px (thumb) + 7px (right offset) */
-      --_scrollbar-size: calc(
-        var(--scrollbar-left-padding) + var(--scrollbar-thumb-size) +
-        var(--scrollbar-right-offset)
-      );
-      inline-size: var(--_scrollbar-size);
-      block-size: var(--_scrollbar-size);
-    }
-
-    ::-webkit-scrollbar-thumb {
-      background-color: var(--scrollbar-color, hsl(0 0% 65% / 0.7));
-      border-radius: 9e9px;
-      border: 4px solid transparent;
-      border-width: var(--scrollbar-left-padding) var(--scrollbar-right-offset)
-        var(--scrollbar-right-offset) var(--scrollbar-left-padding);
-      background-clip: content-box;
-    }
-
-    ::-webkit-scrollbar-thumb:hover {
-      background-color: var(--scrollbar-hover-color, hsl(0 0% 65% / 0.85));
-    }
-  }
 }
 
 


### PR DESCRIPTION
## Changes

not sure why these were added in the first place; the default scrollbars work fine.

my guess is the site was made before we had scoped styling support (`iui-root`), so iTwinUI scrollbars may have been messing up docs scrollbars, but now we are running into the opposite issue (https://github.com/iTwin/iTwinUI/issues/941#issuecomment-1492479881, https://github.com/iTwin/iTwinUI/pull/1656#discussion_r1382236355), so it's better to just use defaults.

## Testing

tested that default scrollbars are appearing ok

![](https://github.com/iTwin/iTwinUI/assets/9084735/43c9b625-e971-4e85-93f6-597f2055dd6c)


## Docs

n/a