### PR TITLE
Fix `<Placeholder>` react stories' links on docs site

### DIFF
--- a/apps/website/src/content/docs/flex.mdx
+++ b/apps/website/src/content/docs/flex.mdx
@@ -8,7 +8,7 @@ group: utilities
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='flex' />
+<Placeholder componentPageName='flex--basic' />
 
 <LiveExample src='Flex.main.jsx'>
   <AllExamples.FlexMainExample client:load />

--- a/apps/website/src/content/docs/progressindicator.mdx
+++ b/apps/website/src/content/docs/progressindicator.mdx
@@ -8,9 +8,9 @@ thumbnail: ProgressIndicator
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='progressindicators' />
-
 ## Progress linear
+
+<Placeholder componentPageName='progresslinear--determinate' />
 
 <LiveExample src='ProgressLinear.main.jsx' truncate={false}>
   <AllExamples.ProgressLinearMainExample client:load />
@@ -21,6 +21,8 @@ thumbnail: ProgressIndicator
 <PropsTable path={frontmatter.propsPath1} />
 
 ## Progress radial
+
+<Placeholder componentPageName='progressradial--determinate' />
 
 <LiveExample src='ProgressRadial.main.jsx' truncate={false}>
   <AllExamples.ProgressRadialMainExample client:load />

--- a/apps/website/src/content/docs/table.mdx
+++ b/apps/website/src/content/docs/table.mdx
@@ -7,7 +7,7 @@ thumbnail: Table
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='table' />
+<Placeholder componentPageName='table--basic' />
 
 <LiveExample src='Table.main.jsx'>
   <AllExamples.TableMainExample client:load />

--- a/apps/website/src/content/docs/toast.mdx
+++ b/apps/website/src/content/docs/toast.mdx
@@ -7,7 +7,7 @@ thumbnail: Toast
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='toast' />
+<Placeholder componentPageName='toasts--positive' />
 
 <LiveExample src='Toast.main.jsx'>
   <AllExamples.ToastMainExample client:load />

--- a/apps/website/src/content/docs/tree.mdx
+++ b/apps/website/src/content/docs/tree.mdx
@@ -7,7 +7,7 @@ thumbnail: Tree
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='tree' />
+<Placeholder componentPageName='tree--basic' />
 
 <LiveExample src='Tree.main.jsx'>
   <AllExamples.TreeMainExample client:load />

--- a/apps/website/src/content/docs/typography.mdx
+++ b/apps/website/src/content/docs/typography.mdx
@@ -8,7 +8,7 @@ thumbnail: Typography
 
 <p>{frontmatter.description}</p>
 
-<Placeholder componentPageName='text' />
+<Placeholder componentPageName='text--basic' />
 
 ## Text
 
@@ -21,6 +21,8 @@ thumbnail: Typography
 <PropsTable path={frontmatter.propsPathText} />
 
 ## Label
+
+<Placeholder componentPageName='label--basic' />
 
 <LiveExample src='Label.main.jsx' truncate={false}>
   <AllExamples.LabelMainExample client:load />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

This PR fixes the `<Placeholder>` links on the docs site that should navigate to the `Basic` or first story for that component.

![image](https://github.com/iTwin/iTwinUI/assets/45748283/8b800a80-f375-41b1-8cc7-872eaa151e0f)

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Ensured that clicking the story link in the placeholder navigates to the correct story.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A