### PR TITLE
add visually hidden "Loading" text to progress indicators

### DIFF
--- a/.changeset/sour-bears-applaud.md
+++ b/.changeset/sour-bears-applaud.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`ProgressRadial` and `ProgressLinear` will now include a visually hidden "Loading" text alternative for non-sighted users.

--- a/apps/website/src/content/docs/progressindicator.mdx
+++ b/apps/website/src/content/docs/progressindicator.mdx
@@ -26,6 +26,12 @@ thumbnail: ProgressIndicator
   <AllExamples.ProgressRadialMainExample client:load />
 </LiveExample>
 
+## Accessibility
+
+To make the progress indicator accessible to non-sighted users, a visually-hidden "Loading" message will be automatically included when the `value` is not set to 100%.
+
+To further improve the experience, applications should have a mechanism to inform users once the loading process is complete. Depending on the criticality of the content and how long it takes to load, the progress completion can be indicated using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), or by programmatically moving focus to the top of the new content.
+
 ### Props
 
 <PropsTable path={frontmatter.propsPath2} />

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.test.tsx
@@ -1015,7 +1015,7 @@ it('should update live region when selection changes', async () => {
   );
 
   const liveRegion = container.querySelector('[aria-live="polite"]');
-  expect(liveRegion).toBeEmptyDOMElement();
+  expect(liveRegion).toHaveTextContent('');
 
   await userEvent.tab();
   const options = document.querySelectorAll('[role="option"]');

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { ProgressLinear } from './ProgressLinear.js';
 
 it('renders determinate ProgressLinear', () => {
@@ -101,4 +101,20 @@ it('passes custom props to ProgressLinear parts', () => {
   ) as HTMLElement;
   expect(labelGroup).toBeTruthy;
   expect(labelGroup.style.fontSize).toBe('12px');
+});
+
+it('should include visually-hidden loading message when not at 100%', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+
+  const { container, rerender } = render(<ProgressLinear />);
+  act(() => vi.runAllTicks());
+
+  const progress = container.querySelector('div') as HTMLElement;
+  expect(progress.shadowRoot).toHaveTextContent('Loading.');
+
+  rerender(<ProgressLinear value={50} />);
+  expect(progress.shadowRoot).toHaveTextContent('Loading.');
+
+  rerender(<ProgressLinear value={100} />);
+  expect(progress.shadowRoot).not.toHaveTextContent('Loading.');
 });

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { Box, getBoundedValue } from '../utils/index.js';
+import { Box, ShadowRoot, getBoundedValue } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden.js';
 
 type ProgressLinearProps = {
   /**
@@ -88,6 +89,11 @@ export const ProgressLinear = React.forwardRef((props, forwardedRef) => {
       }
       {...rest}
     >
+      <ShadowRoot>
+        <VisuallyHidden>Loading.</VisuallyHidden>
+        <slot />
+      </ShadowRoot>
+
       {labels.length > 0 && (
         <Box
           as='div'

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
@@ -90,7 +90,7 @@ export const ProgressLinear = React.forwardRef((props, forwardedRef) => {
       {...rest}
     >
       <ShadowRoot>
-        <VisuallyHidden>Loading.</VisuallyHidden>
+        {value !== 100 && <VisuallyHidden>Loading.</VisuallyHidden>}
         <slot />
       </ShadowRoot>
 

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.test.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 import { ProgressRadial } from './ProgressRadial.js';
 
@@ -59,3 +59,19 @@ it.each(['small', 'x-small', 'large'] as const)(
     expect(spinner).toHaveAttribute('data-iui-size', size);
   },
 );
+
+it('should include visually-hidden loading message when not at 100%', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+
+  const { container, rerender } = render(<ProgressRadial />);
+  act(() => vi.runAllTicks());
+
+  const progress = container.querySelector('div') as HTMLElement;
+  expect(progress.shadowRoot).toHaveTextContent('Loading.');
+
+  rerender(<ProgressRadial value={50} />);
+  expect(progress.shadowRoot).toHaveTextContent('Loading.');
+
+  rerender(<ProgressRadial value={100} />);
+  expect(progress.shadowRoot).not.toHaveTextContent('Loading.');
+});

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.tsx
@@ -9,8 +9,10 @@ import {
   SvgImportantSmall,
   Box,
   getBoundedValue,
+  ShadowRoot,
 } from '../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../utils/index.js';
+import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden.js';
 
 type ProgressRadialProps = {
   /**
@@ -87,6 +89,11 @@ export const ProgressRadial = React.forwardRef((props, forwardedRef) => {
       }}
       {...rest}
     >
+      <ShadowRoot>
+        <VisuallyHidden>Loading.</VisuallyHidden>
+        <slot />
+      </ShadowRoot>
+
       {size !== 'x-small'
         ? children ?? (!!status ? statusMap[status] : null)
         : null}

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressRadial.tsx
@@ -90,7 +90,7 @@ export const ProgressRadial = React.forwardRef((props, forwardedRef) => {
       {...rest}
     >
       <ShadowRoot>
-        <VisuallyHidden>Loading.</VisuallyHidden>
+        {value !== 100 && <VisuallyHidden>Loading.</VisuallyHidden>}
         <slot />
       </ShadowRoot>
 

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -546,7 +546,7 @@ it('should update live region when selection changes', async () => {
   const { container } = render(<MultiSelectTest />);
 
   const liveRegion = container.querySelector('[aria-live="polite"]');
-  expect(liveRegion).toBeEmptyDOMElement();
+  expect(liveRegion).toHaveTextContent('');
   const options = document.querySelectorAll('[role="option"]');
 
   await userEvent.click(options[1]);

--- a/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.test.tsx
@@ -3,14 +3,20 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { VisuallyHidden } from './VisuallyHidden.js';
 
 it('should render in its most basic state', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+
   const { container } = render(<VisuallyHidden>hi</VisuallyHidden>);
+  act(() => vi.runAllTicks());
+
   const visuallyHidden = container.querySelector('span') as HTMLElement;
   expect(visuallyHidden).toHaveClass('iui-visually-hidden');
   expect(visuallyHidden).toHaveAttribute('data-iui-unhide-on-focus');
+
+  expect(visuallyHidden.shadowRoot?.querySelector('slot')).toBeTruthy();
 });
 
 it('should support polymorphic `as` prop', () => {
@@ -25,4 +31,9 @@ it('should respect unhideOnFocus prop', () => {
   expect(container.querySelector('.iui-visually-hidden')).not.toHaveAttribute(
     'data-iui-unhide-on-focus',
   );
+});
+
+it('should work with elements that do not support attaching shadow roots', () => {
+  const { container } = render(<VisuallyHidden as='label'>hi</VisuallyHidden>);
+  expect(container.querySelector('label')).toHaveClass('iui-visually-hidden');
 });

--- a/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.test.tsx
@@ -34,6 +34,15 @@ it('should respect unhideOnFocus prop', () => {
 });
 
 it('should work with elements that do not support attaching shadow roots', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
   const { container } = render(<VisuallyHidden as='label'>hi</VisuallyHidden>);
+  act(() => vi.runAllTicks());
   expect(container.querySelector('label')).toHaveClass('iui-visually-hidden');
+});
+
+it('should work with self-closing elements', () => {
+  vi.useFakeTimers({ toFake: ['queueMicrotask'] });
+  const { container } = render(<VisuallyHidden as='input' />);
+  act(() => vi.runAllTicks());
+  expect(container.querySelector('input')).toHaveClass('iui-visually-hidden');
 });

--- a/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -32,9 +32,21 @@ export const VisuallyHidden = React.forwardRef((props, ref) => {
     as: asProp = 'span',
     className,
     unhideOnFocus = true,
-    children,
+    children: childrenProp,
     ...rest
   } = props;
+
+  // ShadowRoot is not supported on all elements, so we only use it for few common ones.
+  const children = !['div', 'span', 'p'].includes(asProp) ? (
+    childrenProp
+  ) : (
+    <>
+      <ShadowRoot css={css}>
+        <slot />
+      </ShadowRoot>
+      {childrenProp}
+    </>
+  );
 
   return (
     <Box
@@ -44,12 +56,6 @@ export const VisuallyHidden = React.forwardRef((props, ref) => {
       ref={ref}
       {...rest}
     >
-      {['div', 'span', 'p'].includes(asProp) && ( // ShadowRoot is not supported on all elements
-        <ShadowRoot css={css}>
-          <slot />
-        </ShadowRoot>
-      )}
-
       {children}
     </Box>
   );

--- a/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -44,7 +44,7 @@ export const VisuallyHidden = React.forwardRef((props, ref) => {
       ref={ref}
       {...rest}
     >
-      {['div', 'span'].includes(asProp) && ( // ShadowRoot is not supported on all elements
+      {['div', 'span', 'p'].includes(asProp) && ( // ShadowRoot is not supported on all elements
         <ShadowRoot css={css}>
           <slot />
         </ShadowRoot>

--- a/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/itwinui-react/src/core/VisuallyHidden/VisuallyHidden.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import type { PolymorphicForwardRefComponent } from '../utils/props.js';
-import { Box } from '../utils/components/Box.js';
+import { Box, ShadowRoot } from '../utils/index.js';
 
 type VisuallyHiddenOwnProps = {
   /**
@@ -28,15 +28,42 @@ type VisuallyHiddenOwnProps = {
  * @see https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html
  */
 export const VisuallyHidden = React.forwardRef((props, ref) => {
-  const { className, unhideOnFocus = true, ...rest } = props;
+  const {
+    as: asProp = 'span',
+    className,
+    unhideOnFocus = true,
+    children,
+    ...rest
+  } = props;
 
   return (
     <Box
-      as='span'
+      as={asProp}
       className={cx('iui-visually-hidden', className)}
       data-iui-unhide-on-focus={unhideOnFocus ? true : undefined}
       ref={ref}
       {...rest}
-    />
+    >
+      {['div', 'span'].includes(asProp) && ( // ShadowRoot is not supported on all elements
+        <ShadowRoot css={css}>
+          <slot />
+        </ShadowRoot>
+      )}
+
+      {children}
+    </Box>
   );
 }) as PolymorphicForwardRefComponent<'span', VisuallyHiddenOwnProps>;
+
+// ----------------------------------------------------------------------------
+
+const css = /* css */ `
+  :host(:where(:not([data-iui-unhide-on-focus]:is(:focus-within, :active)))) {
+    clip-path: inset(50%) !important;
+    overflow: hidden !important;
+    position: absolute !important;
+    white-space: nowrap !important;
+    block-size: 1px !important;
+    inline-size: 1px !important;
+  }
+`;


### PR DESCRIPTION
## Changes

`ProgressRadial` and `ProgressLinear` are empty divs that do not hold semantics. This is fine for sighted users, since a visual loading indicator is a pretty well-understood pattern. However, non-sighted users do not get any indication at all.

This PR tries to remedy that by using a visually-hidden "Loading" message. Screen-readers will read this out just like any other regular text.

This visually hidden text is located inside shadow DOM. To make this work I had to change the `VisuallyHidden` component to include styles (global styles do not affect elements inside shadow DOM). This in turn required some changes in the `ShadowRoot` component.

**Note:** A much better solution would be to use the [`progressbar` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role), however it [requires an accessible name](https://dequeuniversity.com/rules/axe/4.7/aria-progressbar-name), which the application developers might not set. Also, our progress indicators are supposed to allow passing any arbitrary DOM nodes as `children` (for example, buttons), which might cause problems with the `progressbar` role.

## Testing

Added unit tests to check the presence of "Loading" message. And of course, tested manually to ensure that shadow DOM is wired up correctly, and contains the visually-hidden message with all styles.

![](https://github.com/iTwin/iTwinUI/assets/9084735/d5fcdc58-1e60-442b-8e32-cc46672fb428)

And verified that the text is indeed announced by screen-readers.

![](https://github.com/iTwin/iTwinUI/assets/9084735/a89909a3-93de-4a8e-a511-8c2149c7dd64)


It's near-impossible to write unit tests for shadow DOM CSS, but since the visual tests are passing, the logic is indirectly being tested. (If the CSS was not working, the visual tests would fail).

## Docs

Added changesets for user-facing parts.

Expanded the progressindicator documentation to explain the new functionality, along with an additional recommendation on what to do when loading completes.

## TODOs for future

- [ ] Allow customizing (or disabling) the loading message.
- [ ] Look into incorporating the `progressbar` role, especially for determinate progress indicators.