### PR TITLE
decrease `LinkAction` specificity

### DIFF
--- a/.changeset/plenty-garlics-laugh.md
+++ b/.changeset/plenty-garlics-laugh.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`LinkAction` will no longer override styles from other components (such as `Anchor`).

--- a/.changeset/spicy-rocks-applaud.md
+++ b/.changeset/spicy-rocks-applaud.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Decreased specificity of `iui-link-action` and `iui-link-box` so that they do not override styles from other classes applied on the same element.

--- a/packages/itwinui-css/src/utils/link-action.scss
+++ b/packages/itwinui-css/src/utils/link-action.scss
@@ -30,10 +30,10 @@
 
 // ----------------------------------------------------------------------------
 
-.iui-link-box {
+:where(.iui-link-box) {
   @include iui-link-box;
 }
 
-.iui-link-action {
+:where(.iui-link-action) {
   @include iui-link-action;
 }


### PR DESCRIPTION
## Changes

Follow-up to #1762 where I ran into the issue of `LinkAction` overriding other styles when used with the `as` prop.

This PR is a "quick fix" that addresses the problem today by nullifying the specificity (thus giving priority to anything else).

A "proper" solution would likely involve using nested cascade layers to full control the order of styles, but that can happen in the future.

## Testing

Tested that this code preserves `Anchor` styling:

```jsx
<LinkBox>
  <LinkAction as={Anchor} href='#'>Hello</LinkAction>
</LinkBox>
```

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/d18719a3-3928-4499-b0e7-3042ab376cfd) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/455eb9c4-060a-4cf2-b6fc-7446e67550d3) |

## Docs

N/A. Added changesets.