### PR TITLE
Resize README pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
     <img
       src='https://itwin.github.io/iTwinUI/logo.svg'
       alt='iTwinUI logo'
+      height='150'
     />
   </picture>
 </p>

--- a/packages/itwinui-css/README.md
+++ b/packages/itwinui-css/README.md
@@ -7,6 +7,7 @@
     <img
       src='https://itwin.github.io/iTwinUI/logo.svg'
       alt='iTwinUI logo'
+      height='150'
     />
   </picture>
 </p>

--- a/packages/itwinui-react/README.md
+++ b/packages/itwinui-react/README.md
@@ -7,6 +7,7 @@
     <img
       src='https://itwin.github.io/iTwinUI/logo.svg'
       alt='iTwinUI logo'
+      height='150'
     />
   </picture>
 </p>


### PR DESCRIPTION


## Changes

- This PR changes the  iTwin logo images in our README's to a height of 150px. 

## Testing

N/A

## Docs

N/A
