### PR TITLE
v2: fix full page modal not showing up

### DIFF
--- a/.changeset/nervous-chairs-grow.md
+++ b/.changeset/nervous-chairs-grow.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fix full page `Modal` not showing up.

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
@@ -192,7 +192,7 @@ export const DialogMain = React.forwardRef<HTMLDivElement, DialogMainProps>(
         tabIndex={-1}
         data-iui-placement={placement}
         style={{
-          transform: roundedTransform,
+          transform: styleType !== 'fullPage' ? roundedTransform : undefined,
           ...style,
           ...propStyle,
         }}


### PR DESCRIPTION
## Changes

#1693 broke full page modal, so now excluding the `transform` style based on `styleType`.

## Testing

before: https://itwin.github.io/iTwinUI/legacy/v2/react/?path=/story/core-modal--full-page-modal

after: https://itwin.github.io/iTwinUI/1765/react/?path=/story/core-modal--full-page-modal

## Docs

added changeset