### PR TITLE
Remove unnecessary `appendTo: parent` from v3 Combobox demo code

### DIFF
--- a/apps/website/src/demos/ComboBox.demo.tsx
+++ b/apps/website/src/demos/ComboBox.demo.tsx
@@ -21,11 +21,7 @@ export default function ComboBoxDemo() {
 
   return (
     <ThemeProvider theme='dark'>
-      <ComboBox
-        options={options}
-        inputProps={{ placeholder: 'Pick a fruit, any fruit' }}
-        dropdownMenuProps={{ appendTo: 'parent' }}
-      />
+      <ComboBox options={options} inputProps={{ placeholder: 'Pick a fruit, any fruit' }} />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

In v3, passing `appendTo: 'parent'` in `dropdownMenuProps` is not needed. So removed it from the ComboBox demo on the home page.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in html test pages as well as
storybook, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Did a global search for `appendTo` and found no other matches.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A