### PR TITLE
memoize toaster object

### DIFF
--- a/.changeset/curly-turtles-yawn.md
+++ b/.changeset/curly-turtles-yawn.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Memoize `useToaster` return value so it can be more reliably used in dependency arrays.

--- a/.changeset/curly-turtles-yawn.md
+++ b/.changeset/curly-turtles-yawn.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Memoize `useToaster` return value so it can be more reliably used in dependency arrays.
+Memoize `useToaster`'s return value so that it can be more reliably used in dependency arrays.

--- a/packages/itwinui-react/src/core/Toast/Toaster.tsx
+++ b/packages/itwinui-react/src/core/Toast/Toaster.tsx
@@ -42,8 +42,9 @@ export type ToastOptions = Omit<
 export const useToaster = () => {
   const dispatch = useSafeContext(ToasterDispatchContext);
 
-  const showToast = React.useCallback(
-    (category: ToastCategory) =>
+  return React.useMemo(() => {
+    const showToast =
+      (category: ToastCategory) =>
       (content: React.ReactNode, options?: ToastOptions) => {
         const id = nextId();
 
@@ -53,22 +54,21 @@ export const useToaster = () => {
         });
 
         return { close: () => dispatch({ type: 'remove', id }) };
-      },
-    [dispatch],
-  );
+      };
 
-  return {
-    positive: showToast('positive'),
-    informational: showToast('informational'),
-    negative: showToast('negative'),
-    warning: showToast('warning'),
-    closeAll: () => {
-      dispatch({ type: 'close-all' });
-    },
-    setSettings: (settings: Partial<ToasterSettings>) => {
-      dispatch({ type: 'settings', settings });
-    },
-  };
+    return {
+      positive: showToast('positive'),
+      informational: showToast('informational'),
+      negative: showToast('negative'),
+      warning: showToast('warning'),
+      closeAll: () => {
+        dispatch({ type: 'close-all' });
+      },
+      setSettings: (settings: Partial<ToasterSettings>) => {
+        dispatch({ type: 'settings', settings });
+      },
+    };
+  }, [dispatch]);
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

when working on the migration tool, i noticed `toaster` object was used in dependency arrays in multiple arrays, so it makes sense to memoize it.

## Testing

no other code changes, so everything works the same.

## Docs

n/a