### PR TITLE
Fix autoscale icon story

### DIFF
--- a/apps/react-workshop/src/Icon.stories.tsx
+++ b/apps/react-workshop/src/Icon.stories.tsx
@@ -85,7 +85,7 @@ Sizes.decorators = Statuses.decorators;
 
 export const Autoscale = () => {
   return (
-    <Icon>
+    <Icon size='auto'>
       <SvgPlaceholder />
     </Icon>
   );


### PR DESCRIPTION
## Changes

- Add missing `size='auto'` to `<Icon>`.

## Testing

- Built locally and tested in the browser.

## Docs

n/a