### PR TITLE
make tree nodes fill container width

### DIFF
--- a/.changeset/rotten-tools-matter.md
+++ b/.changeset/rotten-tools-matter.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue with `Tree` nodes not taking up the full width.

--- a/packages/itwinui-css/src/tree/tree.scss
+++ b/packages/itwinui-css/src/tree/tree.scss
@@ -56,6 +56,7 @@ $iui-expander-button-width: calc(var(--iui-component-height-small) + 2px);
     margin-inline-start: calc(#{$iui-expander-button-width} * (var(--level, 0)));
     overflow: hidden;
     padding-inline-start: var(--iui-size-3xs);
+    inline-size: 100%;
 
     &-icon {
       margin-inline: $iui-expander-inline-padding;
@@ -85,6 +86,7 @@ $iui-expander-button-width: calc(var(--iui-component-height-small) + 2px);
     }
 
     &-label {
+      flex: 1;
       min-inline-size: 0;
       padding-inline-start: $iui-expander-inline-padding;
 


### PR DESCRIPTION
## Changes

This change makes it so that tree-node-content will fill up the size of the tree-node, and labels inside it will fill up the size of of the tree-node-content. This is necessary to be able to place right-aligned content in the nodes.

## Testing

Tested in playground by placing right aligned content in TreeNode.

```tsx
 <TreeNode
  label={
    <Flex>
      {node.label}
      <Flex.Spacer />
      <ToggleSwitch size='small' />
    </Flex>
  }
  {...rest}
/>
```

| Before | After |
| --- | --- |
| ![](https://github.com/iTwin/iTwinUI/assets/9084735/6d9d8129-0c61-44c8-a652-7edf38eb71af) | ![](https://github.com/iTwin/iTwinUI/assets/9084735/bddc6c23-82bd-44f7-b336-0a4b93a921c9) |


## Docs

N/A