### PR TITLE
Fix `InputGroup.message=<StatusMessage>` rendering two icons

### DIFF
--- a/.changeset/curly-ads-march.md
+++ b/.changeset/curly-ads-march.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": minor
 ---
 
-Fixed `LabeledSelect` bug where nested `<StatusMessage>`s were rendered when `message={<StatusMessage>}`. As a result, now when `typeof message!=="string"`, `message` is no longer automatically wrapped in `<StatusMessage>`. So you might need to manually wrap your custom `ReactNode` with `<StatusMessage>` for proper styling.
+Fixed `LabeledSelect` bug where nested `<StatusMessage>`s were rendered when `message={<StatusMessage>}`. As a result, now when `typeof message!=="string"`, `message` is no longer automatically wrapped in `<StatusMessage>`. So you might need to manually wrap your custom `ReactNode` with `<StatusMessage>` for proper styling of `message`.

--- a/.changeset/curly-ads-march.md
+++ b/.changeset/curly-ads-march.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": minor
 ---
 
-Fixed `LabeledSelect` bug where nested `<StatusMessage>`s were rendered when `message={<StatusMessage>}`. As a result, now when `typeof message!=="string"`, `message` is no longer wrapped in `<StatusMessage>`. So you might need to wrap your custom `ReactNode` with `<StatusMessage>` for proper styling.
+Fixed `LabeledSelect` bug where nested `<StatusMessage>`s were rendered when `message={<StatusMessage>}`. As a result, now when `typeof message!=="string"`, `message` is no longer automatically wrapped in `<StatusMessage>`. So you might need to manually wrap your custom `ReactNode` with `<StatusMessage>` for proper styling.

--- a/.changeset/curly-ads-march.md
+++ b/.changeset/curly-ads-march.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": minor
+---
+
+Fixed `LabeledSelect` bug where nested `<StatusMessage>`s were rendered when `message={<StatusMessage>}`. As a result, now when `typeof message!=="string"`, `message` is no longer wrapped in `<StatusMessage>`. So you might need to wrap your custom `ReactNode` with `<StatusMessage>` for proper styling.

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.test.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.test.tsx
@@ -51,34 +51,50 @@ it('should render required group', () => {
   inputs.forEach((input) => expect(input.required).toBeTruthy());
 });
 
-it('should render message', () => {
-  const { container, getByText } = render(
-    <InputGroup
-      label='some label'
-      message={<div className='my-message'>Message</div>}
-    >
-      <Radio />
-      <Radio />
-      <Radio />
-    </InputGroup>,
-  );
-  expect(container.querySelector('.iui-input-grid')).toBeTruthy();
-  getByText('some label');
-  const message = container.querySelector('.my-message') as HTMLElement;
-  expect(message).toBeTruthy();
-  expect(message.textContent).toBe('Message');
-  expect(container.querySelectorAll('input').length).toBe(3);
-});
+it.each(['string', 'ReactNode'] as const)(
+  'should render message=%s',
+  (messageType) => {
+    const { container, getByText } = render(
+      <InputGroup
+        label='some label'
+        message={
+          messageType === 'string' ? (
+            'Message'
+          ) : (
+            <div className='my-message'>Message</div>
+          )
+        }
+      >
+        <Radio />
+        <Radio />
+        <Radio />
+      </InputGroup>,
+    );
+
+    expect(container.querySelector('.iui-input-grid')).toBeTruthy();
+    getByText('some label');
+
+    let message;
+    // Automatically wrap string message in `<StatusMessage />`
+    if (messageType === 'string') {
+      message = container.querySelector('.iui-status-message') as HTMLElement;
+    }
+    // Do not wrap ReactNode message in `<StatusMessage />`
+    else {
+      expect(container.querySelector('.iui-status-message')).toBeFalsy();
+      message = container.querySelector('.my-message') as HTMLElement;
+    }
+
+    expect(message).toBeTruthy();
+    expect(message.textContent).toBe('Message');
+  },
+);
 
 it.each(['positive', 'negative', 'warning'] as const)(
   'should render %s component',
   (status) => {
     const { container, getByText } = render(
-      <InputGroup
-        label='some label'
-        message={<div className='my-message'>Message</div>}
-        status={status}
-      >
+      <InputGroup label='some label' message='Message' status={status}>
         <Radio />
         <Radio />
         <Radio />

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -89,12 +89,9 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
     disabled = false,
     displayStyle = 'default',
     label,
-    message,
     status,
-    svgIcon,
     required = false,
     labelProps,
-    messageProps,
     innerProps,
     ...rest
   } = props;
@@ -125,29 +122,39 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
       >
         {children}
       </Box>
-      {(() => {
-        // E.g. when message={<StatusMessage />}
-        if (message && typeof message !== 'string') {
-          return message;
-        }
-
-        if (message || status || svgIcon) {
-          return (
-            <StatusMessage
-              iconProps={{
-                'aria-hidden': true,
-              }}
-              startIcon={svgIcon}
-              status={status}
-              {...messageProps}
-            >
-              {displayStyle !== 'inline' && message}
-            </StatusMessage>
-          );
-        }
-
-        return undefined;
-      })()}
+      {<BottomMessage {...props} />}
     </InputGrid>
   );
 }) as PolymorphicForwardRefComponent<'div', InputGroupProps>;
+
+// ------------------------------------------------------------------------------------------------
+
+/**
+ * @private
+ * - When `typeof message !== 'string'`, `message` is returned as-is (e.g. when `message=<StatusMessage />`).
+ * - Else, it is wrapped in a `<StatusMessage />`.
+ */
+const BottomMessage = (props: InputGroupProps) => {
+  const { message, status, svgIcon, displayStyle, messageProps } = props;
+
+  if (message && typeof message !== 'string') {
+    return message;
+  }
+
+  if (message || status || svgIcon) {
+    return (
+      <StatusMessage
+        iconProps={{
+          'aria-hidden': true,
+        }}
+        startIcon={svgIcon}
+        status={status}
+        {...messageProps}
+      >
+        {displayStyle !== 'inline' && message}
+      </StatusMessage>
+    );
+  }
+
+  return undefined;
+};

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -122,7 +122,7 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
       >
         {children}
       </Box>
-      {<BottomMessage {...props} />}
+      <BottomMessage {...props} />
     </InputGrid>
   );
 }) as PolymorphicForwardRefComponent<'div', InputGroupProps>;

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -121,18 +121,29 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
       >
         {children}
       </Box>
-      {(message || status || svgIcon) && (
-        <StatusMessage
-          iconProps={{
-            'aria-hidden': true,
-          }}
-          startIcon={svgIcon}
-          status={status}
-          {...messageProps}
-        >
-          {displayStyle !== 'inline' && message}
-        </StatusMessage>
-      )}
+      {(() => {
+        // E.g. when message={<StatusMessage />}
+        if (message && typeof message !== 'string') {
+          return message;
+        }
+
+        if (message || status || svgIcon) {
+          return (
+            <StatusMessage
+              iconProps={{
+                'aria-hidden': true,
+              }}
+              startIcon={svgIcon}
+              status={status}
+              {...messageProps}
+            >
+              {displayStyle !== 'inline' && message}
+            </StatusMessage>
+          );
+        }
+
+        return undefined;
+      })()}
     </InputGrid>
   );
 }) as PolymorphicForwardRefComponent<'div', InputGroupProps>;

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -24,7 +24,7 @@ type InputGroupProps = {
    *
    * When `typeof message === "string"`, it is automatically wrapped with {@link StatusMessage}.
    * If you are passing a non-string message that is not `<StatusMessage>`, you may need to wrap it with
-   * `<StatusMessage>` yourself for proper styling.
+   * `<StatusMessage>` yourself for proper styling of `message`.
    */
   message?: React.ReactNode;
   /**

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -21,6 +21,10 @@ type InputGroupProps = {
   status?: 'positive' | 'warning' | 'negative';
   /**
    * Message below the group. Does not apply to 'inline' group.
+   *
+   * When `typeof message === "string"`, it is automatically wrapped with {@link StatusMessage}.
+   * If you are passing a non-string message that is not `<StatusMessage>`, you may need to wrap it with
+   * `<StatusMessage>` yourself for proper styling.
    */
   message?: React.ReactNode;
   /**

--- a/playgrounds/vite/src/App.tsx
+++ b/playgrounds/vite/src/App.tsx
@@ -1,96 +1,11 @@
-import * as React from 'react';
-import {
-  Checkbox,
-  Divider,
-  InputGroup,
-  LabeledSelect,
-  Radio,
-  StatusMessage,
-} from '@itwin/itwinui-react';
-import { SvgCheckmark, SvgStar } from '@itwin/itwinui-icons-react';
+import { Button } from '@itwin/itwinui-react';
 
-export default function App() {
-  const CustomDivider = () => (
-    <Divider
-      style={{
-        margin: '10px',
-      }}
-    />
-  );
-
+const App = () => {
   return (
     <>
-      {/* ✅ LabeledSelect */}
-      <LabeledSelect
-        label='Select Label'
-        options={[
-          { value: 1, label: 'Item #1' },
-          { value: 2, label: 'Item #2' },
-          { value: 3, label: 'Item #3' },
-        ]}
-        status='positive'
-        svgIcon={<SvgStar />}
-        message={'Help message'}
-      />
-
-      <LabeledSelect
-        label='Select Label'
-        options={[
-          { value: 1, label: 'Item #1' },
-          { value: 2, label: 'Item #2' },
-          { value: 3, label: 'Item #3' },
-        ]}
-        status='positive'
-        message={
-          <StatusMessage status='positive' startIcon={<SvgStar />}>
-            Help message
-          </StatusMessage>
-        }
-      />
-
-      <CustomDivider />
-
-      {/* ❌ InputGroup */}
-      <InputGroup
-        label='Checkbox group'
-        svgIcon={<SvgStar />}
-        status='positive'
-        message='Help message'
-      >
-        <Checkbox label='Select all' />
-        <Checkbox label='Football' />
-        <Checkbox label='Hockey' />
-      </InputGroup>
-
-      {/* ❌ Passing <StatusMessage startIcon={…} /> to the message of <InputGroup status="…" /> shows duplicate status icons */}
-      <InputGroup
-        label='Checkbox group'
-        status='positive'
-        svgIcon={<SvgCheckmark />}
-        message='Help message'
-        // message={
-        //   <StatusMessage startIcon={<SvgStar />} status='positive'>
-        //     Help message
-        //   </StatusMessage>
-        // }
-      >
-        <Checkbox label='Select all' />
-        <Checkbox label='Football' />
-        <Checkbox label='Hockey' />
-      </InputGroup>
-
-      <InputGroup
-        label='some label'
-        message={
-          <StatusMessage>
-            <div className='my-message'>Message</div>
-          </StatusMessage>
-        }
-      >
-        <Radio />
-        <Radio />
-        <Radio />
-      </InputGroup>
+      <Button>Hello world</Button>
     </>
   );
-}
+};
+
+export default App;

--- a/playgrounds/vite/src/App.tsx
+++ b/playgrounds/vite/src/App.tsx
@@ -1,11 +1,80 @@
-import { Button } from '@itwin/itwinui-react';
+import * as React from 'react';
+import {
+  Checkbox,
+  Divider,
+  InputGroup,
+  LabeledSelect,
+  StatusMessage,
+} from '@itwin/itwinui-react';
+import { SvgStar } from '@itwin/itwinui-icons-react';
 
-const App = () => {
+export default function App() {
+  const CustomDivider = () => (
+    <Divider
+      style={{
+        margin: '10px',
+      }}
+    />
+  );
+
   return (
     <>
-      <Button>Hello world</Button>
+      {/* ✅ LabeledSelect */}
+      <LabeledSelect
+        label='Select Label'
+        options={[
+          { value: 1, label: 'Item #1' },
+          { value: 2, label: 'Item #2' },
+          { value: 3, label: 'Item #3' },
+        ]}
+        status='positive'
+        svgIcon={<SvgStar />}
+        message={'Help message'}
+      />
+
+      <LabeledSelect
+        label='Select Label'
+        options={[
+          { value: 1, label: 'Item #1' },
+          { value: 2, label: 'Item #2' },
+          { value: 3, label: 'Item #3' },
+        ]}
+        status='positive'
+        message={
+          <StatusMessage status='positive' startIcon={<SvgStar />}>
+            Help message
+          </StatusMessage>
+        }
+      />
+
+      <CustomDivider />
+
+      {/* ❌ InputGroup */}
+      <InputGroup
+        label='Checkbox group'
+        svgIcon={<SvgStar />}
+        status='positive'
+        message='Help message'
+      >
+        <Checkbox label='Select all' />
+        <Checkbox label='Football' />
+        <Checkbox label='Hockey' />
+      </InputGroup>
+
+      {/* ❌ Passing <StatusMessage startIcon={…} /> to the message of <InputGroup status="…" /> shows duplicate status icons */}
+      <InputGroup
+        label='Checkbox group'
+        status='positive'
+        message={
+          <StatusMessage startIcon={<SvgStar />} status='positive'>
+            Help message
+          </StatusMessage>
+        }
+      >
+        <Checkbox label='Select all' />
+        <Checkbox label='Football' />
+        <Checkbox label='Hockey' />
+      </InputGroup>
     </>
   );
-};
-
-export default App;
+}

--- a/playgrounds/vite/src/App.tsx
+++ b/playgrounds/vite/src/App.tsx
@@ -4,6 +4,7 @@ import {
   Divider,
   InputGroup,
   LabeledSelect,
+  Radio,
   StatusMessage,
 } from '@itwin/itwinui-react';
 import { SvgCheckmark, SvgStar } from '@itwin/itwinui-icons-react';
@@ -76,6 +77,19 @@ export default function App() {
         <Checkbox label='Select all' />
         <Checkbox label='Football' />
         <Checkbox label='Hockey' />
+      </InputGroup>
+
+      <InputGroup
+        label='some label'
+        message={
+          <StatusMessage>
+            <div className='my-message'>Message</div>
+          </StatusMessage>
+        }
+      >
+        <Radio />
+        <Radio />
+        <Radio />
       </InputGroup>
     </>
   );

--- a/playgrounds/vite/src/App.tsx
+++ b/playgrounds/vite/src/App.tsx
@@ -6,7 +6,7 @@ import {
   LabeledSelect,
   StatusMessage,
 } from '@itwin/itwinui-react';
-import { SvgStar } from '@itwin/itwinui-icons-react';
+import { SvgCheckmark, SvgStar } from '@itwin/itwinui-icons-react';
 
 export default function App() {
   const CustomDivider = () => (
@@ -65,11 +65,13 @@ export default function App() {
       <InputGroup
         label='Checkbox group'
         status='positive'
-        message={
-          <StatusMessage startIcon={<SvgStar />} status='positive'>
-            Help message
-          </StatusMessage>
-        }
+        svgIcon={<SvgCheckmark />}
+        message='Help message'
+        // message={
+        //   <StatusMessage startIcon={<SvgStar />} status='positive'>
+        //     Help message
+        //   </StatusMessage>
+        // }
       >
         <Checkbox label='Select all' />
         <Checkbox label='Football' />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

After-PR TODO from #1753 

Earlier, `message` was always wrapped in `<StatusMessage>`. This caused nested `<StatusMessage>`s when `message={<StatusMessage>}`. Nested StatusMessages could lead to double svgIcons:

<details>
<summary>Example code</summary>

```jsx
{/* ❌ Passing <StatusMessage startIcon={…} /> to the message of <InputGroup status="…" /> shows duplicate status icons */}
<InputGroup
  label='Checkbox group'
  status='positive'
  message={
    <StatusMessage startIcon={<SvgStar />} status='positive'>
      Help message
    </StatusMessage>
  }
>
  <Checkbox label='Select all' />
  <Checkbox label='Football' />
  <Checkbox label='Hockey' />
</InputGroup>
```

</details>

![image](https://github.com/iTwin/iTwinUI/assets/45748283/0f629263-1eb3-419f-8846-535771e88046)

This PR now wraps `message` in `<StatusMessage>` only when `typeof message !== "string"`. This fixes the duplicate svgIcons issue.

![image](https://github.com/iTwin/iTwinUI/assets/45748283/0bcf1437-4adf-4752-bae2-cfe6a981bdf7)

As a result of this change, if users were passing `ReactNode`s that are not `<StatusMessage>` to `message`, they might need to manually wrap their `ReactNode` with `<StatusMessage>` for proper styling of `message`.

<details>
<summary>Example code</summary>

```jsx
<InputGroup
  label='some label'
  message={<div className='my-message'>Message</div>}
>
  <Radio />
  <Radio />
  <Radio />
</InputGroup>
```
</details>

|Previously|Now|
|-|-|
|![image](https://github.com/iTwin/iTwinUI/assets/45748283/c4196b34-61d6-49ea-9724-3b5fefb1ceb3)|![image](https://github.com/iTwin/iTwinUI/assets/45748283/a2cb9c77-5139-4e1b-9f68-196c3f41a1ae)|

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

* Updated unit test to confirm that `message` is not wrapped in `<StatusMessage>` when `typeof message !== 'string'`.
* Fixed failing tests

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Updated JSDocs of `message` to tell that `message` is automatically wrapped with `<StatusMessage>` when `typeof message === 'string'`. It also tells that users may need to wrap their non-string & non-StatusMessage `message` with `<StatusMessage>` for proper styling.