### PR TITLE
fix `Surface` alignment by not relying on `scrollbar-gutter`

### DIFF
--- a/.changeset/rude-rockets-occur.md
+++ b/.changeset/rude-rockets-occur.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-css': patch
+'@itwin/itwinui-react': patch
+---
+
+Fixed `Surface.Body` not being visually aligned with `Surface.Header` depending on scrollbar visibility.

--- a/packages/itwinui-css/src/surface/surface.scss
+++ b/packages/itwinui-css/src/surface/surface.scss
@@ -34,12 +34,13 @@ $surface-padding-with-gutter: var(--iui-size-2xs);
   overflow-y: auto;
 
   &[data-iui-padded='true'] {
-    scrollbar-gutter: stable both-edges;
-    padding-inline: $surface-padding-with-gutter;
-    padding-block: $surface-padding;
+    padding: $surface-padding;
 
-    @supports not (scrollbar-gutter: stable) {
-      padding-inline: $surface-padding;
-    }
+    // Scrollbars might not always occupy space even with a stable gutter, so this can still
+    // result in (tolerable) differences on the right side, depending on scrollbar visibility.
+    // More importantly, the left side will remain aligned, because we are not using a gutter there.
+    // See: https://github.com/iTwin/iTwinUI/issues/1801
+    scrollbar-gutter: stable;
+    padding-inline-end: $surface-padding-with-gutter;
   }
 }


### PR DESCRIPTION
## Changes

Fixes #1801 

The main change is removing `both-edges` from the value of `scrollbar-gutter`. It's fine on the right side, but we cannot rely on it for alignment purposes on the left side.

I've added a code comment with a more detailed rationale. Also see my comment on the linked issue.

## Testing

Verified that the surface body and header stay aligned regardless of scrollbar visibility.

https://github.com/iTwin/iTwinUI/assets/9084735/8e838d05-6a81-4a01-b3df-fff164124ca7


## Docs

Added changeset.