### PR TITLE
allow passing refs in Select and Slider

### DIFF
--- a/.changeset/forty-pets-warn.md
+++ b/.changeset/forty-pets-warn.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed types for `Select` and `Slider` to allow passing refs into `triggerProps` and `thumbProps` respectively.
+Fixed `Select` and `Slider` to allow passing refs into `triggerProps` and `thumbProps` respectively.

--- a/.changeset/forty-pets-warn.md
+++ b/.changeset/forty-pets-warn.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed types for `Select` and `Slider` to allow passing refs into `triggerProps` and `thumbProps` respectively.

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -172,7 +172,7 @@ export type SelectProps<T> = {
   /**
    * Props to pass to the select button (trigger) element.
    */
-  triggerProps?: React.ComponentProps<'div'>;
+  triggerProps?: React.ComponentPropsWithRef<'div'>;
 } & SelectMultipleTypeProps<T> &
   Omit<
     React.ComponentPropsWithoutRef<'div'>,
@@ -388,7 +388,11 @@ export const Select = React.forwardRef(
             aria-haspopup='listbox'
             aria-controls={`${uid}-menu`}
             {...triggerProps}
-            ref={useMergedRefs(selectRef, popover.refs.setReference)}
+            ref={useMergedRefs(
+              selectRef,
+              triggerProps?.ref,
+              popover.refs.setReference,
+            )}
             className={cx(
               'iui-select-button',
               {

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -172,7 +172,7 @@ export type SelectProps<T> = {
   /**
    * Props to pass to the select button (trigger) element.
    */
-  triggerProps?: React.ComponentPropsWithoutRef<'div'>;
+  triggerProps?: React.ComponentProps<'div'>;
 } & SelectMultipleTypeProps<T> &
   Omit<
     React.ComponentPropsWithoutRef<'div'>,

--- a/packages/itwinui-react/src/core/Slider/Slider.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.tsx
@@ -184,7 +184,7 @@ export type SliderProps = {
   /**
    * Callback that can provide additional props for `<div>` representing a thumb.
    */
-  thumbProps?: (index: number) => React.HTMLAttributes<HTMLDivElement>;
+  thumbProps?: (index: number) => React.ComponentProps<'div'>;
   /**
    * Callback fired at the end of a thumb move (i.e. on pointerUp) and when user clicks on rail.
    */

--- a/packages/itwinui-react/src/core/Slider/Slider.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.tsx
@@ -184,7 +184,7 @@ export type SliderProps = {
   /**
    * Callback that can provide additional props for `<div>` representing a thumb.
    */
-  thumbProps?: (index: number) => React.ComponentProps<'div'>;
+  thumbProps?: (index: number) => React.ComponentPropsWithRef<'div'>;
   /**
    * Callback fired at the end of a thumb move (i.e. on pointerUp) and when user clicks on rail.
    */

--- a/packages/itwinui-react/src/core/Slider/Thumb.tsx
+++ b/packages/itwinui-react/src/core/Slider/Thumb.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import { Tooltip } from '../Tooltip/Tooltip.js';
-import { Box } from '../utils/index.js';
+import { Box, useMergedRefs } from '../utils/index.js';
 
 type ThumbProps = {
   /**
@@ -63,7 +63,7 @@ type ThumbProps = {
   /**
    * Additional props for Thumb.
    */
-  thumbProps?: React.HTMLAttributes<HTMLDivElement>;
+  thumbProps?: React.ComponentPropsWithRef<'div'>;
 };
 
 /**
@@ -154,7 +154,7 @@ export const Thumb = (props: ThumbProps) => {
     >
       <Box
         {...rest}
-        ref={thumbRef}
+        ref={useMergedRefs(thumbRef, thumbProps?.ref)}
         style={
           {
             ...style,


### PR DESCRIPTION
## Changes

1. fixed types to allow `ref` in `triggerProps` and `thumbProps`.
2. fixed runtime JS to correctly merge refs

## Testing

n/a.

## Docs

n/a