### PR TITLE
expose `ListItem.Action` to wrap `LinkAction`

### DIFF
--- a/.changeset/silent-knives-search.md
+++ b/.changeset/silent-knives-search.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added new `ListItem.Action` component for rendering links inside `ListItem`s while ensuring that clicking anywhere on the list item triggers the link. This component is a wrapper over the existing `LinkAction` component.

--- a/apps/website/src/content/docs/linkaction.mdx
+++ b/apps/website/src/content/docs/linkaction.mdx
@@ -13,7 +13,7 @@ group: utilities
 
 This component is useful in a wide range of situations when you need to increase the clickable area of an element (e.g. a card, a list item, etc.) without compromising semantics. This means you can keep the link text concise and still make the entire area clickable, even if it includes other elements or extra padding.
 
-`LinkAction` is used internally in [`Tile`](tile#actionable) and [`ListItem`](list#with-linkaction) components, and is also available for use in external components.
+`LinkAction` is used internally in [`Tile`](tile#actionable) and [`ListItem`](list#with-listitemaction) components, and is also available for use in external components.
 
 ## Usage
 

--- a/apps/website/src/content/docs/list.mdx
+++ b/apps/website/src/content/docs/list.mdx
@@ -32,7 +32,7 @@ There is also a `size` prop which can be set to `'large'` to ensure that all ite
 
 `ListItem` has an `actionable` prop which can be set to true to provide hover styling.
 
-Please note that this prop only provides the hover styling and does nothing else. Usually you want to combine this prop either with `LinkAction` (which lets you use an anchor or a button) or with a more advanced component, such as [`Select`](select), which will do many additional things like set `role=option`, manage roving tabindex, and handle arrow-key navigation.
+Please note that this prop only provides the hover styling and does nothing else. Usually you want to combine this prop either with `ListItem.Action` (which lets you use an anchor or a button) or with a more advanced component, such as [`Select`](select), which will do many additional things like set `role=option`, manage roving tabindex, and handle arrow-key navigation.
 
 ### With `ListItem.Action`
 
@@ -42,7 +42,7 @@ When `ListItem` contains a link, it is recommended to use `ListItem.Action` inst
   <AllExamples.ListLinksExample client:idle />
 </LiveExample>
 
-`LinkAction` supports the polymorphic `as` prop so it can also be rendered as a `<button>` if it performs an action on the same page.
+`ListItem.Action` supports the polymorphic `as` prop so it can also be rendered as a `<button>` if it performs an action on the same page.
 
 ### Interactive states
 

--- a/apps/website/src/content/docs/list.mdx
+++ b/apps/website/src/content/docs/list.mdx
@@ -34,9 +34,9 @@ There is also a `size` prop which can be set to `'large'` to ensure that all ite
 
 Please note that this prop only provides the hover styling and does nothing else. Usually you want to combine this prop either with `LinkAction` (which lets you use an anchor or a button) or with a more advanced component, such as [`Select`](select), which will do many additional things like set `role=option`, manage roving tabindex, and handle arrow-key navigation.
 
-### With `LinkAction`
+### With `ListItem.Action`
 
-When `ListItem` contains a link, it is recommended to use [`LinkAction`](linkaction) instead of a regular anchor link. This increases the tap target size (clickable area) of the link to include the padding from list item, and ensures that there is proper hover and focus styling.
+When `ListItem` contains a link, it is recommended to use `ListItem.Action` instead of a regular anchor link. This component is a wrapper over [`LinkAction`](linkaction) which increases the tap target size (clickable area) of the link to include the padding from list item, and ensures that there is proper hover and focus styling.
 
 <LiveExample src='List.links.tsx'>
   <AllExamples.ListLinksExample client:idle />

--- a/examples/List.links.tsx
+++ b/examples/List.links.tsx
@@ -3,25 +3,25 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { List, ListItem, LinkAction } from '@itwin/itwinui-react';
+import { List, ListItem } from '@itwin/itwinui-react';
 
 export default () => {
   return (
     <List>
       <ListItem actionable>
-        <LinkAction href='https://itwinui.bentley.com/docs/button'>
+        <ListItem.Action href='https://itwinui.bentley.com/docs/button'>
           Buttons
-        </LinkAction>
+        </ListItem.Action>
       </ListItem>
       <ListItem actionable>
-        <LinkAction href='https://itwinui.bentley.com/docs/input'>
+        <ListItem.Action href='https://itwinui.bentley.com/docs/input'>
           Inputs
-        </LinkAction>
+        </ListItem.Action>
       </ListItem>
       <ListItem actionable>
-        <LinkAction href='https://itwinui.bentley.com/docs/dialog'>
+        <ListItem.Action href='https://itwinui.bentley.com/docs/dialog'>
           Dialog
-        </LinkAction>
+        </ListItem.Action>
       </ListItem>
     </List>
   );

--- a/packages/itwinui-react/src/core/List/ListItem.tsx
+++ b/packages/itwinui-react/src/core/List/ListItem.tsx
@@ -128,7 +128,7 @@ export const ListItem = Object.assign(ListItemComponent, {
    */
   Description: ListItemDescription,
   /**
-   * Wrapper over [LinkAction](https://dev-itwinui.bentley.com/docs/linkaction) which allows rendering a link inside a ListItem.
+   * Wrapper over [LinkAction](https://itwinui.bentley.com/docs/linkaction) which allows rendering a link inside a ListItem.
    * This ensures that clicking anywhere on the ListItem will trigger the link.
    *
    * @example

--- a/packages/itwinui-react/src/core/List/ListItem.tsx
+++ b/packages/itwinui-react/src/core/List/ListItem.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import { polymorphic, Box } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
+import { LinkAction } from '../LinkAction/LinkAction.js';
 
 const ListItemComponent = React.forwardRef((props, ref) => {
   const {
@@ -79,6 +80,11 @@ const ListItemDescription = polymorphic('iui-list-item-description');
 ListItemDescription.displayName = 'ListItem.Description';
 
 // ----------------------------------------------------------------------------
+
+const ListItemAction = LinkAction;
+ListItemAction.displayName = 'ListItem.Action';
+
+// ----------------------------------------------------------------------------
 // Exported compound component
 
 /**
@@ -121,4 +127,14 @@ export const ListItem = Object.assign(ListItemComponent, {
    * </ListItem>
    */
   Description: ListItemDescription,
+  /**
+   * Wrapper over [LinkAction](https://dev-itwinui.bentley.com/docs/linkaction) which allows rendering a link inside a ListItem.
+   * This ensures that clicking anywhere on the ListItem will trigger the link.
+   *
+   * @example
+   * <ListItem>
+   *  <ListItem.Action href='https://example.com'>Example link</ListItem.Action>
+   * </ListItem>
+   */
+  Action: ListItemAction,
 });


### PR DESCRIPTION
## Changes

follow-up to https://github.com/iTwin/iTwinUI/pull/1762#discussion_r1443202152

## Testing

N/A. The new component is a direct reference to the old one, so no tests needed.

## Docs

Updated docs and added changeset.