### PR TITLE
automatically associate inputs, labels and messages

### DIFF
--- a/.changeset/purple-queens-divide.md
+++ b/.changeset/purple-queens-divide.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+The `message` passed to `LabeledInput`, `LabeledTextarea`, `LabeledSelect` and `ComboBox` will now be associated with the input using `aria-describedby` for better accessibility.

--- a/.changeset/twenty-phones-dream.md
+++ b/.changeset/twenty-phones-dream.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`InputGrid` will now attempt to automatically associate labels, inputs and status messages with each other, in the event that they haven't been explicitly associated.

--- a/apps/react-workshop/src/ComboBox.stories.tsx
+++ b/apps/react-workshop/src/ComboBox.stories.tsx
@@ -360,14 +360,11 @@ export const WithLabel = () => {
 
   return (
     <InputGrid>
-      <Label htmlFor='combo-input'>Country</Label>
+      <Label>Country</Label>
       <ComboBox
         options={options}
-        onChange={(value: string) => console.log(value ?? '')}
-        inputProps={{
-          id: 'combo-input', // passing id to inputProps so it can be used in Label htmlFor
-          placeholder: 'Select a country',
-        }}
+        onChange={(value) => console.log(value ?? '')}
+        inputProps={{ placeholder: 'Select a country' }}
       />
     </InputGrid>
   );

--- a/apps/react-workshop/src/InputGrid.stories.tsx
+++ b/apps/react-workshop/src/InputGrid.stories.tsx
@@ -22,8 +22,8 @@ export default {
 export const WithInput = () => {
   return (
     <InputGrid>
-      <Label htmlFor='input-id'>This is label</Label>
-      <Input id='input-id' />
+      <Label>This is label</Label>
+      <Input />
       <StatusMessage>This is message</StatusMessage>
     </InputGrid>
   );
@@ -60,9 +60,8 @@ export const WithSelect = () => {
 
   return (
     <InputGrid>
-      <Label htmlFor='input-id'>This is label</Label>
+      <Label>This is label</Label>
       <Select
-        id='input-id'
         options={options}
         placeholder='Select destination'
         value={value}

--- a/apps/react-workshop/src/Label.stories.tsx
+++ b/apps/react-workshop/src/Label.stories.tsx
@@ -29,10 +29,10 @@ export const Basic = () => {
 export const Inline = () => {
   return (
     <InputGrid labelPlacement='inline'>
-      <Label htmlFor='text-input' displayStyle='inline' required>
+      <Label displayStyle='inline' required>
         Name
       </Label>
-      <Input id='text-input' defaultValue='James Bond' required />
+      <Input defaultValue='James Bond' required />
     </InputGrid>
   );
 };

--- a/apps/website/src/content/docs/inputgrid.mdx
+++ b/apps/website/src/content/docs/inputgrid.mdx
@@ -29,6 +29,24 @@ You can use `labelPlacement` prop to switch placement of the label to inline.
   <AllExamples.InputGridInlineExample client:load />
 </LiveExample>
 
+## Accessibility
+
+To provide the best experience to all users, it is recommended to associate the label with the form field (e.g. using `htmlFor` and `id` attributes) and the form field with the message (e.g. using [`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)). React's [`useId`](https://react.dev/reference/react/useId) hook can be used to generate component-level unique ids.
+
+```jsx
+const idPrefix = useId();
+const inputId = `${idPrefix}-input`;
+const messageId = `${idPrefix}-message`;
+
+<InputGrid>
+  <Label htmlFor={inputId}>Label</Label>
+  <Input id={inputId} aria-describedby={messageId} />
+  <StatusMessage id={messageId}>Hint message</StatusMessage>
+</InputGrid>;
+```
+
+If the labels, form fields and message passed as children have not been explicitly associated, then `InputGrid` will attempt to associate them automatically as a fallback. This is done by looping through the children and cloning them with the appropriate props. However this fallback approach is not foolproof and may not work in all cases (for example, it will break if you have wrapper elements around your labels or inputs), so make sure you test your final UI and explicitly associate the children if needed.
+
 ## Props
 
 <PropsTable path='@itwin/itwinui-react/esm/core/InputGrid/InputGrid.d.ts' />

--- a/examples/FileUpload.wrappinginput.tsx
+++ b/examples/FileUpload.wrappinginput.tsx
@@ -16,6 +16,7 @@ export default () => {
       }}
     >
       <LabeledInput
+        aria-label='Message'
         placeholder='Type a message'
         style={{
           width: '100%',

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInputContainer.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInputContainer.tsx
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { StatusMessage } from '../StatusMessage/StatusMessage.js';
-import { InputContainer, useSafeContext, Box } from '../utils/index.js';
+import {
+  InputContainer,
+  useSafeContext,
+  InputWithIcon,
+} from '../utils/index.js';
 import type {
   InputContainerProps,
   PolymorphicForwardRefComponent,
@@ -38,7 +42,7 @@ export const ComboBoxInputContainer = React.forwardRef(
         {...rest}
         id={id}
       >
-        <Box className='iui-input-with-icon'>{children}</Box>
+        <InputWithIcon>{children}</InputWithIcon>
       </InputContainer>
     );
   },

--- a/packages/itwinui-react/src/core/InputGrid/InputGrid.test.tsx
+++ b/packages/itwinui-react/src/core/InputGrid/InputGrid.test.tsx
@@ -8,6 +8,11 @@ import * as React from 'react';
 import { InputGrid } from './InputGrid.js';
 import { StatusMessage } from '../StatusMessage/StatusMessage.js';
 import { Label } from '../Label/Label.js';
+import { Input } from '../Input/Input.js';
+import { ComboBox } from '../ComboBox/ComboBox.js';
+import { InputWithDecorations } from '../InputWithDecorations/InputWithDecorations.js';
+import { Textarea } from '../Textarea/Textarea.js';
+import { Select } from '../Select/Select.js';
 
 const assertBaseElement = (container: HTMLElement) => {
   const inputContainer = container.querySelector('.iui-input-grid');
@@ -53,4 +58,58 @@ it('should take class and style', () => {
   ) as HTMLElement;
   expect(inputContainer).toHaveClass('iui-input-grid my-class');
   expect(inputContainer.style.width).toBe('50px');
+});
+
+describe.each([false, true])('should associate label and message', (hasIds) => {
+  it.each`
+    Component                     | name
+    ${Input}                      | ${'Input'}
+    ${Textarea}                   | ${'Textarea'}
+    ${InputWithDecorations.Input} | ${'InputWithDecorations.Input'}
+    ${'input'}                    | ${'input'}
+    ${'textarea'}                 | ${'textarea'}
+    ${'select'}                   | ${'select'}
+  `(`with $name ${hasIds ? '(has user ids)' : ''}`, ({ Component }) => {
+    const { container } = render(
+      <InputGrid>
+        <Label id={hasIds ? 'id1' : undefined}>The label</Label>
+        {Component === InputWithDecorations.Input ? (
+          <InputWithDecorations>
+            <Component id={hasIds ? 'id2' : undefined} />
+          </InputWithDecorations>
+        ) : (
+          <Component id={hasIds ? 'id2' : undefined} />
+        )}
+        <StatusMessage id={hasIds ? 'id3' : undefined}>
+          The message
+        </StatusMessage>
+      </InputGrid>,
+    );
+
+    const input = container.querySelector(
+      'input, textarea, select',
+    ) as HTMLElement;
+    expect(input).toHaveAccessibleName('The label');
+    expect(input).toHaveAccessibleDescription('The message');
+  });
+
+  it.each`
+    Component   | name
+    ${ComboBox} | ${'ComboBox'}
+    ${Select}   | ${'Select'}
+  `(`with $name ${hasIds ? '(has user ids)' : ''}`, ({ Component }) => {
+    const { container } = render(
+      <InputGrid>
+        <Label id={hasIds ? 'id1' : undefined}>The label</Label>
+        <Component id={hasIds ? 'id2' : undefined} options={[]} />
+        <StatusMessage id={hasIds ? 'id3' : undefined}>
+          The message
+        </StatusMessage>
+      </InputGrid>,
+    );
+
+    const combobox = container.querySelector('[role=combobox]') as HTMLElement;
+    expect(combobox).toHaveAccessibleName('The label');
+    expect(combobox).toHaveAccessibleDescription('The message');
+  });
 });

--- a/packages/itwinui-react/src/core/InputGrid/InputGrid.tsx
+++ b/packages/itwinui-react/src/core/InputGrid/InputGrid.tsx
@@ -3,9 +3,21 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Box } from '../utils/index.js';
+import {
+  Box,
+  InputWithIcon,
+  cloneElementWithRef,
+  useId,
+} from '../utils/index.js';
 import cx from 'classnames';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
+import { Label } from '../Label/Label.js';
+import { Input } from '../Input/Input.js';
+import { Textarea } from '../Textarea/Textarea.js';
+import { StatusMessage } from '../StatusMessage/StatusMessage.js';
+import { InputWithDecorations } from '../InputWithDecorations/InputWithDecorations.js';
+import { ComboBox } from '../ComboBox/ComboBox.js';
+import { Select } from '../Select/Select.js';
 
 type InputGridOwnProps = {
   /**
@@ -21,19 +33,28 @@ type InputGridOwnProps = {
 //-------------------------------------------------------------------------------
 
 /**
- * InputGrid component is used to display inputs (input, textarea, select)
+ * InputGrid component is used to display form fields (input, textarea, select)
  * with label and/or status message
  *
- * @usage
+ * Form fields are automatically associated with the label and status message for
+ * better accessibility.
  *
+ * @example
  * <InputGrid>
- *   <Label htmlFor='input-1'>This is label</Label>
- *   <Input id='input-1'/>
- *   <StatusMessage>This is message</StatusMessage>
+ *   <Label>This is a label</Label>
+ *   <Input />
+ *   <StatusMessage>This is a message</StatusMessage>
  * </InputGrid>
  */
 export const InputGrid = React.forwardRef((props, ref) => {
-  const { children, className, labelPlacement = undefined, ...rest } = props;
+  const {
+    children: childrenProp,
+    className,
+    labelPlacement = undefined,
+    ...rest
+  } = props;
+
+  const children = useChildrenWithIds(childrenProp);
 
   return (
     <Box
@@ -46,6 +67,213 @@ export const InputGrid = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', InputGridOwnProps>;
+
+//-------------------------------------------------------------------------------
+
+/**
+ * Ensures that label, input and message are properly associated
+ * with each other, for accessibility purposes.
+ *
+ * - `Select` will be associated with label using `aria-labelledby`
+ * - Other inputs will be associated with label using `htmlFor`
+ * - Message will be associated with input/select using `aria-describedby`
+ */
+const useChildrenWithIds = (children: React.ReactNode) => {
+  const { labelId, inputId, messageId } = useSetup(children);
+
+  return React.useMemo(
+    () =>
+      React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) {
+          return child;
+        }
+
+        if (child.type === Label || child.type === 'label') {
+          return cloneElementWithRef(child, (child) => ({
+            ...child.props,
+            htmlFor: child.props.htmlFor || inputId,
+            id: child.props.id || labelId,
+          }));
+        }
+
+        if (child.type === StatusMessage) {
+          return cloneElementWithRef(child, (child) => ({
+            ...child.props,
+            id: child.props.id || messageId,
+          }));
+        }
+
+        if (
+          isInput(child) ||
+          child.type === InputWithDecorations ||
+          child.type === InputWithIcon
+        ) {
+          return handleCloningInputs(child, {
+            labelId,
+            inputId,
+            messageId,
+          });
+        }
+
+        return child;
+      }),
+    [children, inputId, labelId, messageId],
+  );
+};
+
+//-------------------------------------------------------------------------------
+
+/**
+ * Setup/prerequisite for `useChildrenWithIds` to gather information from children.
+ *
+ * @returns the following ids (prefers id from props, otherwise generates one)
+ *  - `labelId`
+ *  - `inputId`
+ *  - `messageId`
+ */
+const useSetup = (children: React.ReactNode) => {
+  const idPrefix = useId();
+
+  let labelId: string | undefined;
+  let inputId: string | undefined;
+  let messageId: string | undefined;
+
+  let hasLabel = false;
+  let hasSelect = false;
+
+  const findInputId = (child: React.ReactNode) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+    // ComboBox input id is passed through `inputProps`
+    if (child.type === ComboBox) {
+      return child.props.inputProps?.id || `${idPrefix}--input`;
+    }
+    // Select input id would be passed through `triggerProps`, but we don't even
+    // need it because, unlike other inputs, it gets labelled using `aria-labelledby`
+    else if (child.type !== Select) {
+      return child.props.id || `${idPrefix}--input`;
+    }
+  };
+
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+
+    if (child.type === Label || child.type === 'label') {
+      hasLabel = true;
+      labelId ||= child.props.id || `${idPrefix}--label`;
+    }
+
+    if (child.type === StatusMessage) {
+      messageId ||= child.props.id || `${idPrefix}--message`;
+    }
+
+    if (child.type === InputWithDecorations || child.type === InputWithIcon) {
+      React.Children.forEach(child.props.children, (child) => {
+        if (isInput(child)) {
+          inputId ||= findInputId(child);
+        }
+      });
+    } else if (isInput(child)) {
+      inputId ||= findInputId(child);
+    }
+
+    if (child.type === Select) {
+      hasSelect = true;
+    }
+  });
+
+  return {
+    labelId: hasSelect ? labelId : undefined, // only need labelId for Select
+    inputId: hasLabel && !hasSelect ? inputId : undefined, // only need inputId for labeled inputs (not Select)
+    messageId,
+  } as const;
+};
+
+//-------------------------------------------------------------------------------
+
+/**
+ * Handles regular inputs, plus `InputWithDecorations`, `InputWithIcon`, `ComboBox` and `Select`.
+ */
+const handleCloningInputs = (
+  child: React.ReactElement,
+  {
+    labelId,
+    inputId,
+    messageId,
+  }: {
+    labelId: string | undefined;
+    inputId: string | undefined;
+    messageId: string | undefined;
+  },
+) => {
+  const inputProps = (props: Record<string, unknown> = {}) => {
+    // Concatenate aria-describedby from props and from StatusMessage
+    const ariaDescribedBy = [props['aria-describedby'], messageId]
+      .filter(Boolean)
+      .join(' ');
+
+    return {
+      ...props,
+      ...(child.type !== Select && { id: props.id || inputId }),
+      'aria-describedby': ariaDescribedBy?.trim() || undefined,
+    };
+  };
+
+  const cloneInput = (child: React.ReactElement) => {
+    if (child.type === ComboBox) {
+      return cloneElementWithRef(child, (child) => ({
+        inputProps: inputProps(child.props.inputProps),
+      }));
+    }
+
+    if (child.type === Select) {
+      return cloneElementWithRef(child, (child) => ({
+        triggerProps: {
+          ...{ 'aria-labelledby': labelId },
+          ...inputProps(child.props.triggerProps),
+        },
+      }));
+    }
+
+    return cloneElementWithRef(child, (child) => inputProps(child.props));
+  };
+
+  if (child.type === InputWithDecorations || child.type === InputWithIcon) {
+    return cloneElementWithRef(child, (child) => ({
+      children: React.Children.map(
+        child.props.children,
+        (child: React.ReactNode) => {
+          if (React.isValidElement(child) && isInput(child)) {
+            return cloneInput(child);
+          }
+          return child;
+        },
+      ),
+    }));
+  }
+
+  return cloneInput(child);
+};
+
+//-------------------------------------------------------------------------------
+
+/** @returns true if `child` is a form element that can be associated with a label using id  */
+const isInput = (child: React.ReactNode): boolean => {
+  return (
+    React.isValidElement(child) &&
+    (child.type === 'input' ||
+      child.type === 'textarea' ||
+      child.type === 'select' ||
+      child.type === Input ||
+      child.type === Textarea ||
+      child.type === InputWithDecorations.Input ||
+      child.type === Select || // contains Select.triggerProps
+      child.type === ComboBox) // contains ComboBox.inputProps
+  );
+};
 
 //-------------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
+++ b/packages/itwinui-react/src/core/LabeledInput/LabeledInput.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Input } from '../Input/Input.js';
-import { Box, StatusIconMap, useId } from '../utils/index.js';
+import { InputWithIcon, StatusIconMap } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { InputGrid } from '../InputGrid/InputGrid.js';
 import { StatusMessage } from '../StatusMessage/StatusMessage.js';
@@ -68,8 +68,6 @@ export type LabeledInputProps = {
  * <LabeledInput status='negative' label='Negative' />
  */
 export const LabeledInput = React.forwardRef((props, ref) => {
-  const uid = useId();
-
   const {
     disabled = false,
     label,
@@ -83,7 +81,6 @@ export const LabeledInput = React.forwardRef((props, ref) => {
     inputWrapperProps,
     displayStyle = 'default',
     required = false,
-    id = uid,
     ...rest
   } = props;
 
@@ -101,24 +98,14 @@ export const LabeledInput = React.forwardRef((props, ref) => {
           as='label'
           required={required}
           disabled={disabled}
-          htmlFor={id}
           {...labelProps}
         >
           {label}
         </Label>
       )}
 
-      <Box
-        {...inputWrapperProps}
-        className={cx('iui-input-with-icon', inputWrapperProps?.className)}
-      >
-        <Input
-          disabled={disabled}
-          required={required}
-          id={id}
-          ref={ref}
-          {...rest}
-        />
+      <InputWithIcon {...inputWrapperProps}>
+        <Input disabled={disabled} required={required} ref={ref} {...rest} />
         {shouldShowIcon && (
           <Icon
             fill={status}
@@ -128,7 +115,7 @@ export const LabeledInput = React.forwardRef((props, ref) => {
             {icon}
           </Icon>
         )}
-      </Box>
+      </InputWithIcon>
       {typeof message === 'string' ? (
         <StatusMessage
           status={status}

--- a/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
+++ b/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 
 import { Select } from '../Select/Select.js';
 import type { SelectProps } from '../Select/Select.js';
-import { useId } from '../utils/index.js';
 import type { LabeledInputProps } from '../LabeledInput/LabeledInput.js';
 import { StatusMessage } from '../StatusMessage/StatusMessage.js';
 import { InputGrid } from '../InputGrid/InputGrid.js';
@@ -121,15 +120,12 @@ export const LabeledSelect = React.forwardRef(
       displayStyle = 'default',
       style,
       required = false,
-      triggerProps,
       wrapperProps,
       labelProps,
       messageContentProps,
       messageIconProps,
       ...rest
     } = props;
-
-    const labelId = `${useId()}-label`;
 
     return (
       <InputGrid
@@ -142,7 +138,6 @@ export const LabeledSelect = React.forwardRef(
             as='div'
             required={required}
             disabled={disabled}
-            id={labelId}
             {...labelProps}
           >
             {label}
@@ -154,10 +149,6 @@ export const LabeledSelect = React.forwardRef(
           style={style}
           {...rest}
           ref={forwardedRef}
-          triggerProps={{
-            'aria-labelledby': labelId,
-            ...triggerProps,
-          }}
         />
         {typeof message === 'string' ? (
           <StatusMessage

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -16,6 +16,7 @@ import {
   useMergedRefs,
   SvgCheckmark,
   useLatestRef,
+  InputWithIcon,
 } from '../utils/index.js';
 import type { CommonProps } from '../utils/index.js';
 import { SelectTag } from './SelectTag.js';
@@ -244,8 +245,6 @@ export const Select = React.forwardRef(
       size,
       itemRenderer,
       selectedItemRenderer,
-      className,
-      style,
       menuClassName,
       menuStyle,
       multiple = false,
@@ -370,9 +369,7 @@ export const Select = React.forwardRef(
 
     return (
       <>
-        <Box
-          className={cx('iui-input-with-icon', className)}
-          style={style}
+        <InputWithIcon
           {...rest}
           ref={useMergedRefs(popover.refs.setPositionReference, forwardedRef)}
         >
@@ -444,7 +441,7 @@ export const Select = React.forwardRef(
           {multiple ? (
             <AutoclearingHiddenLiveRegion text={liveRegionSelection} />
           ) : null}
-        </Box>
+        </InputWithIcon>
 
         {popover.open && (
           <Portal>

--- a/packages/itwinui-react/src/core/utils/components/InputWithIcon.tsx
+++ b/packages/itwinui-react/src/core/utils/components/InputWithIcon.tsx
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { polymorphic } from '../functions/polymorphic.js';
+
+/** @private */
+export const InputWithIcon = polymorphic.div('iui-input-with-icon');
+InputWithIcon.displayName = 'InputWithIcon';

--- a/packages/itwinui-react/src/core/utils/components/index.ts
+++ b/packages/itwinui-react/src/core/utils/components/index.ts
@@ -6,6 +6,7 @@ export * from './Resizer.js';
 export * from './FocusTrap.js';
 export * from './InputContainer.js';
 export * from './InputFlexContainer.js';
+export * from './InputWithIcon.js';
 export * from './WithCSSTransition.js';
 export * from './MiddleTextTruncation.js';
 export * from './VirtualScroll.js';


### PR DESCRIPTION
## Changes

If a user forgets to connect `Label`/`Input`/`StatusMessage` inside `InputGrid`, we will now handle it for them by cloning `children`.

Since `InputGrid` is also used internally in `LabeledInput`/`LabeledSelect`, I was able to remove some of the explicit id handling in those components.

Lastly, the `StatusMessage` being connected via `aria-describedby` is brand new functionality that we weren't handling before at all, so this is a net improvement for all uses of the `message` prop.

Implementation notes:
- Looping/cloning children is generally [discouraged](https://react.dev/reference/react/Children) and indeed can be quite brittle (breaks if there are wrapper divs anywhere), but it is still a very useful fallback and just a convenient thing.
- It helps ease the v2→v3 migration specifically for the more complex `LabeledInput`→`InputWithDecorations` scenarios (discovered [here](https://github.com/iTwin/iTwinUI-migration-tool/pull/96#discussion_r1446653151)) and especially for React 17 users (who don't have access to `useId`).
- I created an internal `InputWithIcon` component to help with narrowing down children. It's starting to get a little confusing now along with the existing `InputGrid`, `InputContainer`, `InputFlexContainer`, `InputWithDecorations`, `InputGroup` components. We should go through all of them (in a future PR) and try to remove some of them.

## Testing

Made sure existing unit and axe tests pass. Added new unit tests. Also tested a few different permutations of the following code in Vite playground:

```jsx
<InputGrid>
  <Label>Label</Label>
  <Input />
  <StatusMessage>Hint message</StatusMessage>
</InputGrid>
```

Tested the components in screen-readers and the browser's accessibility tree to make sure labels and message are correctly associated and announced.

Works fine in NVDA, but VoiceOver has a bug where it [doesn't automatically announce descriptions on text fields](https://bugs.webkit.org/show_bug.cgi?id=262895#c6).

<details><summary>NVDA 2023.3.1 + Firefox 121</summary>

![image](https://github.com/iTwin/iTwinUI/assets/9084735/92bb5a07-d402-485e-9cb4-c7785878776b)

![image](https://github.com/iTwin/iTwinUI/assets/9084735/25832ba2-5c9c-40cc-b3ec-720c93d14caf)

</details> 

<details><summary>VoiceOver + Safari 17.0</summary>
<p>

![image](https://github.com/iTwin/iTwinUI/assets/9084735/7aef3bcb-5e83-48d6-8250-0575663f4ac3)

![image](https://github.com/iTwin/iTwinUI/assets/9084735/fad47cec-7aa7-4fba-8bb9-e68bd8d1cd1f)

![image](https://github.com/iTwin/iTwinUI/assets/9084735/872e14fd-2008-48e3-b1ed-0973f50f45c4)

</p>
</details> 

## Docs

Added changesets.

Updated `InputGrid` documentation and jsdocs.