### PR TITLE
bump floating-ui

### DIFF
--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -76,7 +76,7 @@
     "dev:styles": "yarn build:styles --watch"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.25.4",
+    "@floating-ui/react": "^0.26.3",
     "classnames": "^2.3.2",
     "react-table": "^7.8.0",
     "react-transition-group": "^4.4.5",

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -518,7 +518,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     onVisibleChange: (open) => (open ? show() : hide()),
     matchWidth: true,
     closeOnOutsideClick: true,
-    trigger: { focus: true },
+    trigger: { focus: true, click: true },
   });
 
   return (

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -518,7 +518,7 @@ export const ComboBox = <T,>(props: ComboBoxProps<T>) => {
     onVisibleChange: (open) => (open ? show() : hide()),
     matchWidth: true,
     closeOnOutsideClick: true,
-    trigger: { focus: true, click: true },
+    trigger: { focus: true },
   });
 
   return (

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -23,13 +23,7 @@ type ComboBoxInputProps = { selectTags?: JSX.Element[] } & React.ComponentProps<
 >;
 
 export const ComboBoxInput = React.forwardRef((props, forwardedRef) => {
-  const {
-    onKeyDown: onKeyDownProp,
-    onClick: onClickProp,
-    selectTags,
-    size,
-    ...rest
-  } = props;
+  const { onKeyDown: onKeyDownProp, selectTags, size, ...rest } = props;
 
   const {
     isOpen,
@@ -192,21 +186,12 @@ export const ComboBoxInput = React.forwardRef((props, forwardedRef) => {
     ],
   );
 
-  const handleClick = React.useCallback(() => {
-    if (!isOpen) {
-      show();
-    } else {
-      hide();
-    }
-  }, [hide, isOpen, show]);
-
   const [tagContainerWidthRef, tagContainerWidth] = useContainerWidth();
 
   return (
     <>
       <Input
         ref={refs}
-        onClick={mergeEventHandlers(onClickProp, handleClick)}
         aria-expanded={isOpen}
         aria-activedescendant={
           isOpen && focusedIndex != undefined && focusedIndex > -1

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -196,8 +196,12 @@ const useTooltip = (options: TooltipOptions = {}) => {
       ...interactions.getReferenceProps(),
     }).forEach(([key, value]) => {
       if (typeof value === 'function') {
-        reference.addEventListener(domEventName(key), value);
-        cleanupValues[key] = value;
+        // manually add `.nativeEvent` (react concept) because floating-ui needs it
+        const patchedHandler = (event: Event) => {
+          value({ ...event, nativeEvent: event });
+        };
+        reference.addEventListener(domEventName(key), patchedHandler);
+        cleanupValues[key] = patchedHandler;
       } else if (value) {
         cleanupValues[key] = reference.getAttribute(key);
         reference.setAttribute(key, value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1518,23 +1518,23 @@
     "@floating-ui/core" "^1.4.2"
     "@floating-ui/utils" "^0.1.3"
 
-"@floating-ui/react-dom@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.2.tgz#fab244d64db08e6bed7be4b5fcce65315ef44d20"
-  integrity sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==
+"@floating-ui/react-dom@^2.0.3":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.4.tgz#b076fafbdfeb881e1d86ae748b7ff95150e9f3ec"
+  integrity sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==
   dependencies:
     "@floating-ui/dom" "^1.5.1"
 
-"@floating-ui/react@^0.25.4":
-  version "0.25.4"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.25.4.tgz#82507e14460aee70f435ad2fd717ea182b6d5c61"
-  integrity sha512-lWRQ/UiTvSIBxohn0/2HFHEmnmOVRjl7j6XcRJuLH0ls6f/9AyHMWVzkAJFuwx0n9gaEeCmg9VccCSCJzbEJig==
+"@floating-ui/react@^0.26.3":
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.3.tgz#1ec435f35e37d5e34577ee89c7abb1eedb3a0c5d"
+  integrity sha512-iKH8WRR0L/nLiM6qavFZxkyegIZRMxGnM9aKEc71M4wRlUNkgTamjPsOQXy11oZbDOH37MiTbk/nAPn9M2+shA==
   dependencies:
-    "@floating-ui/react-dom" "^2.0.2"
-    "@floating-ui/utils" "^0.1.1"
+    "@floating-ui/react-dom" "^2.0.3"
+    "@floating-ui/utils" "^0.1.5"
     tabbable "^6.0.1"
 
-"@floating-ui/utils@^0.1.1", "@floating-ui/utils@^0.1.3":
+"@floating-ui/utils@^0.1.3", "@floating-ui/utils@^0.1.5":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==


### PR DESCRIPTION
## Changes

bumped `@floating-ui` to latest 0.26.x version. needed to make some changes:
- **Tooltip**: added `.nativeEvent` to event object for `reference` prop, because it was throwing an error (some floating-ui code relies on this property).
- **ComboBoxInput**: added a ref to freeze the previous state of `isOpen` for access inside `onClick`, because floating-ui was already opening the menu (on focus) before the click handler executed, causing the menu to immediately close after opening.

## Testing

everything should work the same way. all tests pass.

## Docs

n/a. didn't add changeset as this change should be "transparent" to the user.
