### PR TITLE
use a proxy for styles object to reduce bundle size

### DIFF
--- a/.changeset/lazy-dancers-applaud.md
+++ b/.changeset/lazy-dancers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Reduced bundle size by optimizing how CSS modules are handled internally.

--- a/packages/itwinui-react/src/styles.js/classes.mjs
+++ b/packages/itwinui-react/src/styles.js/classes.mjs
@@ -2,6 +2,18 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import styles from './styles.module.css';
+import './styles.module.css';
 
-export default styles;
+export default new Proxy(
+  {},
+  {
+    get(_, prop) {
+      if (typeof prop === 'string' && prop.startsWith('iui-')) {
+        return prop.replace('iui-', '_iui3-');
+      }
+    },
+    has(_, prop) {
+      return typeof prop === 'string' && prop.startsWith('iui-');
+    },
+  },
+);

--- a/packages/itwinui-react/src/styles.js/classes.mjs
+++ b/packages/itwinui-react/src/styles.js/classes.mjs
@@ -2,8 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+
+// Side-effect import to ensure CSS file is generated even though the classes are not used.
 import './styles.module.css';
 
+// This proxy converts `iui-` to `_iui3-` in class names with very little code.
+// This is more efficient than exporting the entire mapping of original-to-transformed classes.
 export default new Proxy(
   {},
   {

--- a/packages/itwinui-react/src/styles.js/vite.config.mjs
+++ b/packages/itwinui-react/src/styles.js/vite.config.mjs
@@ -12,7 +12,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    minify: false,
+    minify: true,
     cssMinify: false,
     lib: {
       entry: path.resolve(__dirname, './classes.mjs'),


### PR DESCRIPTION
## Changes

Replaced the [`styles` object](https://unpkg.com/browse/@itwin/itwinui-react@3.2.1/esm/styles.js) with a proxy. The giant object is not needed, since we are not using a proper hash in our css modules scoping. The proxy simply transforms the class names at runtime.

In the future if we ever use proper hashing, we can bring back the object.

Note: I had to enable minification because we are now relying on a side-effect import to include all the styles. Without enabling minification, Vite will not tree-shake the giant object even if it's not exported or used anywhere.

## Testing

Everything works the same. All tests pass.

Verified that the bundle size is actually reduced. The difference is ~20KB (or ~4KB compressed).

| Before | After |
| --- | --- |
| ![71KB](https://github.com/iTwin/iTwinUI/assets/9084735/8d44118b-051e-4d4f-9417-36f1406b043c) | ![67KB](https://github.com/iTwin/iTwinUI/assets/9084735/4572b221-37b8-48e3-b0d5-9d99ef264383) |

## Docs

Added changeset.