### PR TITLE
Added overflow style to `minimal-sandbox`

### DIFF
--- a/minimal-sandbox/src/styles.css
+++ b/minimal-sandbox/src/styles.css
@@ -15,4 +15,5 @@ body {
 .my-app-wrapper {
   height: 100dvh;
   padding: 2rem 1rem;
+  overflow: auto;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

When creating playgrounds ([v2](https://stackblitz.com/edit/github-wy4lfv?file=src%2FApp.tsx), [v3](https://stackblitz.com/edit/github-7obvbo?file=src%2FApp.tsx)) for https://github.com/iTwin/iTwinUI-migration-tool/pull/96, I felt that having the overflow style by default would be helpful. This PR just adds that overflow style.

|Before|After|
|-|-|
|<img width="526" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/0ca49fa3-1fe0-422c-b81a-68c6ddc6b2a9">|<img width="527" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/867448b0-c367-48bf-89bc-9edd8c666265">|

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Tested that the minimal-sandbox still looks alright on Stackblitz.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A