### PR TITLE
Fix flaw in `useResizeObserver`'s unit test

### DIFF
--- a/packages/itwinui-react/src/core/utils/hooks/useResizeObserver.test.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useResizeObserver.test.tsx
@@ -56,7 +56,7 @@ it('should initialize ResizeObserver correctly', () => {
   expect(element.getBoundingClientRect()).toMatchObject(mockSize);
 });
 
-it('should call onResize when element resizes', () => {
+it('should call onResize when element resizes', async () => {
   const onResizeMock = vi.fn();
   renderResizeObserver({ onResize: onResizeMock });
   expect(onResizeMock).not.toHaveBeenCalled();
@@ -65,9 +65,13 @@ it('should call onResize when element resizes', () => {
   act(() => triggerResize(newSize));
 
   // Wait for one frame
-  requestAnimationFrame(() => {
-    expect(onResizeMock).toHaveBeenCalledWith(newSize);
+  await new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      resolve(null);
+    });
   });
+
+  expect(onResizeMock).toHaveBeenCalledWith(newSize);
 });
 
 it('should not observe if element is null', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I realized that my [changes](https://github.com/iTwin/iTwinUI/pull/1800/files#diff-111a171304fb0e2aad0260c14c55be12ba9eec60849ded2562386a1d16fa7948) in `useResizeObserver.test.tsx` from #1800 might not have been the correct way to fix the failing test. I confirmed this by adding a `console.log("HERE")` and noticing that this log was not printed.

<details>
<summary>Code</summary>

```diff
// Wait for one frame
requestAnimationFrame(() => {
+ console.log("HERE");
  expect(onResizeMock).toHaveBeenCalledWith(newSize);
});
```

</details>

So, this PR `await`s a `Promise` instead of the old method from #1800. I confirmed that this works by adding the same `console.log` and confirming that it was printed in the console.

<details>
<summary>Code</summary>

```diff
// Wait for one frame
await new Promise((resolve) => {
  requestAnimationFrame(() => {
    resolve(null);
  });
});

+ console.log("HERE");
expect(onResizeMock).toHaveBeenCalledWith(newSize);
```

</details>

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

* useResizeObserver's unit tests still passes.
* All other unit tests still pass.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A