### PR TITLE
reinforce `content-box` using `!important`

### DIFF
--- a/.changeset/silly-rockets-sip.md
+++ b/.changeset/silly-rockets-sip.md
@@ -1,0 +1,6 @@
+---
+"@itwin/itwinui-css": patch
+"@itwin/itwinui-react": patch
+---
+
+All instances of `box-sizing: content-box` have been reinforced with `!important` to prevent accidental overrides from application styles.

--- a/packages/itwinui-css/src/avatar/avatar.scss
+++ b/packages/itwinui-css/src/avatar/avatar.scss
@@ -58,7 +58,7 @@ $avatar-text-color: hsl(0 0% 0% / 0.77);
   &[data-iui-status] {
     &::after {
       content: '';
-      box-sizing: content-box;
+      box-sizing: content-box !important;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/packages/itwinui-css/src/header/header.scss
+++ b/packages/itwinui-css/src/header/header.scss
@@ -96,7 +96,7 @@
 .iui-header-breadcrumbs,
 .iui-header-breadcrumbs-list {
   overflow: hidden;
-  box-sizing: content-box;
+  box-sizing: content-box !important;
   margin-block-end: calc(0px - var(--iui-size-2xs));
   padding-block-end: var(--iui-size-2xs);
 }

--- a/packages/itwinui-css/src/side-navigation/side-navigation.scss
+++ b/packages/itwinui-css/src/side-navigation/side-navigation.scss
@@ -56,7 +56,7 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   }
 
   &.iui-collapsed {
-    box-sizing: content-box;
+    box-sizing: content-box !important;
 
     $icon-large: map.get(mixins.$iui-icon-sizes, l);
 

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -217,7 +217,7 @@ $iui-slider-tick-thickness: 1px;
 }
 
 .iui-slider-thumb {
-  box-sizing: content-box;
+  box-sizing: content-box !important;
   position: absolute;
   block-size: $iui-slider-thumb-size;
   inline-size: $iui-slider-thumb-size;

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -291,7 +291,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 
 @mixin iui-tile-thumbnail {
   order: -1;
-  box-sizing: content-box;
+  box-sizing: content-box !important;
   block-size: calc(var(--iui-size-s) * 13);
   flex-shrink: 0;
   overflow: hidden;

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -13,7 +13,7 @@
   max-inline-size: 400px;
   inline-size: max-content;
   overflow-wrap: break-word;
-  box-sizing: content-box;
+  box-sizing: content-box !important;
   padding-block: calc(var(--iui-size-s) * 0.33);
   padding-inline: var(--iui-size-xs);
   z-index: 999;


### PR DESCRIPTION
## Changes

Ever since introducing layers, application styles always win and usually contain a box-sizing reset which overrides our layered styles. (This can even be seen in some of our playgrounds)

```css
/* This is zero-specificity but still wins over layered iTwinUI styles */
* {
  box-sizing: border-box;
}
```

The correct solution would be for applications to put their resets in a lower-priority layer, but they might not even realize this needs to be done (even though it's [documented](https://github.com/iTwin/iTwinUI/wiki/Styling)), or it might be coming from third-party styles. Adding `!important` helps avoid these issues altogether, serving as a safeguard and reducing the onus on applications.

**Note**: `!important` is generally frowned upon because it is overused as a hack for specificity battles. But in this case we are actually using `!important` for its intended purpose. It's like saying "We know that this should always be `content-box`, so you should not be allowed to override it.".

## Testing

N/A

## Docs

N/A
