### PR TITLE
fix release command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "approve:react": "pnpm --filter react-workshop approve",
     "clean": "turbo run clean && rimraf node_modules",
     "changeset": "npx -y @changesets/cli",
-    "release": "pnpm run build --filter={./packages/*}... && pnpm changeset publish"
+    "release": "pnpm run build --filter=\"{./packages/*}...\" && pnpm changeset publish"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
## Changes

Pnpm seems to require quotes when passing ambiguous arguments, or it will fail.

## Testing

Works locally.

Not possible to test this specific workflow in CI until the PR merges, *but* we have used this exact command (with quotes) in CI in another place, where it works fine.

https://github.com/iTwin/iTwinUI/blob/28416c116f21989040d2fb5f67b29ab123867ab9/.github/workflows/build.yml#L78

## Docs

N/A