### PR TITLE
replace stylelint formatting rules with prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,26 +14,14 @@
   "html.format.wrapLineLength": 120,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
   },
   "[html]": {
     "editor.defaultFormatter": "vscode.html-language-features"
   },
-  "[css]": {
-    "editor.formatOnSave": false
-  },
-  "[scss]": {
-    "editor.formatOnSave": false
-  },
   "[markdown]": {
     "editor.defaultFormatter": "vscode.markdown-language-features"
-  },
-  "[astro]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "javascript.format.semicolons": "insert",
   "javascript.preferences.quoteStyle": "single",

--- a/apps/website/.stylelintrc.json
+++ b/apps/website/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["configs/.stylelintrc.json"],
+  "rules": {
+    "selector-class-pattern": null
+  }
+}

--- a/internal/configs/.stylelintrc.json
+++ b/internal/configs/.stylelintrc.json
@@ -1,10 +1,8 @@
 {
-  "extends": ["stylelint-config-sass-guidelines"],
+  "extends": ["stylelint-config-sass-guidelines", "stylelint-config-prettier"],
   "plugins": ["stylelint-use-logical"],
   "rules": {
-    "color-hex-case": "upper",
     "csstools/use-logical": "always",
-    "declaration-block-semicolon-newline-after": "always-multi-line",
     "declaration-property-value-disallowed-list": {
       "border": ["/^0/"],
       "border-top": ["/^0/"],
@@ -12,11 +10,7 @@
       "border-bottom": ["/^0/"],
       "border-left": ["/^0/"]
     },
-    "no-eol-whitespace": true,
-    "function-parentheses-space-inside": "never-single-line",
     "max-nesting-depth": 4,
-    "order/order": null,
-    "order/properties-alphabetical-order": null,
     "selector-class-pattern": [
       "iui-[a-z]+",
       {
@@ -24,12 +18,11 @@
         "resolveNestedSelectors": true
       }
     ],
-    "selector-combinator-space-after": "always",
-    "selector-combinator-space-before": "always",
     "selector-max-compound-selectors": 4,
     "selector-max-id": 1,
     "selector-no-qualifying-type": null,
-    "scss/dollar-variable-pattern": null
+    "scss/dollar-variable-pattern": null,
+    "scss/dollar-variable-colon-space-after": null
   },
   "ignoreFiles": ["**/*.html"],
   "customSyntax": "postcss-scss"

--- a/internal/configs/package.json
+++ b/internal/configs/package.json
@@ -22,7 +22,13 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "fast-glob": "^3.2.5",
     "prettier": "~3.1.0",
-    "prettier-plugin-astro": "^0.12.2"
+    "prettier-plugin-astro": "^0.12.2",
+    "stylelint": "^15.11.0",
+    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-sass-guidelines": "^10.0.0",
+    "stylelint-csstree-validator": "^3.0.0",
+    "stylelint-scss": "^6.0.0",
+    "stylelint-use-logical": "^2.1.0"
   },
   "peerDependencies": {
     "eslint": "^8.43.0",

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -42,12 +42,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",
     "sass": "^1.63.6",
-    "sass-embedded": "^1.63.6",
-    "stylelint": "^15.10.1",
-    "stylelint-config-sass-guidelines": "^9.0.1",
-    "stylelint-csstree-validator": "^3.0.0",
-    "stylelint-scss": "^5.0.1",
-    "stylelint-use-logical": "^2.1.0"
+    "sass-embedded": "^1.63.6"
   },
   "scripts": {
     "build": "yarn clean && yarn build:css && node ../../scripts/copyrightLinter.js --fix css/*",

--- a/packages/itwinui-css/src/backdrop/backdrop.scss
+++ b/packages/itwinui-css/src/backdrop/backdrop.scss
@@ -16,7 +16,9 @@
     opacity: 0;
   }
 
-  transition: visibility var(--iui-duration-0) linear, opacity var(--iui-duration-1) ease-out;
+  transition:
+    visibility var(--iui-duration-0) linear,
+    opacity var(--iui-duration-1) ease-out;
   transition-delay: var(--iui-duration-1), var(--iui-duration-0);
 
   &.iui-backdrop-visible {

--- a/packages/itwinui-css/src/button/base.scss
+++ b/packages/itwinui-css/src/button/base.scss
@@ -26,7 +26,9 @@
   min-inline-size: var(--_iui-button-min-height);
   padding-block: var(--_iui-button-padding-block);
   padding-inline: var(--_iui-button-padding-inline);
-  transition: background-color var(--iui-duration-1) ease-out, border-color var(--iui-duration-1) ease-out;
+  transition:
+    background-color var(--iui-duration-1) ease-out,
+    border-color var(--iui-duration-1) ease-out;
   -webkit-tap-highlight-color: transparent;
   text-decoration: none;
   @include iui-button-size;

--- a/packages/itwinui-css/src/color-picker/color-picker.scss
+++ b/packages/itwinui-css/src/color-picker/color-picker.scss
@@ -34,17 +34,19 @@ $iui-hover-box-shadow: 0 0 0 var(--iui-size-3xs) var(--iui-color-border);
   position: relative;
   background-color: var(--iui-color-swatch-background);
   forced-color-adjust: none;
-  background-position: 0 0, calc(var(--iui-size-m) * 0.5) calc(var(--iui-size-m) * 0.5);
+  background-position:
+    0 0,
+    calc(var(--iui-size-m) * 0.5) calc(var(--iui-size-m) * 0.5);
   background-size: var(--iui-size-m) var(--iui-size-m);
   background-image: repeating-linear-gradient(
-    45deg,
-    #C7CCD1 25%,
-    transparent 25%,
-    transparent 75%,
-    #C7CCD1 75%,
-    #C7CCD1
-  ),
-    repeating-linear-gradient(45deg, #C7CCD1 25%, #EDEFF2 25%, #EDEFF2 75%, #C7CCD1 75%, #C7CCD1);
+      45deg,
+      #c7ccd1 25%,
+      transparent 25%,
+      transparent 75%,
+      #c7ccd1 75%,
+      #c7ccd1
+    ),
+    repeating-linear-gradient(45deg, #c7ccd1 25%, #edeff2 25%, #edeff2 75%, #c7ccd1 75%, #c7ccd1);
 
   &::after {
     content: '';
@@ -179,11 +181,14 @@ $iui-hover-box-shadow: 0 0 0 var(--iui-size-3xs) var(--iui-color-border);
 
 .iui-opacity-slider .iui-slider::before {
   forced-color-adjust: none;
-  background-position: 0, 0, calc(var(--iui-size-xs) * 0.5) calc(var(--iui-size-xs) * 0.5);
+  background-position:
+    0,
+    0,
+    calc(var(--iui-size-xs) * 0.5) calc(var(--iui-size-xs) * 0.5);
   background-size: auto, var(--iui-size-xs), var(--iui-size-xs);
   background-image: linear-gradient(to right, transparent 0%, var(--iui-color-picker-selected-color) 100%),
-    repeating-linear-gradient(45deg, #C7CCD1 25%, transparent 25%, transparent 75%, #C7CCD1 75%, #C7CCD1),
-    repeating-linear-gradient(45deg, #C7CCD1 25%, #EDEFF2 25%, #EDEFF2 75%, #C7CCD1 75%, #C7CCD1);
+    repeating-linear-gradient(45deg, #c7ccd1 25%, transparent 25%, transparent 75%, #c7ccd1 75%, #c7ccd1),
+    repeating-linear-gradient(45deg, #c7ccd1 25%, #edeff2 25%, #edeff2 75%, #c7ccd1 75%, #c7ccd1);
 }
 
 .iui-color-dot {

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -52,7 +52,9 @@ $iui-dialog-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins
     opacity: 0;
   }
 
-  transition: visibility var(--iui-duration-0) linear, opacity var(--iui-duration-1) ease-out;
+  transition:
+    visibility var(--iui-duration-0) linear,
+    opacity var(--iui-duration-1) ease-out;
   transition-delay: var(--iui-duration-1), var(--iui-duration-0);
 
   &.iui-dialog-visible {
@@ -117,8 +119,10 @@ $iui-dialog-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    transition: visibility var(--iui-duration-0) linear var(--iui-duration-2),
-      opacity var(--iui-duration-0) linear var(--iui-duration-2), transform var(--iui-duration-1) ease-in;
+    transition:
+      visibility var(--iui-duration-0) linear var(--iui-duration-2),
+      opacity var(--iui-duration-0) linear var(--iui-duration-2),
+      transform var(--iui-duration-1) ease-in;
 
     &.iui-dialog-visible {
       transition: transform var(--iui-duration-2) ease-out;

--- a/packages/itwinui-css/src/expandable-block/expandable-block.scss
+++ b/packages/itwinui-css/src/expandable-block/expandable-block.scss
@@ -117,7 +117,9 @@
   transform: var(--_iui-expandable-block-expander-icon-transform);
   transition: fill var(--iui-duration-1) ease-out;
   @media (prefers-reduced-motion: no-preference) {
-    transition: fill var(--iui-duration-1) ease-out, transform var(--iui-duration-1) ease-out;
+    transition:
+      fill var(--iui-duration-1) ease-out,
+      transform var(--iui-duration-1) ease-out;
   }
 }
 

--- a/packages/itwinui-css/src/header/header.scss
+++ b/packages/itwinui-css/src/header/header.scss
@@ -55,7 +55,9 @@
     .iui-avatar {
       &,
       * {
-        transition: width var(--iui-duration-1) ease-out, height var(--iui-duration-1) ease-out,
+        transition:
+          width var(--iui-duration-1) ease-out,
+          height var(--iui-duration-1) ease-out,
           font-size var(--iui-duration-1) ease-out;
       }
     }

--- a/packages/itwinui-css/src/information-panel/information-panel.scss
+++ b/packages/itwinui-css/src/information-panel/information-panel.scss
@@ -20,7 +20,9 @@
       block-size: 100%;
       inline-size: 1px;
       @media (prefers-reduced-motion: no-preference) {
-        transition: background-color var(--iui-duration-1) ease-out, width var(--iui-duration-1) ease-out;
+        transition:
+          background-color var(--iui-duration-1) ease-out,
+          width var(--iui-duration-1) ease-out;
       }
     }
 
@@ -48,7 +50,9 @@
       inline-size: 100%;
       block-size: 1px;
       @media (prefers-reduced-motion: no-preference) {
-        transition: background-color var(--iui-duration-1) ease-out, height var(--iui-duration-1) ease-out;
+        transition:
+          background-color var(--iui-duration-1) ease-out,
+          height var(--iui-duration-1) ease-out;
       }
     }
 
@@ -76,7 +80,9 @@
   max-block-size: 100%;
   background-color: var(--iui-color-background);
   @media (prefers-reduced-motion: no-preference) {
-    transition: visibility var(--iui-duration-0) var(--iui-duration-1) ease-in, transform var(--iui-duration-1) ease-out,
+    transition:
+      visibility var(--iui-duration-0) var(--iui-duration-1) ease-in,
+      transform var(--iui-duration-1) ease-out,
       opacity var(--iui-duration-1) ease;
   }
 
@@ -172,7 +178,9 @@
     transform: translate(0);
 
     @media (prefers-reduced-motion: no-preference) {
-      transition: transform var(--iui-duration-1) ease-out, opacity var(--iui-duration-1) ease;
+      transition:
+        transform var(--iui-duration-1) ease-out,
+        opacity var(--iui-duration-1) ease;
     }
 
     > .iui-resizer {

--- a/packages/itwinui-css/src/keyboard/keyboard.scss
+++ b/packages/itwinui-css/src/keyboard/keyboard.scss
@@ -18,11 +18,15 @@
   cursor: default;
   background-color: var(--iui-color-background);
   border: 1px solid var(--iui-color-border);
-  box-shadow: 0 1px 1px var(--iui-color-border), 0 1px 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;
+  box-shadow:
+    0 1px 1px var(--iui-color-border),
+    0 1px 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;
   transition: box-shadow var(--iui-duration-1) ease-out;
   color: var(--iui-color-text);
 
   &:hover {
-    box-shadow: 0 0 0 var(--iui-color-border), 0 0 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;
+    box-shadow:
+      0 0 0 var(--iui-color-border),
+      0 0 0 0 rgba(255, 255, 255, var(--iui-opacity-5)) inset;
   }
 }

--- a/packages/itwinui-css/src/mixins.scss
+++ b/packages/itwinui-css/src/mixins.scss
@@ -81,7 +81,9 @@
 /// Classes for react-transition-group
 /// Used for expand/collapse transitions. Needs height/width to be set in JS.
 @mixin iui-transition-group {
-  $transition-rule: opacity var(--iui-duration-1) ease-out, width var(--iui-duration-1) ease-out,
+  $transition-rule:
+    opacity var(--iui-duration-1) ease-out,
+    width var(--iui-duration-1) ease-out,
     height var(--iui-duration-1) ease-out;
 
   &.iui-enter {
@@ -175,7 +177,7 @@
 // // later:
 // --is-red: var(--iui-on);
 @mixin space-toggle-states {
-  --iui-off: /* whitespace means "off" */ ; /* stylelint-disable-line */
+  --iui-off: ; // whitespace means "off"
   --iui-on: initial;
 }
 

--- a/packages/itwinui-css/src/skip-to-content/skip-to-content.scss
+++ b/packages/itwinui-css/src/skip-to-content/skip-to-content.scss
@@ -20,8 +20,11 @@
   transform: translateX(-50%) translateY(-170%);
   transition: background-color var(--iui-duration-1) ease-in-out;
   @media (prefers-reduced-motion: no-preference) {
-    transition: opacity var(--iui-duration-3) ease-in-out, background-color var(--iui-duration-3) ease-in-out,
-      transform var(--iui-duration-3) ease-in-out, box-shadow var(--iui-duration-3) ease-in-out;
+    transition:
+      opacity var(--iui-duration-3) ease-in-out,
+      background-color var(--iui-duration-3) ease-in-out,
+      transform var(--iui-duration-3) ease-in-out,
+      box-shadow var(--iui-duration-3) ease-in-out;
   }
 
   &:hover {
@@ -33,8 +36,11 @@
     transform: translateX(-50%) translateY(0);
     box-shadow: var(--iui-shadow-4);
     @media (prefers-reduced-motion: no-preference) {
-      transition: opacity var(--iui-duration-0) ease-in-out, background-color var(--iui-duration-1) ease-in-out,
-        transform var(--iui-duration-1) ease-in-out, box-shadow var(--iui-duration-1) ease-in-out;
+      transition:
+        opacity var(--iui-duration-0) ease-in-out,
+        background-color var(--iui-duration-1) ease-in-out,
+        transform var(--iui-duration-1) ease-in-out,
+        box-shadow var(--iui-duration-1) ease-in-out;
     }
   }
 }

--- a/packages/itwinui-css/src/stepper/stepper.scss
+++ b/packages/itwinui-css/src/stepper/stepper.scss
@@ -84,7 +84,9 @@
 
   .iui-clickable & {
     cursor: pointer;
-    transition: background-color var(--iui-duration-1) ease-out, border-color var(--iui-duration-1) ease-out,
+    transition:
+      background-color var(--iui-duration-1) ease-out,
+      border-color var(--iui-duration-1) ease-out,
       color var(--iui-duration-1) ease-out;
 
     &:hover {

--- a/packages/itwinui-css/src/toggle-switch/toggle-switch.scss
+++ b/packages/itwinui-css/src/toggle-switch/toggle-switch.scss
@@ -63,10 +63,12 @@
   inline-size: calc((var(--_iui-toggle-switch-handle-size) + var(--_iui-toggle-switch-handle-offset) * 2) * 2);
   block-size: calc(
     var(--_iui-toggle-switch-handle-size) + (var(--_iui-toggle-switch-handle-offset) * 2) +
-    ($iui-toggle-switch-border-thickness * 2)
+      ($iui-toggle-switch-border-thickness * 2)
   );
   border-radius: var(--iui-border-radius-round);
-  transition: background-color var(--iui-duration-1) ease-out, border-color var(--iui-duration-1) ease-out;
+  transition:
+    background-color var(--iui-duration-1) ease-out,
+    border-color var(--iui-duration-1) ease-out;
   background-color: var(--iui-color-background);
   border: $iui-toggle-switch-border-thickness solid;
 
@@ -84,7 +86,9 @@
     transition: background-color var(--iui-duration-1) ease-out;
     z-index: 2;
     @media (prefers-reduced-motion: no-preference) {
-      transition: transform var(--iui-duration-1) ease-out, background-color var(--iui-duration-1) ease-out;
+      transition:
+        transform var(--iui-duration-1) ease-out,
+        background-color var(--iui-duration-1) ease-out;
     }
   }
 

--- a/packages/itwinui-css/src/utils/notification-marker.scss
+++ b/packages/itwinui-css/src/utils/notification-marker.scss
@@ -24,7 +24,9 @@ $iui-notification-marker-cutout-radius: calc(0.5 * $iui-notification-marker-cuto
     border-radius: 100%;
     background-color: var(--_iui-notification-marker-color);
     @media (prefers-reduced-motion: no-preference) {
-      transition: background-color var(--iui-duration-1) ease-out, border-color var(--iui-duration-1) ease-out;
+      transition:
+        background-color var(--iui-duration-1) ease-out,
+        border-color var(--iui-duration-1) ease-out;
     }
   }
 

--- a/packages/itwinui-variables/src/themes/light-hc.scss
+++ b/packages/itwinui-variables/src/themes/light-hc.scss
@@ -93,8 +93,12 @@ $opacities: (
   --iui-color-background-backdrop-hover: #{hex($bg-300)};
   --iui-color-background-disabled: #{hex($bg-400)};
   --iui-color-background-accent: var(--iui-color-background-informational);
-  --iui-color-background-accent-hover: var(--iui-color-background-informational-hover);
-  --iui-color-background-accent-muted: var(--iui-color-background-informational-muted);
+  --iui-color-background-accent-hover: var(
+    --iui-color-background-informational-hover
+  );
+  --iui-color-background-accent-muted: var(
+    --iui-color-background-informational-muted
+  );
   --iui-color-background-informational: #{hex($bg-informational-1)};
   --iui-color-background-informational-hover: #{hex($bg-informational-2)};
   --iui-color-background-informational-muted: #{hex($bg-informational-0)};

--- a/packages/itwinui-variables/src/typography.scss
+++ b/packages/itwinui-variables/src/typography.scss
@@ -4,7 +4,8 @@
 
 @mixin typography {
   --iui-font-sans: 'Noto Sans', 'Open Sans', system-ui, sans-serif;
-  --iui-font-mono: 'Noto Sans Mono', ui-monospace, 'Segoe UI Mono', Consolas, 'Roboto Mono', monospace;
+  --iui-font-mono: 'Noto Sans Mono', ui-monospace, 'Segoe UI Mono', Consolas,
+    'Roboto Mono', monospace;
 
   --iui-font-size-0: #{math.div(12, 16)}rem;
   --iui-font-size-1: #{math.div(14, 16)}rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,25 +814,25 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz#1e0d581dbf4518cb3e939c3b863cb7180c8cedad"
   integrity sha512-sLYGdAdEY2x7TSw9FtmdaTrh2wFtRJO5VMbBrA8tEqEod7GEggFmxTSK9XqExib3yMuYNcvcTdCZIP6ukdjAIA==
 
-"@csstools/css-parser-algorithms@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.0.tgz#0cc3a656dc2d638370ecf6f98358973bfbd00141"
-  integrity sha512-dTKSIHHWc0zPvcS5cqGP+/TPFUJB0ekJ9dGKvMAFoNuBFhDPBt9OMGNZiIA5vTiNdGHHBeScYPXIGBMnVOahsA==
+"@csstools/css-parser-algorithms@^2.3.1":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.4.0.tgz#88c7b62b8e00c391b24c585f9db5a0b62ed665b0"
+  integrity sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==
 
-"@csstools/css-tokenizer@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz#07ae11a0a06365d7ec686549db7b729bc036528e"
-  integrity sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==
+"@csstools/css-tokenizer@^2.2.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.2.2.tgz#bcd85cef4468c356833b21e96d38b940c9760605"
+  integrity sha512-wCDUe/MAw7npAHFLyW3QjSyLA66S5QFaV1jIXlNQvdJ8RzXDSgALa49eWcUO6P55ARQaz0TsDdAgdRgkXFYY8g==
 
 "@csstools/css-tokenizer@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.2.1.tgz#9dc431c9a5f61087af626e41ac2a79cce7bb253d"
   integrity sha512-Zmsf2f/CaEPWEVgw29odOj+WEVoiJy9s9NOv5GgNY9mZ1CZ7394By6wONrONrTsnNDv6F9hR02nvFihrGVGHBg==
 
-"@csstools/media-query-list-parser@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.2.tgz#6ef642b728d30c1009bfbba3211c7e4c11302728"
-  integrity sha512-M8cFGGwl866o6++vIY7j1AKuq9v57cf+dGepScwCcbut9ypJNr4Cj+LLTWligYUZ0uyhEoJDKt5lvyBfh2L3ZQ==
+"@csstools/media-query-list-parser@^2.1.4":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.6.tgz#e4e9a8a35be7a066836389b03ec19e584bc61af3"
+  integrity sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw==
 
 "@csstools/media-query-list-parser@^2.1.5":
   version "2.1.5"
@@ -3046,10 +3046,15 @@
   resolved "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.2.tgz"
   integrity sha512-mJGfgj4aWpiKb8C0nnJJchs1sHBHn0HugkVfqqyQi7Wn6mBRksLeQsPOFvih/Pu8L1vlDzfe/LidhVHBeUk3aQ==
 
-"@types/minimist@^1.2.0", "@types/minimist@^1.2.2":
+"@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/minimist@^1.2.2":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
+  integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
 "@types/ms@*":
   version "0.7.31"
@@ -4900,13 +4905,13 @@ cosmiconfig@^7.0.0:
     yaml "^1.10.0"
 
 cosmiconfig@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.2.0.tgz#f7d17c56a590856cd1e7cee98734dca272b0d8fd"
-  integrity sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
+  integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
   dependencies:
-    import-fresh "^3.2.1"
+    import-fresh "^3.3.0"
     js-yaml "^4.1.0"
-    parse-json "^5.0.0"
+    parse-json "^5.2.0"
     path-type "^4.0.0"
 
 create-require@^1.1.0:
@@ -4964,10 +4969,10 @@ css-blank-pseudo@^6.0.0:
   dependencies:
     postcss-selector-parser "^6.0.13"
 
-css-functions-list@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz"
-  integrity sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==
+css-functions-list@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.1.tgz#2eb205d8ce9f9ce74c5c1d7490b66b77c45ce3ea"
+  integrity sha512-Nj5YcaGgBtuUmn1D7oHqPW0c9iui7xsTsj5lIX8ZgevdfhmjFfKB3r8moHJtNJnctnYXJyYX5I1pp90HM4TPgQ==
 
 css-has-pseudo@^6.0.0:
   version "6.0.0"
@@ -6377,7 +6382,7 @@ fast-glob@^3.3.0:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.3.2:
+fast-glob@^3.3.1, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -6444,6 +6449,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-entry-cache@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-7.0.2.tgz#2d61bb70ba89b9548e3035b7c9173fe91deafff0"
+  integrity sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==
+  dependencies:
+    flat-cache "^3.2.0"
 
 file-type@^16.5.4:
   version "16.5.4"
@@ -6560,10 +6572,24 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
+flat-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.3"
+    rimraf "^3.0.2"
+
 flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
+flatted@^3.2.9:
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
+  integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
 flattie@^1.1.0:
   version "1.1.0"
@@ -7570,7 +7596,7 @@ immutable@^4.0.0:
   resolved "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz"
   integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -7580,7 +7606,7 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 
 import-lazy@^4.0.0:
   version "4.0.0"
-  resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
 import-local@^3.0.2:
@@ -7773,19 +7799,12 @@ is-core-module@^2.11.0:
   dependencies:
     has "^1.0.3"
 
-is-core-module@^2.13.0:
+is-core-module@^2.13.0, is-core-module@^2.5.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
   integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==
   dependencies:
     hasown "^2.0.0"
-
-is-core-module@^2.5.0:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
-  integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
-  dependencies:
-    has "^1.0.3"
 
 is-core-module@^2.9.0:
   version "2.9.0"
@@ -8708,6 +8727,13 @@ keyv@^4.0.0:
   dependencies:
     json-buffer "3.0.1"
 
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
 kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz"
@@ -8735,10 +8761,10 @@ kleur@^4.1.4:
   resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz"
   integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
-known-css-properties@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.27.0.tgz#82a9358dda5fe7f7bd12b5e7142c0a205393c0c5"
-  integrity sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==
+known-css-properties@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.29.0.tgz#e8ba024fb03886f23cb882e806929f32d814158f"
+  integrity sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==
 
 koa-compose@^4.1.0:
   version "4.1.0"
@@ -11661,13 +11687,13 @@ postcss-resolve-nested-selector@^0.1.1:
 
 postcss-safe-parser@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-scss@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz"
-  integrity sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==
+postcss-scss@^4.0.6:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
+  integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
 
 postcss-selector-not@^7.0.1:
   version "7.0.1"
@@ -11684,17 +11710,12 @@ postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11, postcss-select
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-sorting@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz"
-  integrity sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==
-
 postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31, postcss@^8.3.11, postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.27, postcss@^8.4.31, postcss@^8.4.32:
+postcss@8.4.31, postcss@^8.4.21, postcss@^8.4.27, postcss@^8.4.28, postcss@^8.4.31, postcss@^8.4.32:
   version "8.4.31"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
@@ -13523,8 +13544,8 @@ strtok3@^7.0.0-alpha.9:
 
 style-search@^0.1.0:
   version "0.1.0"
-  resolved "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz"
-  integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
 style-to-object@^0.4.0, style-to-object@^0.4.1:
   version "0.4.4"
@@ -13547,14 +13568,18 @@ styled-jsx@5.1.1:
   dependencies:
     client-only "0.0.1"
 
-stylelint-config-sass-guidelines@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-9.0.1.tgz"
-  integrity sha512-N06PsVsrgKijQ3YT5hqKA7x3NUkgELTRI1cbWMqcYiCGG6MjzvNk6Cb5YYA1PrvrksBV76BvY9P9bAswojVMqA==
+stylelint-config-prettier@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
+  integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
+
+stylelint-config-sass-guidelines@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-10.0.0.tgz#ace99689eb6769534c9b40d62e2a8562b1ddc9f2"
+  integrity sha512-+Rr2Dd4b72CWA4qoj1Kk+y449nP/WJsrD0nzQAWkmPPIuyVcy2GMIcfNr0Z8JJOLjRvtlkKxa49FCNXMePBikQ==
   dependencies:
-    postcss-scss "^4.0.2"
-    stylelint-order "^5.0.0"
-    stylelint-scss "^4.0.0"
+    postcss-scss "^4.0.6"
+    stylelint-scss "^4.4.0"
 
 stylelint-csstree-validator@^3.0.0:
   version "3.0.0"
@@ -13563,17 +13588,9 @@ stylelint-csstree-validator@^3.0.0:
   dependencies:
     css-tree "^2.3.1"
 
-stylelint-order@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz"
-  integrity sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==
-  dependencies:
-    postcss "^8.3.11"
-    postcss-sorting "^7.0.1"
-
-stylelint-scss@^4.0.0:
+stylelint-scss@^4.4.0:
   version "4.7.0"
-  resolved "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.7.0.tgz"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.7.0.tgz#f986bf8c5a4b93eae2b67d3a3562eef822657908"
   integrity sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==
   dependencies:
     postcss-media-query-parser "^0.2.3"
@@ -13581,11 +13598,12 @@ stylelint-scss@^4.0.0:
     postcss-selector-parser "^6.0.11"
     postcss-value-parser "^4.2.0"
 
-stylelint-scss@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-5.0.1.tgz#b33a6580b5734eace083cfc2cc3021225e28547f"
-  integrity sha512-n87iCRZrr2J7//I/QFsDXxFLnHKw633U4qvWZ+mOW6KDAp/HLj06H+6+f9zOuTYy+MdGdTuCSDROCpQIhw5fvQ==
+stylelint-scss@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-6.0.0.tgz#bf6be6798d71c898484b7e97007d5ed69a89308d"
+  integrity sha512-N1xV/Ef5PNRQQt9E45unzGvBUN1KZxCI8B4FgN/pMfmyRYbZGVN4y9qWlvOMdScU17c8VVCnjIHTVn38Bb6qSA==
   dependencies:
+    known-css-properties "^0.29.0"
     postcss-media-query-parser "^0.2.3"
     postcss-resolve-nested-selector "^0.1.1"
     postcss-selector-parser "^6.0.13"
@@ -13596,24 +13614,24 @@ stylelint-use-logical@^2.1.0:
   resolved "https://registry.yarnpkg.com/stylelint-use-logical/-/stylelint-use-logical-2.1.0.tgz#4d2e58418d1a5d459beb3d51552491fab1ed22ec"
   integrity sha512-DN1boOPI6IMYTlu2KeQpH5hDEiCODHhd+AtXU0InO37wkWAuELiPwuv59HrTg2m9PYmqGTTO/QWdMBafYVPfew==
 
-stylelint@^15.10.1:
-  version "15.10.1"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.10.1.tgz#93f189958687e330c106b010cbec0c41dcae506d"
-  integrity sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==
+stylelint@^15.11.0:
+  version "15.11.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.11.0.tgz#3ff8466f5f5c47362bc7c8c9d382741c58bc3292"
+  integrity sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==
   dependencies:
-    "@csstools/css-parser-algorithms" "^2.3.0"
-    "@csstools/css-tokenizer" "^2.1.1"
-    "@csstools/media-query-list-parser" "^2.1.2"
+    "@csstools/css-parser-algorithms" "^2.3.1"
+    "@csstools/css-tokenizer" "^2.2.0"
+    "@csstools/media-query-list-parser" "^2.1.4"
     "@csstools/selector-specificity" "^3.0.0"
     balanced-match "^2.0.0"
     colord "^2.9.3"
     cosmiconfig "^8.2.0"
-    css-functions-list "^3.1.0"
+    css-functions-list "^3.2.1"
     css-tree "^2.3.1"
     debug "^4.3.4"
-    fast-glob "^3.3.0"
+    fast-glob "^3.3.1"
     fastest-levenshtein "^1.0.16"
-    file-entry-cache "^6.0.1"
+    file-entry-cache "^7.0.0"
     global-modules "^2.0.0"
     globby "^11.1.0"
     globjoin "^0.1.4"
@@ -13622,13 +13640,13 @@ stylelint@^15.10.1:
     import-lazy "^4.0.0"
     imurmurhash "^0.1.4"
     is-plain-object "^5.0.0"
-    known-css-properties "^0.27.0"
+    known-css-properties "^0.29.0"
     mathml-tag-names "^2.1.3"
     meow "^10.1.5"
     micromatch "^4.0.5"
     normalize-path "^3.0.0"
     picocolors "^1.0.0"
-    postcss "^8.4.24"
+    postcss "^8.4.28"
     postcss-resolve-nested-selector "^0.1.1"
     postcss-safe-parser "^6.0.0"
     postcss-selector-parser "^6.0.13"


### PR DESCRIPTION
## Changes

part of #1571

- `prettier` is now used for formatting all scss files, both in the editor and in the pre-commit hook.
	- ran `prettier` on all scss files to avoid random annoyances in future PRs.
- `stylelint` is only used for non-stylistic linting.
- .scss files are now allowed in `website/` (needed for #1751), with unnecessary rules disabled.

## Testing

tested that linting and formatting works in both IDE and precommit hooks. 

## Docs

n/a
