### PR TITLE
fix edit page link

### DIFF
--- a/apps/website/src/components/EditPageLink.astro
+++ b/apps/website/src/components/EditPageLink.astro
@@ -16,7 +16,7 @@ if (page === 'components') {
 }
 
 const repoUrl = 'https://github.com/iTwin/iTwinUI';
-const githubEditUrl = `${repoUrl}/edit/main/apps/website/src/pages/docs/${fileName}`;
+const githubEditUrl = `${repoUrl}/edit/main/apps/website/src/content/docs/${fileName}`;
 ---
 
 <a href={githubEditUrl} {...rest}>


### PR DESCRIPTION
## Changes

Small update to the github url (changed after we first migrated to content collections).

## Testing

Tested that the link correctly opens the associated source file on github.

## Docs

N/A