### PR TITLE
`Select`: fix `null` value handling

### DIFF
--- a/.changeset/neat-walls-fix.md
+++ b/.changeset/neat-walls-fix.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`Select` will now correctly reset its `value` if `null` is passed.

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -612,3 +612,13 @@ it('should allow passing ref to Select', () => {
 
   expect(selectRef?.current).toHaveAttribute('data-select');
 });
+
+it('should reset value when null is passed', () => {
+  const { container, rerender } = render(
+    <Select value='A' options={[{ value: 'A', label: 'A' }]} />,
+  );
+  expect(container.querySelector('[role=combobox]')).toHaveTextContent('A');
+
+  rerender(<Select value={null} options={[{ value: 'A', label: 'A' }]} />);
+  expect(container.querySelector('[role=combobox]')).toHaveTextContent('');
+});

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -111,7 +111,7 @@ export type SelectMultipleTypeProps<T> =
        *
        * Pass `null` to reset the value.
        */
-      value?: T;
+      value?: T | null;
       /**
        * Callback function handling change event on select.
        */

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -70,6 +70,8 @@ export type SelectOption<T> = {
   size?: 'default' | 'large';
   /**
    * Value of the item.
+   *
+   * Pass `null` to reset the value.
    */
   value: T;
   /**
@@ -258,7 +260,7 @@ export const Select = React.forwardRef(
     const [liveRegionSelection, setLiveRegionSelection] = React.useState('');
 
     const [uncontrolledValue, setUncontrolledValue] = React.useState<T | T[]>();
-    const value = valueProp ?? uncontrolledValue;
+    const value = valueProp !== undefined ? valueProp : uncontrolledValue;
 
     const onChangeRef = useLatestRef(onChangeProp);
     const selectRef = React.useRef<HTMLDivElement>(null);

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -70,8 +70,6 @@ export type SelectOption<T> = {
   size?: 'default' | 'large';
   /**
    * Value of the item.
-   *
-   * Pass `null` to reset the value.
    */
   value: T;
   /**
@@ -110,6 +108,8 @@ export type SelectMultipleTypeProps<T> =
       /**
        * Selected option value.
        * If `multiple` is enabled, it is an array of values.
+       *
+       * Pass `null` to reset the value.
        */
       value?: T;
       /**


### PR DESCRIPTION
## Changes

`Select` had a small (but significant) bug where it wouldn't respect `value={null}` and instead enter uncontrolled mode. This is annoying when trying to reset the value.

This PR fixes it by updating the logic to match the [`useControlledState`](https://github.com/iTwin/iTwinUI/blob/mayank/select-null/packages/itwinui-react/src/core/utils/hooks/useControlledState.ts) hook.

## Testing

Tested in playground and added a unit test.

<details><summary>App.tsx</summary>

```tsx
import * as React from 'react';
import { Button, Select } from '@itwin/itwinui-react';

export default function App() {
  const [value, setValue] = React.useState<number | null>(2);

  return (
    <>
      <Select
        value={value}
        onChange={setValue}
        options={[
          { value: 1, label: 'Option 1' },
          { value: 2, label: 'Option 2' },
          { value: 3, label: 'Option 3' },
        ]}
      />
      <Button onClick={() => setValue(null)}>Reset</Button>
    </>
  );
}
```

</details> 

## Docs

Added changeset.

While this is a bug fix and doesn't really need docs, I've still updated the jsdocs for the `value` prop.

## TODOs for future

- [ ] Investigate [JSDocs not showing up in IDE](https://github.com/iTwin/iTwinUI/pull/1862#discussion_r1492672122).