### PR TITLE
Added styles.css to sideEffects

### DIFF
--- a/.changeset/plenty-icons-cry.md
+++ b/.changeset/plenty-icons-cry.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added missing `sideEffects` to prevent tree-shaking `styles.css` in webpack.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -133,5 +133,7 @@
     ]
   },
   "prettier": "configs/prettier-config",
-  "sideEffects": false
+  "sideEffects": [
+    "styles.css"
+  ]
 }


### PR DESCRIPTION
This fix is intended for webpack users.
When using ESM, webpack will apply it's treeshaking too harshly sometimes.
This applies to imported css files too.
Possible webpack bug: https://github.com/webpack/webpack/issues/7094

Fixes #1737 

## Changes

Added `styles.css` to `sideEffects` in `package.json`

## Testing

"N/A"

## Docs

"N/A"
