### PR TITLE
use `LinkAction` inside `Tag`

### DIFF
--- a/.changeset/empty-geckos-joke.md
+++ b/.changeset/empty-geckos-joke.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`LinkAction` will now automatically render a `<button>` by default if no `href` is passed.

--- a/.changeset/four-years-beam.md
+++ b/.changeset/four-years-beam.md
@@ -1,5 +1,6 @@
 ---
 '@itwin/itwinui-css': minor
+'@itwin/itwinui-react': minor
 ---
 
 Removed unnecessary `Tag` styles, and added support for tags to be used as `<button>` elements.

--- a/.changeset/moody-turtles-vanish.md
+++ b/.changeset/moody-turtles-vanish.md
@@ -1,7 +1,0 @@
----
-'@itwin/itwinui-react': minor
----
-
-Removed unnecessary `Tag` styles, and added support for tags to be used as `<button>` elements.
-
-If an `onClick` prop is passed to `Tag`, it will be automatically rendered as a `<button>`. This prop is mutually exclusive with `onRemove`, to prevent outputting invalid markup (nested buttons).

--- a/apps/website/src/content/docs/linkaction.mdx
+++ b/apps/website/src/content/docs/linkaction.mdx
@@ -13,7 +13,7 @@ group: utilities
 
 This component is useful in a wide range of situations when you need to increase the clickable area of an element (e.g. a card, a list item, etc.) without compromising semantics. This means you can keep the link text concise and still make the entire area clickable, even if it includes other elements or extra padding.
 
-`LinkAction` is used internally in [`Tile`](tile#actionable), [`ListItem`](list#with-listitemaction), and [`ExpandableBlock`](expandableblock) components, and is also available for use in external components.
+`LinkAction` is used internally in other components ([`Tile`](tile#actionable), [`ListItem`](list#with-listitemaction), [`ExpandableBlock`](expandableblock), etc), and is also available for use in external components.
 
 ## Usage
 

--- a/apps/website/src/content/docs/linkaction.mdx
+++ b/apps/website/src/content/docs/linkaction.mdx
@@ -13,7 +13,7 @@ group: utilities
 
 This component is useful in a wide range of situations when you need to increase the clickable area of an element (e.g. a card, a list item, etc.) without compromising semantics. This means you can keep the link text concise and still make the entire area clickable, even if it includes other elements or extra padding.
 
-`LinkAction` is used internally in other components ([`Tile`](tile#actionable), [`ListItem`](list#with-listitemaction), [`ExpandableBlock`](expandableblock), etc), and is also available for use in external components.
+`LinkAction` is used internally in other components ([`Tile`](tile#actionable), [`ListItem`](list#with-listitemaction), [`ExpandableBlock`](expandableblock), etc.), and is also available for use in external components.
 
 ## Usage
 

--- a/apps/website/src/content/docs/tag.mdx
+++ b/apps/website/src/content/docs/tag.mdx
@@ -13,17 +13,13 @@ thumbnail: Tag
 
 Tags are user-generated keywords used to label, categorize, or organize items and files. A group of multiple tags is a standard way of labeling an item to make it easily discoverable by peers who may not know the exact title of said item. A single tag may be mapped to more than one project at once if these projects fit in similar categories. Tags may also be used as a way to filter out content; in that context, the tags are pre-existing, and users select tags that fit their search to narrow down the results.
 
-## Variants
-
-### Default
-
-Default tags can be added and removed by a user. Tags adapt their size to the length of the label inside, making it easier to tell them apart due to their different sizes.
+## Usage
 
 <LiveExample src='Tag.default.tsx'>
   <AllExamples.TagDefaultExample client:load />
 </LiveExample>
 
-### Basic
+### Basic tags
 
 Tags in the basic state are static and cannot be removed or edited by the user. No new tags can be added through this state either. This state is commonly seen in [tile](tile) metadata.
 
@@ -31,9 +27,22 @@ Tags in the basic state are static and cannot be removed or edited by the user. 
   <AllExamples.TagBasicExample client:load />
 </LiveExample>
 
-## Props
+### Props
 
 <PropsTable path={frontmatter.propsPath} />
+
+### Usage guidelines
+
+- Tags are meant to be used for display purposes. While interactivity is possible, it is not the primary use case.
+- Use [basic](#basic) tags when you need to make tags read-only.
+
+## Accessibility
+
+When the `onClick` prop is passed to `Tag`, it is automatically rendered as a `<button>` element. This gives the tag proper semantics and makes it keyboard interactable.
+
+When the `onRemove` prop is passed to `Tag`, a remove button is rendered inside the tag. This button has an `aria-label` set to `"Delete tag"`, which can be customized using the `removeButtonProps` prop.
+
+If both `onClick` and `onRemove` props are passed, then the tag label (rather than the tag itself) will be rendered as a button, to avoid invalid markup (button nested inside another button). This is achieved using the [`LinkAction`](linkaction) component.
 
 ## Tag container
 
@@ -71,9 +80,8 @@ The scrollable container is much like the truncating container, except it allows
 
 <PropsTable path={'@itwin/itwinui-react/esm/core/Tag/TagContainer.d.ts'} />
 
-## Usage
+### Usage guidelines
 
-- Use [basic](#basic) tags whenever you need to make tags read-only.
 - [Wrapping](#wrapping) tag containers are ideal for layouts with plenty of vertical space, in situations where seeing all the tags is necessary.
 - Use [truncating](#truncating) tag containers when you have limited space, and display of the full tags is not necessary.
 - [Scrollable](#scrollable) tag containers are a good choice when the space in a layout is limited, but viewing all the tags is essential.

--- a/apps/website/src/content/docs/tag.mdx
+++ b/apps/website/src/content/docs/tag.mdx
@@ -34,7 +34,7 @@ Tags in the basic state are static and cannot be removed or edited by the user. 
 ### Usage guidelines
 
 - Tags are meant to be used for display purposes. While interactivity is possible, it is not the primary use case.
-- Use [basic](#basic) tags when you need to make tags read-only.
+- Use [basic](#basic-tags) tags when you need to make tags read-only.
 
 ## Accessibility
 

--- a/packages/itwinui-react/src/core/LinkAction/LinkAction.test.tsx
+++ b/packages/itwinui-react/src/core/LinkAction/LinkAction.test.tsx
@@ -9,7 +9,9 @@ import { LinkBox, LinkAction } from './LinkAction.js';
 it('should render LinkBox and LinkAction in its most basic state', () => {
   const { container } = render(
     <LinkBox data-testid='link-box'>
-      <LinkAction data-testid='link-overlay'>Content</LinkAction>
+      <LinkAction href='#' data-testid='link-overlay'>
+        Content
+      </LinkAction>
     </LinkBox>,
   );
 
@@ -25,22 +27,29 @@ it('should render LinkBox and LinkAction in its most basic state', () => {
   expect(linkAction).toHaveAttribute('data-testid', 'link-overlay');
 });
 
-it('should render LinkAction as a button', () => {
-  const { container } = render(
-    <LinkBox data-test-id='link-box'>
-      <LinkAction as='button' data-test-id='link-overlay'>
-        Content
-      </LinkAction>
-    </LinkBox>,
-  );
-  expect(container.querySelector('div')).toHaveClass('iui-link-box');
-  expect(container.querySelector('button')).toHaveClass('iui-link-action');
-});
+it.each(['implicit', 'explicit'])(
+  'should render LinkAction as a button (%s)',
+  (implicitOrExplicit) => {
+    const as = implicitOrExplicit === 'implicit' ? undefined : 'button';
+
+    const { container } = render(
+      <LinkBox data-test-id='link-box'>
+        <LinkAction as={as as 'button'} data-test-id='link-overlay'>
+          Content
+        </LinkAction>
+      </LinkBox>,
+    );
+    expect(container.querySelector('div')).toHaveClass('iui-link-box');
+    expect(container.querySelector('button')).toHaveClass('iui-link-action');
+  },
+);
 
 it('should render LinkAction as a paragraph', () => {
   const { container } = render(
     <LinkBox as='p' data-test-id='link-box'>
-      <LinkAction data-test-id='link-overlay'>Content</LinkAction>
+      <LinkAction href='#' data-test-id='link-overlay'>
+        Content
+      </LinkAction>
     </LinkBox>,
   );
   expect(container.querySelector('p')).toHaveClass('iui-link-box');

--- a/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
+++ b/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
@@ -2,7 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import cx from 'classnames';
 import { polymorphic } from '../utils/functions/polymorphic.js';
+import type { PolymorphicForwardRefComponent } from '../utils/props.js';
+import { Box } from '../utils/components/index.js';
 
 /**
  * Polymorphic link action component.
@@ -14,7 +18,16 @@ import { polymorphic } from '../utils/functions/polymorphic.js';
  *   </Surface>
  * </LinkBox>
  */
-export const LinkAction = polymorphic.a('iui-link-action');
+export const LinkAction = React.forwardRef((props, forwardedRef) => {
+  return (
+    <Box
+      as={(!!props.href ? 'a' : 'button') as 'a'}
+      {...props}
+      className={cx('iui-link-action', props.className)}
+      ref={forwardedRef}
+    />
+  );
+}) as PolymorphicForwardRefComponent<'a'>;
 LinkAction.displayName = 'LinkAction';
 
 /**

--- a/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
+++ b/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
@@ -19,10 +19,11 @@ import { Box } from '../utils/components/index.js';
  * </LinkBox>
  */
 export const LinkAction = React.forwardRef((props, forwardedRef) => {
+  const { as: asProp = (!!props.href ? 'a' : 'button') as 'a' } = props;
   return (
     <Box
-      as={(!!props.href ? 'a' : 'button') as 'a'}
       {...props}
+      as={asProp}
       className={cx('iui-link-action', props.className)}
       ref={forwardedRef}
     />

--- a/packages/itwinui-react/src/core/Tag/Tag.test.tsx
+++ b/packages/itwinui-react/src/core/Tag/Tag.test.tsx
@@ -62,9 +62,24 @@ it('should be usable as a button', () => {
   const { getByRole } = render(<Tag onClick={() => {}}>Tag</Tag>);
   const button = getByRole('button');
   expect(button).toHaveTextContent('Tag');
+});
 
-  // @ts-expect-error -- onClick and onRemove shouldn't be used together
-  <Tag onClick={() => {}} onRemove={() => {}}>
-    …
-  </Tag>;
+it('should not produce invalid markup when using both onClick and onRemove', () => {
+  const { container } = render(
+    <Tag
+      onClick={() => {}}
+      labelProps={{ className: 'the-label' }}
+      onRemove={() => {}}
+      removeButtonProps={{ className: 'the-remove' }}
+      className='the-tag'
+    >
+      Tag
+    </Tag>,
+  );
+
+  expect(container.querySelector('.the-tag')?.nodeName).toBe('DIV');
+  expect(container.querySelector('.the-label')?.nodeName).toBe('BUTTON');
+  expect(container.querySelector('.the-remove')?.nodeName).toBe('BUTTON');
+
+  expect(container.querySelector('button button')).toBeNull();
 });

--- a/packages/itwinui-react/src/core/Tag/Tag.tsx
+++ b/packages/itwinui-react/src/core/Tag/Tag.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { SvgCloseSmall, Box, ButtonBase } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { IconButton } from '../Buttons/IconButton.js';
+import { LinkAction, LinkBox } from '../LinkAction/LinkAction.js';
 
 type TagProps = {
   /**
@@ -75,14 +76,17 @@ export const Tag = React.forwardRef((props, forwardedRef) => {
     variant = 'default',
     children,
     onRemove,
+    onClick,
     labelProps,
     removeButtonProps,
     ...rest
   } = props;
 
+  const shouldUseLinkAction = !!onClick && !!onRemove;
+
   return (
     <Box
-      as={!!props.onClick ? ButtonBase : 'span'}
+      as={shouldUseLinkAction ? LinkBox : !!onClick ? ButtonBase : 'span'}
       className={cx(
         {
           'iui-tag-basic': variant === 'basic',
@@ -92,11 +96,13 @@ export const Tag = React.forwardRef((props, forwardedRef) => {
       )}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ref's type doesn't matter internally
       ref={forwardedRef as any}
+      onClick={!shouldUseLinkAction ? onClick : undefined}
       {...rest}
     >
       {variant === 'default' ? (
         <Box
-          as='span'
+          as={(shouldUseLinkAction ? LinkAction : 'span') as 'span'}
+          onClick={shouldUseLinkAction ? onClick : undefined}
           {...labelProps}
           className={cx('iui-tag-label', labelProps?.className)}
         >

--- a/packages/itwinui-react/src/core/Tag/Tag.tsx
+++ b/packages/itwinui-react/src/core/Tag/Tag.tsx
@@ -14,6 +14,24 @@ type TagProps = {
    * Text inside the tag.
    */
   children: React.ReactNode;
+  /**
+   * Callback invoked when the tag is clicked.
+   *
+   * When this prop is passed, the tag will be rendered as a button.
+   */
+  onClick?: React.MouseEventHandler;
+  /**
+   * Callback function that handles click on the remove ("❌") button.
+   * If not passed, the remove button will not be shown.
+   *
+   * If both `onClick` and `onRemove` are passed, then the tag label (rather than the tag itself)
+   * will be rendered as a button, to avoid invalid markup (nested buttons).
+   */
+  onRemove?: React.MouseEventHandler;
+  /**
+   * Props for customizing the remove ("❌") button.
+   */
+  removeButtonProps?: React.ComponentPropsWithRef<'button'>;
 } & (
   | {
       /**
@@ -33,36 +51,7 @@ type TagProps = {
       variant?: 'basic';
       labelProps?: never;
     }
-) &
-  (
-    | {
-        /**
-         * Callback invoked when the tag is clicked.
-         *
-         * When this prop is passed, the tag will be rendered as a button.
-         *
-         * This prop is mutually exclusive with `onRemove`.
-         */
-        onClick?: React.MouseEventHandler;
-        onRemove?: never;
-        removeButtonProps?: never;
-      }
-    | {
-        onClick?: never;
-        /**
-         * Callback function that handles click on the remove ("❌") button.
-         * If not passed, the remove button will not be shown.
-         *
-         * This prop is mutually exclusive with the `onClick` prop, because
-         * the tag will be rendered as a button when `onClick` is passed.
-         */
-        onRemove?: React.MouseEventHandler;
-        /**
-         * Props for customizing the remove ("❌") button.
-         */
-        removeButtonProps?: React.ComponentPropsWithRef<'button'>;
-      }
-  );
+);
 
 /**
  * Tag for showing categories, filters etc.
@@ -82,6 +71,9 @@ export const Tag = React.forwardRef((props, forwardedRef) => {
     ...rest
   } = props;
 
+  // If both onClick and onRemove are passed, we want to render the label as a button
+  // to avoid invalid markup (nested buttons). LinkAction ensures that clicking anywhere outside
+  // the remove button (including padding) will still trigger the main onClick callback.
   const shouldUseLinkAction = !!onClick && !!onRemove;
 
   return (


### PR DESCRIPTION
## Changes

When working on demos for interactive `Tag`s (#1815), I realized that the type error when simultaneously using `onClick` and `onRemove` is not enough. The component still renders (no runtime error) with nested buttons. This has a risk of the developer suppressing the type error without giving it further thought.

This PR remedies that by conditionally using `LinkAction` only when both `onClick` and `onRemove` are passed. `LinkAction` will avoid invalid markup while preserving the same clickable area, i.e. clicking anywhere on the tag invokes `onClick` and clicking on the ❌ button invokes `onRemove`. I probably still wouldn't recommend this pattern, but it's better than before.

Also `LinkAction` itself has been updated to automatically render `<button>` (rather than `<a>`) by default when `href` is not passed.

## Testing

Removed type test + added new unit test (runtime) ensuring proper markup.

Tested in playground as well. Everything works correctly, including hover and focus states.

![image](https://github.com/iTwin/iTwinUI/assets/9084735/cfaa0676-6abc-4b49-9962-c79f1076868b)

## Docs

Updated/added changesets and jsdocs.

Updated docs page to mention accessibility considerations.