### PR TITLE
move dialog resizers into shadow dom

### DIFF
--- a/.changeset/violet-games-raise.md
+++ b/.changeset/violet-games-raise.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Updated Dialog resizer positioning to protrude outside the dialog.

--- a/packages/itwinui-react/setupTests.ts
+++ b/packages/itwinui-react/setupTests.ts
@@ -21,3 +21,7 @@ vi.mock('./src/core/utils/hooks/useGlobals.js', () => {
     useGlobals: () => {},
   };
 });
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
@@ -11,6 +11,7 @@ import {
   useMergedRefs,
   useLayoutEffect,
   Box,
+  ShadowRoot,
 } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
 import { useDialogContext } from './DialogContext.js';
@@ -184,19 +185,23 @@ export const DialogMain = React.forwardRef((props, ref) => {
       }}
       {...rest}
     >
-      {isResizable && (
-        <Resizer
-          elementRef={dialogRef}
-          containerRef={dialogContext.dialogRootRef}
-          onResizeStart={() => {
-            if (!hasBeenResized.current) {
-              hasBeenResized.current = true;
-              setResizeStyle({ maxInlineSize: '100%' });
-            }
-          }}
-          onResizeEnd={setResizeStyle}
-        />
-      )}
+      <ShadowRoot>
+        <slot />
+        {isResizable && (
+          <Resizer
+            elementRef={dialogRef}
+            containerRef={dialogContext.dialogRootRef}
+            onResizeStart={() => {
+              if (!hasBeenResized.current) {
+                hasBeenResized.current = true;
+                setResizeStyle({ maxInlineSize: '100%' });
+              }
+            }}
+            onResizeEnd={setResizeStyle}
+          />
+        )}
+      </ShadowRoot>
+
       {children}
     </Box>
   );

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -3452,46 +3452,9 @@ it('should sync body horizontal scroll with header scroll', () => {
   expect(body.scrollLeft).toBe(0);
 });
 
-it('should add a shadow tree to table-body.', () => {
-  const columnWidths = [400, 600, 200];
-  const columnWidthsSum = columnWidths.reduce((a, b) => a + b, 0);
-
-  // Mocking the scrollWidth of the table header
-  vi.spyOn(HTMLDivElement.prototype, 'scrollWidth', 'get').mockReturnValue(
-    columnWidthsSum,
-  );
-
-  const { container } = renderComponent({
-    columns: [
-      {
-        Header: 'Name',
-        accessor: 'name',
-        id: 'name',
-        width: columnWidths[0],
-      },
-      {
-        Header: 'Description',
-        accessor: 'description',
-        id: 'description',
-        width: columnWidths[1],
-      },
-      {
-        Header: 'View',
-        Cell: () => <>View</>,
-        id: 'view',
-        width: columnWidths[2],
-      },
-    ],
-  });
-
-  // body serves as the shadow host
-  const host = container.querySelector('.iui-table-body') as HTMLDivElement;
-
-  const slot = host?.shadowRoot?.querySelector('slot');
-  expect(slot).toBeTruthy();
-});
-
 it('should have a shadow tree in table-body that has a dummy div only when needed', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+
   const columnWidths = [400, 600, 200];
   const columnWidthsSum = columnWidths.reduce((a, b) => a + b, 0);
 
@@ -3528,6 +3491,7 @@ it('should have a shadow tree in table-body that has a dummy div only when neede
     isResizable: true,
     columnResizeMode: 'expand',
   });
+  act(() => vi.runAllTicks());
 
   // Initial render
   triggerResize({ width: columnWidthsSum } as DOMRectReadOnly);

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -3500,6 +3500,9 @@ it('should have a shadow tree in table-body that has a dummy div only when neede
   let host = container.querySelector('.iui-table-body') as HTMLDivElement;
   expect(host).toBeTruthy();
 
+  const slot = host?.shadowRoot?.querySelector('slot');
+  expect(slot).toBeTruthy();
+
   // When clientWidth >= scrollWidth, the dummy div should not be rendered
   const htmlScrollWidthMock = vi
     .spyOn(HTMLDivElement.prototype, 'scrollWidth', 'get')

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import cx from 'classnames';
 import {
   actions as TableActions,
@@ -36,6 +35,7 @@ import {
   useLayoutEffect,
   Box,
   createWarningLogger,
+  ShadowRoot,
 } from '../utils/index.js';
 import type { CommonProps } from '../utils/index.js';
 import { getCellStyle, getStickyStyle, getSubRowStyle } from './utils.js';
@@ -1085,7 +1085,7 @@ export const Table = <
             (isSelectable && selectionMode === 'multi') || undefined
           }
         >
-          <ShadowTemplate>
+          <ShadowRoot>
             <slot />
             {rows.length === 0 && headerScrollWidth > headerClientWidth && (
               <div
@@ -1098,7 +1098,7 @@ export const Table = <
                 }}
               />
             )}
-          </ShadowTemplate>
+          </ShadowRoot>
           {data.length !== 0 && (
             <>
               {enableVirtualization ? (
@@ -1161,32 +1161,5 @@ export const Table = <
         {paginatorRenderer?.(paginatorRendererProps)}
       </Box>
     </>
-  );
-};
-// ----------------------------------------------------------------------------
-
-/**
- * Wrapper around `<template>` element that attaches shadow root to its parent
- * and moves its children into the shadow root.
- */
-const ShadowTemplate = ({ children }: { children: React.ReactNode }) => {
-  const [shadowRoot, setShadowRoot] = React.useState<ShadowRoot>();
-
-  const attachShadowRef = React.useCallback(
-    (template: HTMLTemplateElement | null) => {
-      const parent = template?.parentElement;
-      if (!template || !parent || parent.shadowRoot) {
-        return;
-      }
-      setShadowRoot(parent.attachShadow({ mode: 'open' }));
-      template.remove();
-    },
-    [],
-  );
-
-  return (
-    <template ref={attachShadowRef}>
-      {shadowRoot && ReactDOM.createPortal(children, shadowRoot)}
-    </template>
   );
 };

--- a/packages/itwinui-react/src/core/utils/components/Resizer.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Resizer.tsx
@@ -33,6 +33,8 @@ export type ResizerProps = {
 /**
  * Component that allows to resize parent element.
  * Parent must have `position: relative`.
+ *
+ * Ideally should be used within a shadow root.
  * @private
  * @example
  * const ref = React.useRef<HTMLDivElement>(null);
@@ -212,103 +214,92 @@ export const Resizer = (props: ResizerProps) => {
   };
 
   return (
-    <>
+    <div
+      style={{
+        position: 'absolute',
+        inset: -6,
+        display: 'grid',
+        pointerEvents: 'none',
+      }}
+    >
+      <ResizerStyles />
       <div
         data-iui-resizer='top-left'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: 12,
-          height: 12,
-          cursor: 'nw-resize',
-        }}
+        style={{ cursor: 'nw-resize' }}
       />
       <div
         data-iui-resizer='top'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 8,
-          right: 8,
-          height: 8,
-          cursor: 'n-resize',
-        }}
+        style={{ cursor: 'n-resize' }}
       />
       <div
         data-iui-resizer='top-right'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          top: 0,
-          right: 0,
-          width: 12,
-          height: 12,
-          cursor: 'ne-resize',
-        }}
+        style={{ cursor: 'ne-resize' }}
       />
       <div
         data-iui-resizer='right'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          top: 8,
-          right: 0,
-          bottom: 8,
-          width: 8,
-          cursor: 'e-resize',
-        }}
+        style={{ cursor: 'e-resize' }}
       />
       <div
         data-iui-resizer='bottom-right'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          right: 0,
-          width: 12,
-          height: 12,
-          cursor: 'se-resize',
-        }}
+        style={{ cursor: 'se-resize' }}
       />
       <div
         data-iui-resizer='bottom'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 8,
-          right: 8,
-          height: 8,
-          cursor: 's-resize',
-        }}
+        style={{ cursor: 's-resize' }}
       />
       <div
         data-iui-resizer='bottom-left'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          width: 12,
-          height: 12,
-          cursor: 'sw-resize',
-        }}
+        style={{ cursor: 'sw-resize' }}
       />
       <div
         data-iui-resizer='left'
         onPointerDown={onResizePointerDown}
-        style={{
-          position: 'absolute',
-          top: 8,
-          left: 0,
-          bottom: 8,
-          width: 8,
-          cursor: 'w-resize',
-        }}
+        style={{ cursor: 'w-resize' }}
       />
-    </>
+    </div>
   );
 };
+
+// ----------------------------------------------------------------------------
+
+const ResizerStyles = React.memo(() => <style>{resizerStyles}</style>);
+
+const resizerStyles = /* css */ `
+[data-iui-resizer] {
+  pointer-events: auto;
+  grid-area: 1 / 1 / -1 / -1;
+  width: 12px;
+  height: 12px;
+  z-index: 1;
+}
+[data-iui-resizer='top'],
+[data-iui-resizer='bottom'] {
+  height: 8px;
+  width: auto;
+  z-index: 0;
+}
+[data-iui-resizer='left'],
+[data-iui-resizer='right'] {
+  height: auto;
+  width: 8px;
+  z-index: 0;
+}
+[data-iui-resizer^='top'] {
+  align-self: start;
+}
+[data-iui-resizer^='bottom'] {
+  align-self: end;
+}
+[data-iui-resizer$='left'] {
+  justify-self: start;
+}
+[data-iui-resizer$='right'] {
+  justify-self: end;
+}`;

--- a/packages/itwinui-react/src/core/utils/components/Resizer.tsx
+++ b/packages/itwinui-react/src/core/utils/components/Resizer.tsx
@@ -45,6 +45,22 @@ export type ResizerProps = {
  * );
  */
 export const Resizer = (props: ResizerProps) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: -6,
+        display: 'grid',
+        pointerEvents: 'none',
+      }}
+    >
+      <ResizerStyles />
+      <Resizers {...props} />
+    </div>
+  );
+};
+
+const Resizers = (props: ResizerProps) => {
   const { elementRef, containerRef, onResizeStart, onResizeEnd } = props;
 
   const isResizing = React.useRef(false);
@@ -214,15 +230,7 @@ export const Resizer = (props: ResizerProps) => {
   };
 
   return (
-    <div
-      style={{
-        position: 'absolute',
-        inset: -6,
-        display: 'grid',
-        pointerEvents: 'none',
-      }}
-    >
-      <ResizerStyles />
+    <>
       <div
         data-iui-resizer='top-left'
         onPointerDown={onResizePointerDown}
@@ -263,7 +271,7 @@ export const Resizer = (props: ResizerProps) => {
         onPointerDown={onResizePointerDown}
         style={{ cursor: 'w-resize' }}
       />
-    </div>
+    </>
   );
 };
 

--- a/packages/itwinui-react/src/core/utils/components/ShadowRoot.test.tsx
+++ b/packages/itwinui-react/src/core/utils/components/ShadowRoot.test.tsx
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import { render, act } from '@testing-library/react';
+import { ShadowRoot } from './ShadowRoot.js';
+
+it('works', async () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+
+  const { container } = render(
+    <div>
+      <ShadowRoot>
+        <button>hello</button>
+      </ShadowRoot>
+    </div>,
+  );
+
+  act(() => vi.runAllTicks());
+
+  const host = container.querySelector('div');
+  expect(host?.shadowRoot).toBeTruthy();
+  expect(host?.shadowRoot?.querySelector('button')).toBeTruthy();
+});

--- a/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
+++ b/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+const isBrowser = typeof document !== 'undefined';
+const supportsDSD =
+  isBrowser && 'shadowRootMode' in HTMLTemplateElement.prototype;
+
+/**
+ * Wrapper around `<template>` element that attaches shadow root to its parent
+ * and moves its children into the shadow root.
+ */
+export const ShadowRoot = ({ children }: { children: React.ReactNode }) => {
+  const [shadowRoot, setShadowRoot] = React.useState<ShadowRoot>();
+  const isFirstRender = useIsFirstRender();
+
+  const attachShadowRef = React.useCallback(
+    (template: HTMLTemplateElement | null) => {
+      const parent = template?.parentElement;
+      if (!template || !parent) {
+        return;
+      }
+      queueMicrotask(() =>
+        ReactDOM.flushSync(() =>
+          setShadowRoot(
+            parent.shadowRoot || parent.attachShadow({ mode: 'open' }),
+          ),
+        ),
+      );
+    },
+    [],
+  );
+
+  if (!isBrowser) {
+    return <template {...{ shadowrootmode: 'open' }}>{children}</template>;
+  }
+
+  // In browsers that support DSD, the template will be automatically removed as soon as it's parsed.
+  // To pass hydration, the first client render needs to emulate this browser behavior and return null.
+  if (supportsDSD && isFirstRender) {
+    return null;
+  }
+
+  return (
+    <>
+      {shadowRoot ? (
+        ReactDOM.createPortal(children, shadowRoot)
+      ) : (
+        <template ref={attachShadowRef} />
+      )}
+    </>
+  );
+};
+
+// ----------------------------------------------------------------------------
+
+function useIsFirstRender() {
+  const [isFirstRender, setIsFirstRender] = React.useState(true);
+  React.useEffect(() => setIsFirstRender(false), []);
+  return isFirstRender;
+}

--- a/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
+++ b/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
@@ -12,6 +12,8 @@ const supportsDSD =
 /**
  * Wrapper around `<template>` element that attaches shadow root to its parent
  * and moves its children into the shadow root.
+ *
+ * @private
  */
 export const ShadowRoot = ({ children }: { children: React.ReactNode }) => {
   const [shadowRoot, setShadowRoot] = React.useState<ShadowRoot>();

--- a/packages/itwinui-react/src/core/utils/components/index.ts
+++ b/packages/itwinui-react/src/core/utils/components/index.ts
@@ -14,3 +14,4 @@ export * from './AutoclearingHiddenLiveRegion.js';
 export * from './Box.js';
 export * from './ButtonBase.js';
 export * from './Portal.js';
+export * from './ShadowRoot.js';


### PR DESCRIPTION
## Changes

This is a slight refactor of the `Resizer` component used in `Dialog`.
- It is now rendered inside shadow DOM, and its styles have been updated to use CSS grid for positioning. As an added benefit of shadow DOM, I was able to use a plain `<style>` here (vs inline styles) without causing performance issues.
- User-facing change: It now protrudes outside the edge of the dialog, as originally intended (before it was reversed in #1424 due to `overflow`, which was recently removed in #1795).
    - Screenshot below visualizes the resizers (corners in hotpink, perpendiculars in wheat); the corner resizers appear on top using a higher z-index.
      <img width="398" alt="image" src="https://github.com/iTwin/iTwinUI/assets/9084735/a1dc0192-985d-4822-8a66-cb4e6139875e">

Internal change: Extracted out `ShadowTemplate` into a shared component and renamed to `ShadowRoot`. Updated the logic inside to correctly handle isomorphic rendering (via [declarative syntax](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM#declaratively_with_html)). Also added a `flushSync` to immediately force a re-render (needed by `createPortal`); this ensures that any layout measurements are immediately reflected correctly. This is important because the Dialog resizing logic immediately measures the DOM inside a `useLayoutEffect` and was reporting incorrect measurements if the shadow root content was not present on first mount.

## Testing

Updated affected unit tests. Since `attachShadow` is called inside `queueMicrotask`, I had to use fake timers.

Manually tested that resizing works correctly. Inspect the [Resizable Dialog story](https://itwin.github.io/iTwinUI/1836/react/?story=dialog--draggable-and-resizable) and play with it in devtools to understand the new changes. 

## Docs

Added changeset for the one-user facing change.
