### PR TITLE
No more incorrect rest props in `InputGroup`'s DOM

### DIFF
--- a/.changeset/hungry-hats-think.md
+++ b/.changeset/hungry-hats-think.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed an `InputGroup` bug where some variables were unnecessarily added as attribute-value pairs to the DOM.

--- a/.changeset/hungry-hats-think.md
+++ b/.changeset/hungry-hats-think.md
@@ -1,5 +1,0 @@
----
-"@itwin/itwinui-react": patch
----
-
-Fixed an `InputGroup` bug where some variables were unnecessarily added as attribute-value pairs to the DOM.

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -93,6 +93,9 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
     required = false,
     labelProps,
     innerProps,
+    message,
+    svgIcon,
+    messageProps,
     ...rest
   } = props;
 
@@ -122,7 +125,13 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
       >
         {children}
       </Box>
-      <BottomMessage {...props} />
+      <BottomMessage
+        message={message}
+        status={status}
+        svgIcon={svgIcon}
+        displayStyle={displayStyle}
+        messageProps={messageProps}
+      />
     </InputGrid>
   );
 }) as PolymorphicForwardRefComponent<'div', InputGroupProps>;
@@ -134,7 +143,12 @@ export const InputGroup = React.forwardRef((props, forwardedRef) => {
  * - When `typeof message !== 'string'`, `message` is returned as-is (e.g. when `message=<StatusMessage />`).
  * - Else, it is wrapped in a `<StatusMessage />`.
  */
-const BottomMessage = (props: InputGroupProps) => {
+const BottomMessage = (
+  props: Pick<
+    InputGroupProps,
+    'message' | 'status' | 'svgIcon' | 'displayStyle' | 'messageProps'
+  >,
+) => {
   const { message, status, svgIcon, displayStyle, messageProps } = props;
 
   if (message && typeof message !== 'string') {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

This PR fixes an issue that @mayank99 noticed: some variables were added to `InputGroup`'s DOM as attribute-value pairs.

This was happening because in #1877, I was no longer deconstructing the variables passed to the new helper component, `BottomMessage`. Thus, the non-deconstructed variables were included in `rest` and added to the DOM.

This PR fixes that by properly deconstructing the props that shouldn't be in the DOM and then passing them down to the helper component (`BottomMessage`).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed manually that `BottomMessage` props are no longer showing up in the DOM.

I thought against having unit tests since this might be too specific. But I can add it if anyone feels differently.

<details>
<summary>App.tsx (vite-playground)</summary>

```jsx
import { SvgStar } from '@itwin/itwinui-icons-react';
import { Checkbox, InputGroup } from '@itwin/itwinui-react';

const App = () => {
  return (
    <>
      <InputGroup
        label='Checkbox group'
        message='Foobar'
        status='positive'
        svgIcon={<SvgStar />}
        displayStyle='default'
        messageProps={{
          contentProps: {
            color: 'hotpink',
          },
        }}
      >
        <Checkbox />
        <Checkbox />
      </InputGroup>
    </>
  );
};

export default App;

```

</details>

Result of the code:

|Old|New|
|-|-|
|![image](https://github.com/iTwin/iTwinUI/assets/45748283/7e202d02-7731-409e-b89e-3ca62a3e6c31)|![image](https://github.com/iTwin/iTwinUI/assets/45748283/5e8eef3c-233c-4046-b7d6-d394421cb108)|

<!-- ![image](https://github.com/iTwin/iTwinUI/assets/45748283/6ee69495-1dfb-454d-9f1e-c4f44b85d3ff) 

![image](https://github.com/iTwin/iTwinUI/assets/45748283/46de8083-9c29-40ab-bb71-3c94d1f2b9cf)
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

No changeset since #1877 is not released yet. (https://github.com/iTwin/iTwinUI/pull/1903#discussion_r1516398299)