### PR TITLE
update `LinkAction` docs to show secondary link

### DIFF
--- a/apps/website/src/content/docs/linkaction.mdx
+++ b/apps/website/src/content/docs/linkaction.mdx
@@ -31,21 +31,21 @@ This component consists of two parts:
 
 Similar to the [`Anchor`](anchor) component, `LinkAction` supports the polymorphic `as` prop, which can be used to render a different link component (e.g. from a client-side router) or a `"button"` (e.g. when you want to trigger an action within the same page, rather than a page navigation).
 
+### Secondary actions
+
+If your container includes other elements that should be clickable, you can either manually give them a higher z-index, or simply wrap them in nested `LinkBox`es.
+
+In the following example, clicking anywhere on the card will navigate to the primary link, but clicking on the secondary link will still navigate to the second link.
+
+<LiveExample src='LinkAction.nested.tsx'>
+  <AllExamples.LinkActionNestedExample client:load />
+</LiveExample>
+
 ## Technical explanation
 
 The implementation of this component is based on [the pseudo-content trick](https://inclusive-components.design/cards/#thepseudocontenttrick), which makes the `LinkAction`'s `::after` pseudo-element expand to fill up all the available space of the `LinkBox` component. A side-effect of this is that the text inside the `LinkBox` will not be selectable, but this is usually not a problem.
 
-If your container includes other elements that should be clickable, you can set `position: relative` on them or give them a higher z-index. This will make them appear on top of the pseudo-element and therefore receive the click event instead of the primary `LinkAction`.
-
-```jsx
-<LinkBox>
-  <LinkAction href='#'>Primary link</LinkAction>
-
-  <a href='#' style={{ position: 'relative' }}>
-    Secondary link
-  </a>
-</LinkBox>
-```
+When your container has a secondary action, wrapping it in a nested `LinkBox` gives it `position: relative`, which makes it appear on top of the pseudo-element and therefore receive the click event instead of the primary `LinkAction`.
 
 ### Props
 

--- a/examples/LinkAction.nested.tsx
+++ b/examples/LinkAction.nested.tsx
@@ -3,27 +3,16 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import {
-  Anchor,
-  LinkAction,
-  LinkBox,
-  Surface,
-  Text,
-} from '@itwin/itwinui-react';
+import { Anchor, LinkAction, LinkBox, Surface } from '@itwin/itwinui-react';
 
 export default () => {
   return (
     <LinkBox as={Surface}>
-      <Surface.Header>
-        <Text as='h2' variant='subheading'>
-          <LinkAction as={Anchor} href='https://www.example.com'>
-            Stadium
-          </LinkAction>
-        </Text>
-      </Surface.Header>
-      <Surface.Body isPadded style={{ maxWidth: '40ch' }}>
-        National stadium in Singapore. Features landscape details and a metro
-        station.
+      <Surface.Body isPadded>
+        <LinkAction href='https://example.com'>Primary link</LinkAction>
+        <LinkBox>
+          <Anchor href='https://mdn.io'>Secondary link</Anchor>
+        </LinkBox>
       </Surface.Body>
     </LinkBox>
   );

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -722,6 +722,10 @@ import { default as LinkActionMainExampleRaw } from './LinkAction.main';
 const LinkActionMainExample = withThemeProvider(LinkActionMainExampleRaw);
 export { LinkActionMainExample };
 
+import { default as LinkActionNestedExampleRaw } from './LinkAction.nested';
+const LinkActionNestedExample = withThemeProvider(LinkActionNestedExampleRaw);
+export { LinkActionNestedExample };
+
 // ----------------------------------------------------------------------------
 
 import { default as ListMainExampleRaw } from './List.main';


### PR DESCRIPTION
## Changes

Another follow-up to #1762.

1. Updated the main example to make it look clickable (using `Anchor` which now takes priority, thanks to #1788). Addresses [this thread](https://github.com/iTwin/iTwinUI/pull/1762#discussion_r1440690501).
2. Added a live example to show secondary actions. This is achieved by simply nesting `LinkBox`es to create "holes"; no new component needed. Since `LinkBox` has `position: relative`, it appears above the rest of the content. Addresses [this thread](https://github.com/iTwin/iTwinUI/pull/1762#discussion_r1443149939).

## Testing

N/A. No code changes.

See [deploy preview](https://deploy-preview-1793--itwinui-previews.netlify.app/docs/linkaction).

## Docs

These *are* docs.