### PR TITLE
expose `package.json` in `exports`

### DIFF
--- a/.changeset/metal-starfishes-juggle.md
+++ b/.changeset/metal-starfishes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added `package.json` to exports map.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -23,7 +23,8 @@
     },
     "./styles.css": "./styles.css",
     "./cjs": "./cjs/index.js",
-    "./esm": "./esm/index.js"
+    "./esm": "./esm/index.js",
+    "./package.json": "./package.json"
   },
   "files": [
     "cjs",


### PR DESCRIPTION
## Changes

a user wants to import `package.json` for some reason, so adding it to `exports`.

## Testing

tested that this import works:
```js
import { version } from '@itwin/itwinui-react/package.json';
```

## Docs

n/a
