### PR TITLE
Fix `InputWithDecorations` JSDocs

### DIFF
--- a/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
+++ b/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
@@ -81,7 +81,7 @@ const InputWithDecorationsButton = React.forwardRef((props, ref) => {
  *
  * If you are not using default InputWithDecorations.Icon and InputWithDecorations.Button, use borderless versions of other components.
  *
- * @usage
+ * @example
  * <InputWithDecorations>
  *    <InputWithDecorations.Input />
  *    <InputWithDecorations.Icon>

--- a/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
+++ b/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
@@ -79,7 +79,7 @@ const InputWithDecorationsButton = React.forwardRef((props, ref) => {
  * Input component with various additional decorations.
  * You can add icons, buttons and other various subcomponents to it.
  *
- * If you are not using default `Icon` and {@link InputWithDecorations.Button}, use borderless versions of other components.
+ * If you are not using default `Icon` and `InputWithDecorations.Button`, use borderless versions of other components.
  *
  * @example
  * <InputWithDecorations>

--- a/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
+++ b/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
@@ -79,7 +79,7 @@ const InputWithDecorationsButton = React.forwardRef((props, ref) => {
  * Input component with various additional decorations.
  * You can add icons, buttons and other various subcomponents to it.
  *
- * If you are not using default InputWithDecorations.Icon and InputWithDecorations.Button, use borderless versions of other components.
+ * If you are not using default `Icon` and {@link InputWithDecorations.Button}, use borderless versions of other components.
  *
  * @example
  * <InputWithDecorations>

--- a/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
+++ b/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
@@ -84,9 +84,9 @@ const InputWithDecorationsButton = React.forwardRef((props, ref) => {
  * @example
  * <InputWithDecorations>
  *    <InputWithDecorations.Input />
- *    <InputWithDecorations.Icon>
+ *    <Icon>
  *      <SvgAdd />
- *    </InputWithDecorations.Icon>
+ *    </Icon>
  * </InputWithDecorations>
  */
 export const InputWithDecorations = Object.assign(


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

`InputWithDecorations`'s JSDocs refers a non-existent `InputWithDecorations.Icon` component. This PR replaces that with `Icon`.

I also noticed that the example in the JSDocs for InputWithDecorations was not formatted correctly. This PR also fixes this by replacing `@usage` with `@example`.

|Before|After|
|-|-|
|<img width="673" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/0d926104-0f33-4443-a260-b89e9e0c8957">|<img width="429" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/5a28b1a6-24fa-4600-a606-ea48dc78c851">|


<!--
<img width="412" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/969382b6-69bf-4a35-9377-1faa576c74d4">|
-->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

* Confirmed that the example in `InputWithDecorations`'s JSDocs is now formatted correctly.
* Did a global search for `@usage` and found no other such issues.
* Did a global search for `InputWithDecorations.Icon` and confirmed that there are no more references to this non-existent component.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A