### PR TITLE
fix id hydration mismatch

### DIFF
--- a/.changeset/five-cheetahs-hang.md
+++ b/.changeset/five-cheetahs-hang.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a hydration mismatch warning due to `id` in `ComboBox` and `Carousel`.

--- a/packages/itwinui-react/src/core/Carousel/Carousel.tsx
+++ b/packages/itwinui-react/src/core/Carousel/Carousel.tsx
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import {
-  getRandomValue,
-  useMergedRefs,
-  Box,
-  useLatestRef,
-} from '../utils/index.js';
+import { useMergedRefs, Box, useLatestRef, useId } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { CarouselContext } from './CarouselContext.js';
 import { CarouselSlider } from './CarouselSlider.js';
@@ -32,18 +27,15 @@ type CarouselProps = {
 };
 
 const CarouselComponent = React.forwardRef((props, ref) => {
+  const idPrefix = useId();
   const {
     activeSlideIndex: userActiveIndex = 0,
     onSlideChange,
     className,
     children,
+    id = idPrefix,
     ...rest
   } = props;
-
-  // Generate a stateful random id if not specified
-  const [id] = React.useState(
-    () => props.id ?? `iui-carousel-${getRandomValue(10)}`,
-  );
 
   const isManuallyUpdating = React.useRef(false);
   const carouselRef = React.useRef<HTMLElement>(null);

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -480,8 +480,12 @@ it('should accept inputProps', () => {
   expect(input.id).toBe(inputId);
 
   fireEvent.focus(input);
-  expect(container.querySelector('.iui-input-grid')?.id).toBe(`${inputId}-cb`);
-  expect(document.querySelector('.iui-menu')?.id).toBe(`${inputId}-cb-list`);
+  expect(container.querySelector('.iui-input-grid')?.id).toBe(
+    `iui-${inputId}-cb`,
+  );
+  expect(document.querySelector('.iui-menu')?.id).toBe(
+    `iui-${inputId}-cb-list`,
+  );
 });
 
 it('should work with custom itemRenderer', async () => {

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -9,11 +9,11 @@ import { SelectTag } from '../Select/SelectTag.js';
 import { Text } from '../Typography/Text.js';
 import type { Input } from '../Input/Input.js';
 import {
-  getRandomValue,
   mergeRefs,
   useLatestRef,
   useIsomorphicLayoutEffect,
   AutoclearingHiddenLiveRegion,
+  useId,
 } from '../utils/index.js';
 import { usePopover } from '../Popover/Popover.js';
 import type { InputContainerProps, CommonProps } from '../utils/index.js';
@@ -166,6 +166,8 @@ const getOptionId = (option: SelectOption<unknown>, idPrefix: string) => {
  * />
  */
 export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
+  const idPrefix = useId();
+
   const {
     options,
     value: valueProp,
@@ -180,16 +182,9 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     multiple = false,
     onShow: onShowProp,
     onHide: onHideProp,
+    id = inputProps?.id ? `iui-${inputProps.id}-cb` : idPrefix,
     ...rest
   } = props;
-
-  // Generate a stateful random id if not specified
-  const [id] = React.useState(
-    () =>
-      props.id ??
-      (inputProps?.id && `${inputProps.id}-cb`) ??
-      `iui-cb-${getRandomValue(10)}`,
-  );
 
   // Refs get set in subcomponents
   const inputRef = React.useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Changes

When working on the website, I noticed some hydration warnings in the console.
![image](https://github.com/iTwin/iTwinUI/assets/9084735/708ee358-57e1-42f4-902d-c7b2c487012e)


This was happening because we aren't using the `useId` hook in a couple components (these were coded before `useId` existed), so I've fixed them.

## Testing

Confirmed that there is no hydration warning by visiting website.

## Docs

N/A
