### PR TITLE
fix menu item focus outline in firefox

### DIFF
--- a/.changeset/healthy-windows-whisper.md
+++ b/.changeset/healthy-windows-whisper.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed a Firefox-specific bug where focus outlines were not appearing correctly around menu items (e.g. inside `ComboBox` and `Select`).

--- a/.changeset/healthy-windows-whisper.md
+++ b/.changeset/healthy-windows-whisper.md
@@ -3,4 +3,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed a Firefox-specific bug where focus outlines were not appearing correctly around menu items (e.g. inside `ComboBox` and `Select`).
+Fixed a Firefox-specific bug where focus outlines were not appearing correctly around menu items inside `ComboBox`.

--- a/packages/itwinui-css/src/menu/mixins.scss
+++ b/packages/itwinui-css/src/menu/mixins.scss
@@ -49,7 +49,8 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
     margin-block-start: -1px;
   }
 
-  &:where([data-iui-actionable='true'], .iui-menu-item, :has(.iui-link-action:hover)):where(:hover) {
+  &:where([data-iui-actionable='true'], .iui-menu-item):where(:hover),
+  &:where(:has(.iui-link-action):hover) {
     cursor: pointer;
     background-color: var(--iui-color-background-hover);
   }
@@ -90,7 +91,8 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
     --_iui-list-item-description-color: var(--iui-color-text-disabled);
   }
 
-  &:where(:focus-visible, .iui-focused, [data-iui-focused='true'], :has(.iui-link-action:focus-visible)) {
+  &:where(:focus-visible, .iui-focused, [data-iui-focused='true']),
+  &:where(:has(.iui-link-action:focus-visible)) {
     outline: $iui-active-outline;
     outline-offset: -1px;
     z-index: 2;


### PR DESCRIPTION
## Changes

Firefox 121 shipped with `:has` support but has a [nasty bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1874042) where `:has` breaks the other selectors used inside `:is` or `:where`. This bug specifically affected `MenuItem` which uses `:has` inside `:where` for focus outlines.

This PR moves the `:has` part out of `:where` which avoids the Firefox bug.

## Testing

Verified that focus outlines appear correctly.

| Before | After |
| --- | --- |
| <p>https://github.com/iTwin/iTwinUI/assets/9084735/1a9ec520-a4fb-415e-9ead-72ed8b203a47</p> | <p>https://github.com/iTwin/iTwinUI/assets/9084735/1a5b63fc-08a1-4132-a2a7-f8fdbfae9974</p> |

Bug can repro'd in live storybook using keyboard ([ComboBox](https://itwin.github.io/iTwinUI/react/?story=combobox--basic))

## Docs

Added changeset.