### PR TITLE
add banner on homepage

### DIFF
--- a/apps/website/src/components/HomepageBanner.astro
+++ b/apps/website/src/components/HomepageBanner.astro
@@ -1,0 +1,63 @@
+---
+import RightArrowIcon from '~/icons/RightArrowIcon.astro';
+
+type Props = {
+  href: string;
+  [key: string]: unknown;
+};
+
+const { href, ...props } = Astro.props;
+---
+
+<aside {...props}>
+  <a href={href}>
+    <slot />
+  </a>
+
+  <RightArrowIcon class='arrow' lineProps={{ class: 'line' }} />
+</aside>
+
+<style lang='scss'>
+  aside {
+    border: 1px solid var(--color-line-2);
+    background-color: var(--color-background-1);
+    border-radius: 9e9px;
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text);
+    padding-inline: 16px 8px;
+    padding-block: 4px;
+    gap: 4px;
+    cursor: pointer;
+    transition: border-color 0.2s ease-in-out;
+
+    :global(.line) {
+      opacity: 0;
+      transition: opacity 0.2s ease-in-out;
+    }
+  }
+
+  a {
+    all: unset;
+  }
+
+  .arrow {
+    flex: none;
+    width: 1.5rem;
+    height: 1.5rem;
+    transform: translateX(-6px);
+    transition: transform 0.2s ease-in-out;
+  }
+
+  aside:hover {
+    border-color: var(--color-line-1);
+
+    :global(.line) {
+      opacity: 1;
+    }
+
+    .arrow {
+      transform: translateX(0);
+    }
+  }
+</style>

--- a/apps/website/src/components/HomepageBanner.astro
+++ b/apps/website/src/components/HomepageBanner.astro
@@ -18,46 +18,48 @@ const { href, ...props } = Astro.props;
 </aside>
 
 <style lang='scss'>
-  aside {
-    border: 1px solid var(--color-line-2);
-    background-color: var(--color-background-1);
-    border-radius: 9e9px;
-    display: inline-flex;
-    align-items: center;
-    color: var(--color-text);
-    padding-inline: 16px 8px;
-    padding-block: 4px;
-    gap: 4px;
-    cursor: pointer;
-    transition: border-color 0.2s ease-in-out;
+  @layer components {
+    aside {
+      border: 1px solid var(--color-line-2);
+      background-color: var(--color-background-1);
+      border-radius: 9e9px;
+      display: inline-flex;
+      align-items: center;
+      color: var(--color-text);
+      padding-inline: 16px 8px;
+      padding-block: 4px;
+      gap: 4px;
+      cursor: pointer;
+      transition: border-color 0.2s ease-in-out;
 
-    :global(.line) {
-      opacity: 0;
-      transition: opacity 0.2s ease-in-out;
+      :global(.line) {
+        opacity: 0;
+        transition: opacity 0.2s ease-in-out;
+      }
     }
-  }
 
-  a {
-    all: unset;
-  }
-
-  .arrow {
-    flex: none;
-    width: 1.5rem;
-    height: 1.5rem;
-    transform: translateX(-6px);
-    transition: transform 0.2s ease-in-out;
-  }
-
-  aside:hover {
-    border-color: var(--color-line-1);
-
-    :global(.line) {
-      opacity: 1;
+    a {
+      all: unset;
     }
 
     .arrow {
-      transform: translateX(0);
+      flex: none;
+      width: 1.5rem;
+      height: 1.5rem;
+      transform: translateX(-6px);
+      transition: transform 0.2s ease-in-out;
+    }
+
+    aside:hover {
+      border-color: var(--color-line-1);
+
+      :global(.line) {
+        opacity: 1;
+      }
+
+      .arrow {
+        transform: translateX(0);
+      }
     }
   }
 </style>

--- a/apps/website/src/components/HomepageBanner.astro
+++ b/apps/website/src/components/HomepageBanner.astro
@@ -61,5 +61,10 @@ const { href, ...props } = Astro.props;
         transform: translateX(0);
       }
     }
+
+    aside:focus-within {
+      outline: 2px solid var(--color-line-1);
+      outline-offset: 3px;
+    }
   }
 </style>

--- a/apps/website/src/components/HomepageBanner.astro
+++ b/apps/website/src/components/HomepageBanner.astro
@@ -50,7 +50,7 @@ const { href, ...props } = Astro.props;
       transition: transform 0.2s ease-in-out;
     }
 
-    aside:hover {
+    aside:is(:hover, :focus-within) {
       border-color: var(--color-line-1);
 
       :global(.line) {

--- a/apps/website/src/icons/RightArrowIcon.astro
+++ b/apps/website/src/icons/RightArrowIcon.astro
@@ -1,12 +1,16 @@
-<svg
-  xmlns='http://www.w3.org/2000/svg'
-  width='32'
-  height='32'
-  fill='currentColor'
-  viewBox='0 0 16 16'
-  {...Astro.props}
->
-  <path
-    d='M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z'
-  ></path>
+---
+const { lineProps, ...props } = Astro.props;
+---
+
+<svg width='32' height='32' fill='currentColor' viewBox='0 0 24 24' {...props}>
+  <g>
+    <path d='M4 11.25a.75.75 0 0 0 0 1.5zm0 1.5h16v-1.5H4z' {...lineProps}></path>
+    <path
+      fill='none'
+      stroke='currentColor'
+      stroke-linecap='round'
+      stroke-linejoin='round'
+      stroke-width='1.5'
+      d='m14 6l6 6l-6 6'></path>
+  </g>
 </svg>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -31,7 +31,7 @@ const currentPage = new URL(Astro.request.url).pathname;
             class='banner'
             href='https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v3-migration-guide'
           >
-            iTwinUI v3 is now available!
+            iTwinUI <span class='highlight-text v3'>v3</span> is now available!
           </HomepageBanner>
 
           <h1>For a <span class='highlight-text'>unified</span> experience</h1>
@@ -191,6 +191,10 @@ const currentPage = new URL(Astro.request.url).pathname;
 
         .banner {
           margin-block-end: var(--space-4);
+
+          .v3 {
+            font-weight: 600;
+          }
         }
       }
       .animated-logo-wrapper {

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -15,6 +15,7 @@ import DialogDemo from '~/demos/Dialog.demo';
 import ComboBoxDemo from '~/demos/ComboBox.demo';
 import SliderDemo from '~/demos/Slider.demo';
 import FieldsetDemo from '~/demos/Fieldset.demo';
+import HomepageBanner from '~/components/HomepageBanner.astro';
 
 const currentPage = new URL(Astro.request.url).pathname;
 ---
@@ -26,6 +27,13 @@ const currentPage = new URL(Astro.request.url).pathname;
     <div class='title-box'>
       <div class='hero-box'>
         <div class='hero-text move-on-visible' data-move-on-visible-direction='right'>
+          <HomepageBanner
+            class='banner'
+            href='https://github.com/iTwin/iTwinUI/wiki/iTwinUI-react-v3-migration-guide'
+          >
+            iTwinUI v3 is now available!
+          </HomepageBanner>
+
           <h1>For a <span class='highlight-text'>unified</span> experience</h1>
           <h2 class='subheading'>
             iTwinUI delivers common UI components and UI layouts bundled with accessibility best
@@ -179,6 +187,10 @@ const currentPage = new URL(Astro.request.url).pathname;
         @media (max-width: 50em) {
           grid-template-columns: 1fr;
           gap: var(--space-5);
+        }
+
+        .banner {
+          margin-block-end: var(--space-4);
         }
       }
       .animated-logo-wrapper {


### PR DESCRIPTION
## Changes

Added new `HomepageBanner` component for announcing new updates. It's a simple link within an `aside`.

![image](https://github.com/iTwin/iTwinUI/assets/9084735/8c4a9a46-4fe8-4c12-980a-5abceb1589c2)

For now it just links to the migration guide, but I assume we will want to look to a proper page within the docs in the future.

Modified `RightArrowIcon` to support individually modifying the line and the caret, for hover effect (try hovering yourself, i won't spoil the effect).

## Testing

See deploy preview: https://deploy-preview-1775--itwinui-previews.netlify.app/

Tested on narrow widths as well.

## Docs

N/A