### PR TITLE
fix dialog title overflow

### DIFF
--- a/.changeset/tame-foxes-deliver.md
+++ b/.changeset/tame-foxes-deliver.md
@@ -1,0 +1,6 @@
+---
+"@itwin/itwinui-css": patch
+"@itwin/itwinui-react": patch
+---
+
+Dialog title will now wrap to multiple lines instead of getting clippped.

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -133,12 +133,6 @@ $iui-dialog-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins
 }
 
 .iui-dialog-title {
-  display: flex;
-  align-items: center;
-  font-size: inherit;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   margin-inline-end: auto;
 }
 


### PR DESCRIPTION
## Changes

Fixes #1904 by removing `whitespace: nowrap`, along with other redundant CSS declarations.

## Testing

Tested by manually recreating the linked issue in playground.

![](https://github.com/iTwin/iTwinUI/assets/9084735/f102df6d-c2f9-49f1-97c7-94aed698ab9f)


## Docs

N/A