### PR TITLE
Added overflow style to all playgrounds

### DIFF
--- a/playgrounds/astro/src/pages/_layout.astro
+++ b/playgrounds/astro/src/pages/_layout.astro
@@ -27,6 +27,7 @@ import '@itwin/itwinui-react/styles.css';
     .app-wrapper {
       padding: 2rem 1rem;
       height: 100dvh;
+      /* overflow: auto; */
     }
   </style>
 </html>

--- a/playgrounds/astro/src/pages/_layout.astro
+++ b/playgrounds/astro/src/pages/_layout.astro
@@ -27,7 +27,7 @@ import '@itwin/itwinui-react/styles.css';
     .app-wrapper {
       padding: 2rem 1rem;
       height: 100dvh;
-      /* overflow: auto; */
+      overflow: auto;
     }
   </style>
 </html>

--- a/playgrounds/next/pages/_app.tsx
+++ b/playgrounds/next/pages/_app.tsx
@@ -25,5 +25,6 @@ const styles = css.global`
     padding-inline: 1rem;
     padding-block: 2rem;
     block-size: 100dvh;
+    overflow: auto;
   }
 `;

--- a/playgrounds/vite/src/main.module.css
+++ b/playgrounds/vite/src/main.module.css
@@ -1,6 +1,7 @@
 .main {
   padding: 2rem 1rem;
   height: 100vh;
+  overflow: auto;
 }
 
 .themeButton {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

When testing #1828 by adding many input containers in a long vertically overflowing `Flex`, I realized that the overflow style was missing on the playgrounds' containers. So, I thought it would be good to add `overflow: auto` to all playgrounds, similar to #1752.

|Old|New|
|-|-|
|![image](https://github.com/iTwin/iTwinUI/assets/45748283/92247092-5afe-400e-b268-a76132fdaad3)|![image](https://github.com/iTwin/iTwinUI/assets/45748283/d752341e-8560-4a73-8bec-cd17410d608b)|

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`yarn approve:css` and `yarn approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that all playgrounds overflow correctly when the content overflows.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`yarn changeset`).

If not applicable, you can write "N/A".
-->

N/A