### PR TITLE
Added "build css-workshop before testing particular component" warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
 
 - Make sure Docker is running.
 - To run tests for a specific component, use this command:
-  `yarn workspace css-workshop test --filter=[component_name]` (e.g. `yarn workspace css-workshop test --filter=side-navigation`)
+  `yarn workspace css-workshop test --filter=[component_name]` (e.g. `yarn workspace css-workshop test --filter=side-navigation`). But don't forget to build css-workshop first (yarn build --filter=css-workshop).
 - To approve test images, run `yarn approve:css`.
 
 #### How to write tests:
@@ -309,7 +309,7 @@ We reuse our stories for visual tests by taking screenshots of the story iframes
 
 1. Make sure you have [Docker](https://www.docker.com/get-started) installed and running.
 2. From the monorepo root, run `yarn test --filter=react-workshop`. This will build react-workshop and run all cypress tests in docker.
-   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `yarn workspace react-workshop test --spec="**/Alert.*"`. Don't forget to build react-workshop first (yarn build --filter=react-workshop).
+   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `yarn workspace react-workshop test --spec="**/Alert.*"`. But don't forget to build react-workshop first (yarn build --filter=react-workshop).
 3. Once the tests finish running, you can approve any failing test images using `yarn approve:react`.
 
 #### Writing visual tests


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I noticed that the warning to build the css-workshop before testing a particular component was missing. This PR adds that warning.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that running `yarn build --filter=css-workshop` before `yarn workspace css-workshop --filter=table` fixes the stale testing images issue.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A