### PR TITLE
add `accent-color` to global styles

### DIFF
--- a/.changeset/four-hairs-hear.md
+++ b/.changeset/four-hairs-hear.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-variables': minor
+---
+
+`data-iui-theme` will now automatically specify an `accent-color` to match the current theme.

--- a/.changeset/fresh-bananas-judge.md
+++ b/.changeset/fresh-bananas-judge.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`ThemeProvider` will now automatically specify an `accent-color` to match the current theme.

--- a/packages/itwinui-variables/src/index.scss
+++ b/packages/itwinui-variables/src/index.scss
@@ -10,6 +10,7 @@
 // global vars shared between all themes
 :where([data-iui-theme]) {
   color-scheme: light dark;
+  accent-color: var(--iui-color-border-accent);
   @include spacing;
   @include component-heights;
   @include border-radii;


### PR DESCRIPTION
## Changes

Added [`accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color) at the entrypoint. This is similar to #1360 where [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) was added.

Motivation: Helps native elements fit better within the design system. (I recently discovered a rogue `<progress>` element in an application and it looked very out of place).

As for the value, the `--iui-color-border-accent` variable most closely matches what is already used in our components.

## Testing

Can be tested manually in the vite playground by using native elements:
```jsx
<progress></progress>
<input type='checkbox' />
<input type='range' />
```

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/98e4aa83-52f2-403e-893b-78afa6be587a) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/67b5d435-e944-4530-8c72-467cd780bd5d) |

## Docs

Added changesets.