### PR TITLE
fix v2 SearchBox outline

### DIFF
--- a/.changeset/spotty-glasses-sell.md
+++ b/.changeset/spotty-glasses-sell.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': patch
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue where `SearchBox` was showing two focus outlines.

--- a/packages/itwinui-css/src/input-container/input-container.scss
+++ b/packages/itwinui-css/src/input-container/input-container.scss
@@ -110,6 +110,10 @@
       font-weight: var(--iui-font-weight-light);
       opacity: 1;
     }
+
+    &:focus {
+      outline: none !important;
+    }
   }
 
   &[data-iui-disabled='true'] {


### PR DESCRIPTION
## Changes

Fixes #1849

Previously, `all: unset` was being used to undo focus outlines. In #1362 (v3), a global focus outline was added, requiring an explicit override for `:focus`.

The actual focus styling still shows up via the container's `:has(:focus-visible)`/`:focus-within` rules.

## Testing

Somewhat difficult to test this locally, as the bug requires using multiple versions, but I was able to test the fix in the linked issue's sandbox by dynamically adding this style in devtools.

![image](https://github.com/iTwin/iTwinUI/assets/9084735/c16b4344-8548-42be-8b8d-23e685924874)

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/ef2f55d7-e416-4bb4-92b8-6ba8c5bc7aab) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/f361809d-9477-4a71-bf48-5bbc5c8388bc) |

## Docs

Added changeset.
