### PR TITLE
fix Table `columnOrder` resetting incorrectly

### DIFF
--- a/.changeset/sharp-gorillas-search.md
+++ b/.changeset/sharp-gorillas-search.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a bug in `Table` where `initialState.columnOrder` was not being respected.

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -3685,6 +3685,29 @@ it.each([
   },
 );
 
+it('should respect initialState.columnOrder', () => {
+  const mockColumns = columns();
+  const columnOrder = ['description', 'view', 'name'];
+
+  const { container } = render(
+    <Table
+      columns={mockColumns}
+      data={mockedData()}
+      emptyTableContent='Empty table'
+      initialState={{ columnOrder }}
+    />,
+  );
+
+  // DOM order should match columnOrder
+  container
+    .querySelectorAll<HTMLDivElement>('[role=columnheader]')
+    .forEach((cell, index) =>
+      expect(cell.textContent).toBe(
+        mockColumns.find((c) => c.id === columnOrder[index])?.Header,
+      ),
+    );
+});
+
 it('should not have `draggable` attribute on columns with `disableReordering` enabled', () => {
   const columns: Column<TestDataType>[] = [
     {

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -717,7 +717,10 @@ export const Table = <
   // This is to avoid the old columnOrder from affecting the new columns' columnOrder
   React.useEffect(() => {
     // Check if columns have changed (by value)
-    if (JSON.stringify(lastPassedColumns.current) !== JSON.stringify(columns)) {
+    if (
+      lastPassedColumns.current.length > 0 &&
+      JSON.stringify(lastPassedColumns.current) !== JSON.stringify(columns)
+    ) {
       instance.setColumnOrder([]);
     }
     lastPassedColumns.current = columns;


### PR DESCRIPTION
## Changes

Fixes #1899.

The root cause was that the initial value of `lastPassedColumns` is `[]` so it was always resetting the columns. `[]` is never valid so I've added a simple check for it.

## Testing

Tested in playground (using [linked sandbox](https://stackblitz.com/edit/github-y5zcvc?file=src%2FDraggableColumns.tsx)) and added unit test.

## Docs

N/A