### PR TITLE
fix Select uncontrolled mode

### DIFF
--- a/.changeset/lemon-kangaroos-brake.md
+++ b/.changeset/lemon-kangaroos-brake.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed `Select` so that it works in uncontrolled mode (without `value`/`onChange` props).

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -589,16 +589,12 @@ it.each([true, false] as const)(
     // select option B
     await userEvent.click((await findAllByRole(document.body, 'option'))[1]);
 
-    if (multiple) {
-      expect(selectButton).toHaveTextContent('AB');
-    } else {
-      expect(selectButton).toHaveTextContent('B');
-    }
-
     // deselect option A
     if (multiple) {
+      expect(selectButton).toHaveTextContent('AB');
       await userEvent.click((await findAllByRole(document.body, 'option'))[0]);
-      expect(selectButton).toHaveTextContent('B');
     }
+
+    expect(selectButton).toHaveTextContent('B');
   },
 );

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { findAllByRole, fireEvent, render } from '@testing-library/react';
 import Select, {
   type SelectProps,
   type SelectMultipleTypeProps,
@@ -557,3 +557,48 @@ it('should update live region when selection changes', async () => {
   await userEvent.click(options[0]);
   expect(liveRegion).toHaveTextContent('Item 1, Item 2');
 });
+
+it.each([true, false] as const)(
+  'should work in uncontrolled mode (multiple=%s)',
+  async (multiple) => {
+    const { container } = render(
+      <Select
+        multiple={multiple}
+        options={[
+          { value: 'A', label: 'A' },
+          { value: 'B', label: 'B' },
+        ]}
+      />,
+    );
+
+    const selectButton = container.querySelector(
+      '[role=combobox]',
+    ) as HTMLElement;
+    await userEvent.click(selectButton);
+
+    // select option A
+    await userEvent.click((await findAllByRole(document.body, 'option'))[0]);
+
+    expect(selectButton).toHaveTextContent('A');
+
+    // reopen menu
+    if (!multiple) {
+      await userEvent.click(selectButton);
+    }
+
+    // select option B
+    await userEvent.click((await findAllByRole(document.body, 'option'))[1]);
+
+    if (multiple) {
+      expect(selectButton).toHaveTextContent('AB');
+    } else {
+      expect(selectButton).toHaveTextContent('B');
+    }
+
+    // deselect option A
+    if (multiple) {
+      await userEvent.click((await findAllByRole(document.body, 'option'))[0]);
+      expect(selectButton).toHaveTextContent('B');
+    }
+  },
+);


### PR DESCRIPTION
## Changes

I noticed that the basic Select usage shown in jsdocs and website was not updating state, so i've fixed that by adding internal uncontrolled state. Preference is given to user-passed `value` prop.

## Testing

Tested that uncontrolled state works fine in playground and on docs website. Added unit test.

## Docs

Added changeset.

Although this behavior should be mentioned on docs page too, I didn't touch it because the whole thing needs some restructuring/rewriting.