### PR TITLE
fix docsearch error on homepage

### DIFF
--- a/apps/website/src/components/AlgoliaSearch.astro
+++ b/apps/website/src/components/AlgoliaSearch.astro
@@ -1,44 +1,49 @@
----
-
----
-
 <algolia-searchbox></algolia-searchbox>
 
 <script>
   import docsearch from '@docsearch/js';
 
-  docsearch({
-    appId: import.meta.env.PUBLIC_ALGOLIA_APP_ID,
-    apiKey: import.meta.env.PUBLIC_ALGOLIA_API_KEY,
-    indexName: import.meta.env.PUBLIC_ALGOLIA_INDEX_NAME,
-    container: 'algolia-searchbox',
-    transformItems: (items) => {
-      return items.map((item) => {
-        // Absolute URL -> Relative URL to work better on localhost, preview URLs, etc.
-        const url = new URL(item.url);
-        return {
-          ...item,
-          url: url.href.replace(url.origin, ''),
-        };
-      });
+  customElements.define(
+    'algolia-searchbox',
+    class extends HTMLElement {
+      connectedCallback() {
+        docsearch({
+          appId: import.meta.env.PUBLIC_ALGOLIA_APP_ID,
+          apiKey: import.meta.env.PUBLIC_ALGOLIA_API_KEY,
+          indexName: import.meta.env.PUBLIC_ALGOLIA_INDEX_NAME,
+          container: this,
+          transformItems: (items) => {
+            return items.map((item) => {
+              // Absolute URL -> Relative URL to work better on localhost, preview URLs, etc.
+              const url = new URL(item.url);
+              return {
+                ...item,
+                url: url.href.replace(url.origin, ''),
+              };
+            });
+          },
+        });
+      }
     },
-  });
+  );
 </script>
 
 <style lang='scss' is:global>
   @import '@docsearch/css' layer(thirdparty.algolia);
 
-  body {
-    // Algolia DocSearch: https://docsearch.algolia.com/docs/styling/
-    --docsearch-primary-color: var(--color-highlight-4);
-    --docsearch-text-color: var(--color-text--dark);
-    --docsearch-searchbox-background: var(--color-background-1);
-    --docsearch-searchbox-focus-background: var(--color-background-1);
-    --docsearch-hit-color: var(--color-text--dark);
-    --docsearch-muted-color: var(--color-subtext--dark);
-    --docsearch-hit-background: var(--color-background-1);
-    --docsearch-hit-shadow: none;
-    --docsearch-modal-background: var(--color-background-2);
-    --docsearch-footer-background: var(--color-background-2);
+  @layer components {
+    body {
+      // Algolia DocSearch: https://docsearch.algolia.com/docs/styling/
+      --docsearch-primary-color: var(--color-highlight-4);
+      --docsearch-text-color: var(--color-text--dark);
+      --docsearch-searchbox-background: var(--color-background-1);
+      --docsearch-searchbox-focus-background: var(--color-background-1);
+      --docsearch-hit-color: var(--color-text--dark);
+      --docsearch-muted-color: var(--color-subtext--dark);
+      --docsearch-hit-background: var(--color-background-1);
+      --docsearch-hit-shadow: none;
+      --docsearch-modal-background: var(--color-background-2);
+      --docsearch-footer-background: var(--color-background-2);
+    }
   }
 </style>


### PR DESCRIPTION
## Changes

This fixes the website error by wrapping the `docsearch` initialization code in [`connectedCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks), ensuring that it is always called at the correct time.

Unrelated: added missing `@layer components` in component css.

## Testing

Verified that there is no console error.

## Docs

N/A