### PR TITLE
Adds Popover elements to DatePicker demos

### DIFF
--- a/examples/DatePicker.menu.jsx
+++ b/examples/DatePicker.menu.jsx
@@ -3,30 +3,33 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { DatePicker, IconButton } from '@itwin/itwinui-react';
+import { DatePicker, IconButton, Popover } from '@itwin/itwinui-react';
 import { SvgCalendar } from '@itwin/itwinui-icons-react';
 
 export default () => {
   const [currentDate, setCurrentDate] = React.useState(new Date());
-  const [opened, setOpened] = React.useState(false);
 
   return (
     <>
-      <IconButton onClick={() => setOpened(!opened)} label='Choose date'>
-        <SvgCalendar />
-      </IconButton>
+      <Popover
+        content={
+          <div className='demo-container'>
+            <DatePicker
+              showYearSelection
+              date={currentDate}
+              onChange={(date) => {
+                setCurrentDate(date);
+              }}
+            />
+          </div>
+        }
+        placement='bottom'
+      >
+        <IconButton label='Choose date'>
+          <SvgCalendar />
+        </IconButton>
+      </Popover>
       <span className='demo-label'>{currentDate.toString()}</span>
-      {opened && (
-        <div className='demo-container'>
-          <DatePicker
-            showYearSelection
-            date={currentDate}
-            onChange={(date) => {
-              setCurrentDate(date);
-            }}
-          />
-        </div>
-      )}
     </>
   );
 };

--- a/examples/DatePicker.withcombinedtime.jsx
+++ b/examples/DatePicker.withcombinedtime.jsx
@@ -3,19 +3,29 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { DatePicker } from '@itwin/itwinui-react';
+import { DatePicker, Popover, IconButton } from '@itwin/itwinui-react';
+import { SvgCalendar } from '@itwin/itwinui-icons-react';
 
 export default () => {
   const [currentDate, setCurrentDate] = React.useState(new Date());
   return (
-    <DatePicker
-      date={currentDate}
-      onChange={(date) => {
-        setCurrentDate(date);
-      }}
-      showTime={true}
-      useCombinedRenderer={true}
-      use12Hours={true}
-    />
+    <Popover
+      content={
+        <DatePicker
+          date={currentDate}
+          onChange={(date) => {
+            setCurrentDate(date);
+          }}
+          showTime={true}
+          useCombinedRenderer={true}
+          use12Hours={true}
+        />
+      }
+      placement='bottom'
+    >
+      <IconButton label='Choose date'>
+        <SvgCalendar />
+      </IconButton>
+    </Popover>
   );
 };

--- a/examples/DatePicker.withtime.jsx
+++ b/examples/DatePicker.withtime.jsx
@@ -3,17 +3,27 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { DatePicker } from '@itwin/itwinui-react';
+import { DatePicker, Popover, IconButton } from '@itwin/itwinui-react';
+import { SvgCalendar } from '@itwin/itwinui-icons-react';
 
 export default () => {
   const [currentDate, setCurrentDate] = React.useState(new Date());
   return (
-    <DatePicker
-      date={currentDate}
-      onChange={(date) => {
-        setCurrentDate(date);
-      }}
-      showTime={true}
-    />
+    <Popover
+      content={
+        <DatePicker
+          date={currentDate}
+          onChange={(date) => {
+            setCurrentDate(date);
+          }}
+          showTime={true}
+        />
+      }
+      placement='bottom'
+    >
+      <IconButton label='Choose date'>
+        <SvgCalendar />
+      </IconButton>
+    </Popover>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Adds `Popover` elements to 3 `DatePicker` demos. These demos are the 2 Date + Time demos and the Usage demo. The usage demo was updated to show `esc` key functionality. Because the example did not previously use the popover element, the picker could not be closed with the `esc` key. This change fixes that. It also fixes an issue where the `DatePicker` page would scroll to the Date + Time section on load. This was being caused by the `TimePicker` component using the `scrollIntoView`(https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method to make sure that the default values of the picker are displayed when the picker is rendered. This has the unintended effect of  scrolling the page if the picker is rendered on page load. Wrapping the picker in a popover button solves this issue as well.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Made sure that the `DatePicker` documentation page does not scroll to the Date + Time section on reload, and made sure that the `esc` key closes the `Popover` wrapped pickers.

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

The only change that outside users should notice is the Date + Time examples now being a button that user has to activate to see the picker.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
