### PR TITLE
append nested submenus out of parent menu

### DIFF
--- a/.changeset/dry-ants-dress.md
+++ b/.changeset/dry-ants-dress.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where submenu items were not appearing because of overflow on parent menu.

--- a/packages/itwinui-react/src/core/Menu/MenuItem.test.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.test.tsx
@@ -205,7 +205,7 @@ it('should show sub menu on hover', () => {
 
   // hover over menu item
   fireEvent.mouseOver(menuItem);
-  const subMenu = container.querySelectorAll(
+  const subMenu = document.querySelectorAll(
     '[data-tippy-root] .iui-menu-item',
   )[0] as HTMLLIElement;
   expect(subMenu.textContent).toBe('Test sub');
@@ -213,7 +213,7 @@ it('should show sub menu on hover', () => {
 
   // hover over sub menu item
   fireEvent.mouseOver(subMenu);
-  const subSubMenu = container.querySelectorAll(
+  const subSubMenu = document.querySelectorAll(
     '[data-tippy-root] .iui-menu-item',
   )[1] as HTMLLIElement;
   expect(subSubMenu.textContent).toBe('Test sub sub');
@@ -247,7 +247,7 @@ it('should handle key press with sub menus', async () => {
   // go right to open sub menu
   menuItem.focus();
   await userEvent.keyboard('{ArrowRight}');
-  const subTippy = container.querySelector('[data-tippy-root]') as HTMLElement;
+  const subTippy = document.querySelector('[data-tippy-root]') as HTMLElement;
   const subMenu = subTippy.querySelector('.iui-menu-item') as HTMLLIElement;
   expect(subMenu.textContent).toBe('Test sub');
   expect(container.ownerDocument.activeElement).toEqual(subMenu);

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -121,13 +121,11 @@ export const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
           if (subMenuItems.length > 0) {
             setIsSubmenuVisible(true);
             event.preventDefault();
-            event.stopPropagation();
           }
           break;
         }
         case 'ArrowLeft': {
           parentMenuItemRef?.current?.focus();
-          event.stopPropagation();
           event.preventDefault();
           break;
         }
@@ -192,16 +190,20 @@ export const MenuItem = React.forwardRef<HTMLLIElement, MenuItemProps>(
         <Popover
           placement='right-start'
           visible={isSubmenuVisible}
-          appendTo='parent'
+          appendTo={(item) => {
+            // we want the div wrapping the parent menu because the menu has overflow,
+            // which can cause the submenu to be cut off
+            return item.parentElement?.parentElement as HTMLElement;
+          }}
           delay={100}
           content={
             <div
               onMouseLeave={() => setIsSubmenuVisible(false)}
-              onBlur={(e) => {
-                !!(e.relatedTarget instanceof Node) &&
-                  !subMenuRef.current?.contains(e.relatedTarget as Node) &&
-                  !subMenuRef.current?.isEqualNode(e.relatedTarget as Node) &&
+              onKeyDown={(e) => {
+                if (!e.altKey && e.key === 'ArrowLeft') {
                   setIsSubmenuVisible(false);
+                  e.stopPropagation();
+                }
               }}
             >
               <Menu ref={subMenuRef} className='iui-scroll'>


### PR DESCRIPTION
## Changes

fixes #1616 and #1617 (v2 bugs, can be reproduced in [v2 storybook](https://itwin.github.io/iTwinUI/legacy/v2/react/?path=/story/core-dropdownmenu--submenu))

the main problem was that the parent menu always has `overflow: auto` (after #1576), and we were appending sub-menus into the parent menu, thus causing clipping.

to fix this, i am now appending into the parent's parent (which will be some div that does not have `overflow: auto`).

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/b6d13154-c78b-4ade-b4e9-9a9cac5e3c32) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/0b4d5a49-59d4-4ccb-a458-e3de8944062a) |

the code for this component is very delicate, so i've arrived at this minimal solution after lots of iteration and playing around. i had to replace the `onBlur` code with `onKeyDown` to avoid breaking keyboard focus behavior.

## Testing

verified that nested submenus open correctly in storybook.
![](https://github.com/iTwin/iTwinUI/assets/9084735/9de07e71-aec5-4ebd-bca7-f123cd35d338)

## Docs

n/a