### PR TITLE
Include docs link in `FileUploadTemplate` deprecation message

### DIFF
--- a/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadTemplate.tsx
@@ -41,7 +41,8 @@ type FileUploadTemplateProps = {
 };
 
 /**
- * @deprecated Use `FileUploadCard` instead.
+ * @deprecated Use [`FileUploadCard`](https://itwinui.bentley.com/docs/fileupload#fileuploadcard) instead.
+ *
  * Default template to be used with the `FileUpload` wrapper component.
  * Contains a hidden input with styled labels (customizable).
  * @example


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Based on https://github.com/iTwin/iTwinUI-migration-tool/pull/99#issuecomment-1875506489.

This small PR just adds a link to the [`FileUploadCard`](https://itwinui.bentley.com/docs/fileupload#fileuploadcard) docs site page in the `FileUploadTemplate` deprecation message.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A