### PR TITLE
fix v2 svg styles overriding v3

### DIFF
--- a/.changeset/grumpy-cobras-sniff.md
+++ b/.changeset/grumpy-cobras-sniff.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where `svg` selectors from v2 and v3 were conflicting.

--- a/.changeset/slow-bikes-own.md
+++ b/.changeset/slow-bikes-own.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue where `data-iui-icon-color` was applying styles even when `class="iui-svg-icon"` was not set.

--- a/packages/itwinui-css/src/utils/icon.scss
+++ b/packages/itwinui-css/src/utils/icon.scss
@@ -44,25 +44,24 @@ $icon-sizes: (
 
 // ----------------------------------------------------------------------------
 
-.iui-svg-icon,
-[data-iui-icon-color] {
+.iui-svg-icon {
   @include iui-svg-icon;
-}
 
-@each $size in 's', 'm', 'l', 'auto' {
-  [data-iui-icon-size='#{$size}'] {
-    @include svg-icon-size($size);
+  @each $size in 's', 'm', 'l', 'auto' {
+    &[data-iui-icon-size='#{$size}'] {
+      @include svg-icon-size($size);
+    }
   }
-}
 
-@each $fill in 'informational', 'positive', 'warning', 'negative' {
-  [data-iui-icon-color='#{$fill}'] {
-    @include svg-icon-status-color($fill);
+  @each $fill in 'informational', 'positive', 'warning', 'negative' {
+    &[data-iui-icon-color='#{$fill}'] {
+      @include svg-icon-status-color($fill);
+    }
   }
-}
 
-// override forced colors only if it doesn't have a status fill
-.iui-svg-icon:where(:not([data-iui-icon-color])),
-[data-iui-icon-color='default'] {
-  @include svg-icon-forced-colors;
+  // override forced colors only if it doesn't have a status fill
+  &:where(:not([data-iui-icon-color])),
+  &[data-iui-icon-color='default'] {
+    @include svg-icon-forced-colors;
+  }
 }


### PR DESCRIPTION
## Changes

Fixes #1867. The `data-iui-icon-color` selector was applying `width`/`height` even when `class="iui-svg-icon"` is not present, thus affecting v3 elements which use the same attribute with a different class.

## Testing

All existing tests are unaffected.

Currently working on recreating the test sandbox locally.

## Docs

N/A