### PR TITLE
move live demos into shadow dom

### DIFF
--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import OpenInCodePen from './OpenInCodePen.astro';
 import { Code } from 'astro/components';
 import { createRequire } from 'node:module';
+import itwinuiStyles from '@itwin/itwinui-react/styles.css?url';
+
 const require = createRequire(import.meta.url);
 
 export type Props = {
@@ -18,22 +20,50 @@ export type Props = {
 
 const { src, truncate = true } = Astro.props;
 
-const codePath = require.resolve(`examples/${src}`);
-let code = await fs.promises.readFile(codePath, 'utf8');
+const jsxPath = require.resolve(`examples/${src}`);
+const cssPath = jsxPath.replace(/\.jsx$/, '.css');
+
+let jsxCode = await fs.promises.readFile(jsxPath, 'utf8');
 
 // strip copyright header (first 4 lines)
-if (code.includes('Copyright (c) Bentley Systems')) {
-  code = code.split('\n').slice(4).join('\n');
+if (jsxCode.includes('Copyright (c) Bentley Systems')) {
+  jsxCode = jsxCode.split('\n').slice(4).join('\n');
 }
+
+const cssCode = await (async () => {
+  try {
+    return await fs.promises.readFile(cssPath, 'utf8');
+  } catch {
+    return '';
+  }
+})();
 ---
 
-<div class='demo-box'>
-  <slot />
-  <OpenInCodePen class='sandbox-link' code={code} />
-</div>
+<demo-box>
+  <template shadowrootmode='open'>
+    <style is:inline>
+      astro-island {
+        display: contents;
+      }
+    </style>
+    <style set:html={cssCode}></style>
+    <link rel='stylesheet' href={itwinuiStyles} />
+    <slot />
+    <slot is:inline />
+  </template>
+
+  <OpenInCodePen
+    class='sandbox-link'
+    code={{
+      js: jsxCode,
+      css: cssCode,
+    }}
+  />
+</demo-box>
+
 <demo-code>
   {truncate && <button aria-expanded='false'>Toggle full code</button>}
-  <Code code={code} lang='tsx' theme={'github-dark'} />
+  <Code code={jsxCode} lang='tsx' theme={'github-dark'} />
 </demo-code>
 
 <script>
@@ -52,45 +82,35 @@ if (code.includes('Copyright (c) Bentley Systems')) {
       }
     },
   );
+
+  customElements.define(
+    'demo-box',
+    class extends HTMLElement {
+      connectedCallback() {
+        // firefox fallback
+        if (!this.shadowRoot) {
+          const template = this.querySelector('template');
+          if (!template) return;
+          this.attachShadow({ mode: 'open' }).appendChild(template.content);
+          template.remove();
+        }
+      }
+    },
+  );
 </script>
 
 <style lang='scss'>
-  // revert all website styles from the demo
-  .demo-box > :global(:first-child *) {
-    @layer globals {
-      all: revert-layer;
-    }
-    @layer layouts {
-      all: revert-layer;
-    }
-    @layer components {
-      all: revert-layer;
-    }
-    @layer pages {
-      all: revert-layer;
-    }
-  }
   @layer components {
-    .demo-box {
+    demo-box {
       position: relative;
       min-height: 300px;
       max-height: 500px;
       display: grid;
-      justify-items: center;
+      place-items: center;
       padding: 1rem;
       isolation: isolate;
       border-radius: var(--border-radius-1);
       outline: 1px solid var(--color-line-2);
-    }
-
-    .demo-box :global([data-iui-theme]) {
-      height: 100%;
-      width: 100%;
-      overflow: auto;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
     }
 
     .sandbox-link {

--- a/apps/website/src/components/OpenInCodePen.astro
+++ b/apps/website/src/components/OpenInCodePen.astro
@@ -2,8 +2,11 @@
 import outdent from 'outdent';
 import VisuallyHidden from './utils/VisuallyHidden.astro';
 
-type Props = { code: string } & astroHTML.JSX.HTMLAttributes;
-const { code = 'export default () => "hello"', ...rest } = Astro.props;
+type Props = { code: { js: string; css?: string } } & astroHTML.JSX.HTMLAttributes;
+const { code, ...rest } = Astro.props;
+
+code.js ||= 'export default () => "hello";';
+code.css ||= '';
 
 const css = outdent`
   @layer reset, itwinui;
@@ -12,6 +15,8 @@ const css = outdent`
     height: 100dvh;
     padding: 1rem;
   }
+
+  ${code.css.trim()}
 
   @layer reset {
     * {
@@ -23,7 +28,7 @@ const css = outdent`
   }
 `;
 const js = outdent`
-  ${code.replace('export default () =>', 'const App = () =>')}
+  ${code.js.replace('export default () =>', 'const App = () =>')}
 
   // -------------------------------------------------------------
 

--- a/apps/website/src/pages/_global.scss
+++ b/apps/website/src/pages/_global.scss
@@ -6,7 +6,6 @@
 @import '@fontsource/noto-sans/600.css' layer(thirdparty);
 @import '@fontsource/noto-sans/300.css' layer(thirdparty);
 @import '@fontsource/noto-sans/800.css' layer(thirdparty);
-@import '@itwin/itwinui-react/styles.css' layer(thirdparty);
 @import '@itwin/itwinui-variables' layer(thirdparty);
 
 @mixin themeVar($name, $dark, $light: null) {

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -14,6 +14,7 @@ const withThemeProvider = (Component: () => React.ReactElement) => () => {
       theme='dark'
       themeOptions={{ applyBackground: false }}
       portalContainer={portalContainer}
+      style={{ display: 'contents' }}
     >
       <Component />
     </ThemeProvider>


### PR DESCRIPTION
## Changes

Moves all live example demos into shadow DOM (using [declarative template syntax](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM#declaratively_with_html), with firefox fallback), so that the CSS selectors are automatically scoped. This helps address https://github.com/iTwin/iTwinUI/pull/1854#discussion_r1488609044.

Added basic handling of `.css` example files to be inlined into a `<style>` inside shadow DOM.

## Testing

Tested that existing demos work fine. Also verified behavior by creating a `.css` example file (not committed). Further testing will be done in #1854.

## Docs

N/A