### PR TITLE
add fallback size for inlined svgs

### DIFF
--- a/.changeset/sour-masks-sleep.md
+++ b/.changeset/sour-masks-sleep.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added `width`/`height` attributes to inlined svgs, to make them more resilient in case CSS fails.

--- a/packages/itwinui-react/src/core/utils/icons/Svg.tsx
+++ b/packages/itwinui-react/src/core/utils/icons/Svg.tsx
@@ -4,4 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { polymorphic } from '../functions/polymorphic.js';
 
-export const Svg = polymorphic.svg('', { viewBox: '0 0 16 16' });
+export const Svg = polymorphic.svg('', {
+  viewBox: '0 0 16 16',
+  width: 16,
+  height: 16,
+});


### PR DESCRIPTION
## Changes

Added `width`/`height` attributes to svgs that are used within our components. Without them, the svgs depend on the CSS. If the CSS doesn't specify the size (or fails to load), then the svg fills up the entire container (sometimes the entire page). This is just a "nice" thing to do; very minimal impact.

## Testing

Verified that the attributes appear in the output. No rigorous testing needed.

![](https://github.com/iTwin/iTwinUI/assets/9084735/fe8474c3-e786-4e38-b963-c9f0a4dcc002)

## Docs

Added changeset.