### PR TITLE
add direct dependency on illustrations

### DIFF
--- a/.changeset/gentle-worms-dance.md
+++ b/.changeset/gentle-worms-dance.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`@itwin/itwinui-illustrations-react` has been made a direct dependency again, to avoid issues with bundlers attempting to bundle it even if `ErrorPage` is not used anywhere.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -114,14 +114,8 @@
     "vite": "^4.5.1"
   },
   "peerDependencies": {
-    "@itwin/itwinui-illustrations-react": "^2.1.0",
     "react": ">= 17.0.0 < 19.0.0",
     "react-dom": ">=17.0.0 < 19.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@itwin/itwinui-illustrations-react": {
-      "optional": true
-    }
   },
   "lint-staged": {
     "*.{tsx,ts,jsx,js}": [

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -76,6 +76,7 @@
     "dev:styles": "yarn build:styles --watch"
   },
   "dependencies": {
+    "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@floating-ui/react": "^0.26.3",
     "classnames": "^2.3.2",
     "react-table": "^7.8.0",
@@ -84,7 +85,6 @@
   },
   "devDependencies": {
     "@itwin/itwinui-css": "^2.1.0",
-    "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@itwin/itwinui-variables": "3.0.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.68",

--- a/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
+++ b/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
@@ -6,53 +6,34 @@ import * as React from 'react';
 import { Button } from '../Buttons/Button.js';
 import { NonIdealState } from './NonIdealState.js';
 import { ProgressRadial } from '../ProgressIndicators/ProgressRadial.js';
-import { isDev } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 
-/**
- * If `@itwin/itwinui-illustrations-react` is not found, we will log an error
- * and return an empty component to prevent crashing the app.
- */
-const failGracefully = () => {
-  if (isDev) {
-    console.warn(
-      'ErrorPage component requires manually installing the @itwin/itwinui-illustrations-react package.\n' +
-        'If you are not using ErrorPage, you can safely ignore this warning.',
-    );
-  }
-  return { default: () => null };
-};
-
-const Svg401 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg401').catch(failGracefully),
+const Svg401 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg401'),
 );
-const Svg403 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg403').catch(failGracefully),
+const Svg403 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg403'),
 );
-const Svg404 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg404').catch(failGracefully),
+const Svg404 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg404'),
 );
-const Svg500 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg500').catch(failGracefully),
+const Svg500 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg500'),
 );
-const Svg502 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg502').catch(failGracefully),
+const Svg502 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg502'),
 );
-const Svg503 = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/Svg503').catch(failGracefully),
+const Svg503 = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/Svg503'),
 );
-const SvgError = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/SvgError').catch(failGracefully),
+const SvgError = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/SvgError'),
 );
-const SvgRedirect = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/SvgRedirect').catch(
-    failGracefully,
-  ),
+const SvgRedirect = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/SvgRedirect'),
 );
-const SvgTimedOut = React.lazy(() =>
-  import('@itwin/itwinui-illustrations-react/SvgTimedOut').catch(
-    failGracefully,
-  ),
+const SvgTimedOut = React.lazy(
+  () => import('@itwin/itwinui-illustrations-react/SvgTimedOut'),
 );
 
 /** @deprecated Use `NonIdealState` instead. */

--- a/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
+++ b/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
@@ -6,34 +6,53 @@ import * as React from 'react';
 import { Button } from '../Buttons/Button.js';
 import { NonIdealState } from './NonIdealState.js';
 import { ProgressRadial } from '../ProgressIndicators/ProgressRadial.js';
+import { isDev } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 
-const Svg401 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg401'),
+/**
+ * If `@itwin/itwinui-illustrations-react` is not found, we will log an error
+ * and return an empty component to prevent crashing the app.
+ */
+const failGracefully = () => {
+  if (isDev) {
+    console.warn(
+      'ErrorPage component requires manually installing the @itwin/itwinui-illustrations-react package.\n' +
+        'If you are not using ErrorPage, you can safely ignore this warning.',
+    );
+  }
+  return { default: () => null };
+};
+
+const Svg401 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg401').catch(failGracefully),
 );
-const Svg403 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg403'),
+const Svg403 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg403').catch(failGracefully),
 );
-const Svg404 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg404'),
+const Svg404 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg404').catch(failGracefully),
 );
-const Svg500 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg500'),
+const Svg500 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg500').catch(failGracefully),
 );
-const Svg502 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg502'),
+const Svg502 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg502').catch(failGracefully),
 );
-const Svg503 = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/Svg503'),
+const Svg503 = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/Svg503').catch(failGracefully),
 );
-const SvgError = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/SvgError'),
+const SvgError = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/SvgError').catch(failGracefully),
 );
-const SvgRedirect = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/SvgRedirect'),
+const SvgRedirect = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/SvgRedirect').catch(
+    failGracefully,
+  ),
 );
-const SvgTimedOut = React.lazy(
-  () => import('@itwin/itwinui-illustrations-react/SvgTimedOut'),
+const SvgTimedOut = React.lazy(() =>
+  import('@itwin/itwinui-illustrations-react/SvgTimedOut').catch(
+    failGracefully,
+  ),
 );
 
 /** @deprecated Use `NonIdealState` instead. */


### PR DESCRIPTION
## Changes

fixes https://github.com/iTwin/iTwinUI/pull/1742#discussion_r1430493256 which happens because `ErrorPage` is part of the barrel file (`index.js`), resulting in bundlers trying to resolve everything even if it's not used (it later gets tree-shaked)

first i tried `catch`ing these errors ([`a6c4039`](https://github.com/iTwin/iTwinUI/pull/1744/commits/a6c40392023184eeb05b10dbca013f5de4c56812)), but vite and nextjs don't respect this `catch`. so i've resorted to moving it from a peer dependency to direct dependency.

this effectively undoes the breaking change, so users have one less thing to worry about. and if `ErrorPage` is not used, this *should not* be part of the final bundle, so no real downside there.

## Testing

no more errors! i've done preliminary testing locally, but I plan to test in sandboxes some more, together with #1734 after this PR is merged.

## Docs

added changeset. will also update migration guide after this merges.
