### PR TITLE
fix tabs overflow layout shift

### DIFF
--- a/.changeset/dry-moles-repair.md
+++ b/.changeset/dry-moles-repair.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-css': patch
+---
+
+Fixed an overflow-related layout shift in vertical `Tabs`.

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -180,23 +180,19 @@ $borderless-horizontal-tab-min-height: calc(
 
 @mixin iui-tabs-vertical {
   grid-template-areas: 'tabs tabs-content' 'tabs-actions tabs-content';
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   grid-template-rows: 1fr auto;
   block-size: 100%;
 
   .iui-tabs {
-    .iui-tab {
-      inline-size: 100%;
-      white-space: nowrap;
-      block-size: auto;
-    }
-
     ~ .iui-tabs-content {
-      flex-grow: 1;
       overflow: auto;
     }
 
+    display: grid;
+    grid-template-columns: max-content;
     overflow-y: auto;
+    overflow-x: hidden;
     animation-name: scroll-shadow-inset-vertical;
     animation-timing-function: linear;
     /* stylelint-disable-next-line property-no-unknown */
@@ -242,7 +238,9 @@ $borderless-horizontal-tab-min-height: calc(
 
   [aria-selected='true']::after {
     @media (prefers-reduced-motion: no-preference) {
-      transition: width var(--iui-duration-1) ease, height var(--iui-duration-1) ease;
+      transition:
+        width var(--iui-duration-1) ease,
+        height var(--iui-duration-1) ease;
     }
   }
 
@@ -268,7 +266,9 @@ $borderless-horizontal-tab-min-height: calc(
     inset-inline-start: var(--iui-tabs-stripe-position);
     inline-size: var(--iui-tabs-stripe-size);
     @media (prefers-reduced-motion: no-preference) {
-      transition: width var(--iui-duration-1) ease-out, left var(--iui-duration-1) ease-out;
+      transition:
+        width var(--iui-duration-1) ease-out,
+        left var(--iui-duration-1) ease-out;
     }
   }
 

--- a/packages/itwinui-react/tsconfig.json
+++ b/packages/itwinui-react/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "esnext",
-    "lib": ["es6", "dom"],
+    "lib": ["esnext", "dom"],
     "declaration": true,
     "esModuleInterop": true,
     "sourceMap": false,


### PR DESCRIPTION
## Changes

fixes #1627

after investigating for a few hours, i was able to fix the layout shift by conditionally applying `scrollbar-gutter` on mount. i also fixed the css to use grid layout (no `white-space: nowrap` hacks).

unrelated: fixed all ids to convert spaces to hyphens (spaces are not allowed in ids). this also required changing tsconfig `lib` because `replaceAll` is a relatively new function.

## Testing

Tested using vite playground in all three browsers.

https://github.com/iTwin/iTwinUI/assets/9084735/a9ac91e0-76f1-4f94-a873-7545df3f0d9f

## Docs

N/A