### PR TITLE
Fix commands with pnpm's `--filter` in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ By default, a portal will be opened containing links to all the different dev se
 If a script is not available in the root package.json or if you need to pass workspace-specific cli args, then you can specify the workspace as follows:
 ```
 # passing Alert as a cli arg to the `test` command in itwinui-react
-pnpm --filter @itwin/itwinui-react test Alert
+pnpm --filter=@itwin/itwinui-react test Alert
 ```
 
 ...or you can simply run the command normally from inside the workspace folder instead of the monorepo root.
@@ -103,8 +103,8 @@ pnpm test Alert
 
 Note that this bypasses the turborepo pipeline, so you will need to manually run any dependent tasks first. For example, if the `build` command of `react-workshop` relies on the `build` command of `@itwin/itwinui-react`, then you will need to manually run the `build` commands in the right order.
 ```
-pnpm --filter @itwin/itwinui-react build
-pnpm --filter react-workshop build
+pnpm --filter=@itwin/itwinui-react build
+pnpm --filter=react-workshop build
 ```
 
 This is why it's recommended to use the turbo `--filter` syntax whenever possible.
@@ -277,7 +277,7 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
 
 - Make sure Docker is running.
 - To run tests for a specific component, use this command:
-  `pnpm --filter css-workshop test -- --filter=[component_name]` (e.g. `pnpm --filter css-workshop test -- --filter=side-navigation`). But don't forget to build css-workshop first (pnpm build --filter=css-workshop).
+  `pnpm --filter=css-workshop test -- --filter=[component_name]` (e.g. `pnpm --filter=css-workshop test -- --filter=side-navigation`). But don't forget to build css-workshop first (pnpm build --filter=css-workshop).
 - To approve test images, run `pnpm approve:css`.
 
 #### How to write tests:
@@ -315,7 +315,7 @@ We reuse our stories for visual tests by taking screenshots of the story iframes
 
 1. Make sure you have [Docker](https://www.docker.com/get-started) installed and running.
 2. From the monorepo root, run `pnpm run test --filter=react-workshop`. This will build react-workshop and run all cypress tests in docker.
-   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `pnpm --filter react-workshop test -- --spec="**/Alert.*"`. But don't forget to build react-workshop first (pnpm run build --filter=react-workshop).
+   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `pnpm --filter=react-workshop test -- --spec="**/Alert.*"`. But don't forget to build react-workshop first (pnpm run build --filter=react-workshop).
 3. Once the tests finish running, you can approve any failing test images using `pnpm approve:react`.
 
 #### Writing visual tests
@@ -362,7 +362,7 @@ In the terminal:
 
 In the Cypress GUI:
 
-1. From the monorepo root, run `pnpm run --filter a11y open`. This will open the Cypress control panel where you can run the tests.
+1. From the monorepo root, run `pnpm run --filter=a11y open`. This will open the Cypress control panel where you can run the tests.
 2. Choose a browser to evaluate your tests through, then press the `Start Component Testing in [YourBrowser]` button below.
 3. Select `Component.cy.tsx` to run the script that tests all of the component examples.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,8 @@ pnpm test Alert
 
 Note that this bypasses the turborepo pipeline, so you will need to manually run any dependent tasks first. For example, if the `build` command of `react-workshop` relies on the `build` command of `@itwin/itwinui-react`, then you will need to manually run the `build` commands in the right order.
 ```
-pnpm --filter=@itwin/itwinui-react build
-pnpm --filter=react-workshop build
+pnpm --filter=@itwin/itwinui-react run build
+pnpm --filter=react-workshop run build
 ```
 
 This is why it's recommended to use the turbo `--filter` syntax whenever possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,7 +372,7 @@ In the terminal:
 
 In the Cypress GUI:
 
-1. From the monorepo root, run `pnpm run --filter=a11y open`. This will open the Cypress control panel where you can run the tests.
+1. From the monorepo root, run `pnpm --filter=a11y run open`. This will open the Cypress control panel where you can run the tests.
 2. Choose a browser to evaluate your tests through, then press the `Start Component Testing in [YourBrowser]` button below.
 3. Select `Component.cy.tsx` to run the script that tests all of the component examples.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ By default, a portal will be opened containing links to all the different dev se
 If a script is not available in the root package.json or if you need to pass workspace-specific cli args, then you can specify the workspace as follows:
 ```
 # passing Alert as a cli arg to the `test` command in itwinui-react
-pnpm --filter=@itwin/itwinui-react test Alert
+pnpm --filter=@itwin/itwinui-react run test Alert
 ```
 
 ...or you can simply run the command normally from inside the workspace folder instead of the monorepo root.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,7 @@ For running tests you will need [Docker](https://www.docker.com/products/docker-
 
 - Make sure Docker is running.
 - To run tests for a specific component, use this command:
-  `pnpm --filter=css-workshop test -- --filter=[component_name]` (e.g. `pnpm --filter=css-workshop test -- --filter=side-navigation`). But don't forget to build css-workshop first (pnpm build --filter=css-workshop).
+  `pnpm --filter=css-workshop run test --filter=[component_name]` (e.g. `pnpm --filter=css-workshop run test --filter=side-navigation`). But don't forget to build css-workshop first (pnpm build --filter=css-workshop).
 - To approve test images, run `pnpm approve:css`.
 
 #### How to write tests:
@@ -315,7 +315,7 @@ We reuse our stories for visual tests by taking screenshots of the story iframes
 
 1. Make sure you have [Docker](https://www.docker.com/get-started) installed and running.
 2. From the monorepo root, run `pnpm run test --filter=react-workshop`. This will build react-workshop and run all cypress tests in docker.
-   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `pnpm --filter=react-workshop test -- --spec="**/Alert.*"`. But don't forget to build react-workshop first (pnpm run build --filter=react-workshop).
+   -  If you only need to run tests for a specific component, you can do so by passing the `--spec` argument to cypress. e.g. for testing `Alert`, you can run `pnpm --filter=react-workshop run test --spec="**/Alert.*"`. But don't forget to build react-workshop first (pnpm run build --filter=react-workshop).
 3. Once the tests finish running, you can approve any failing test images using `pnpm approve:react`.
 
 #### Writing visual tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,14 @@ This is why it's recommended to use the turbo `--filter` syntax whenever possibl
 pnpm run build --filter=react-workshop
 ```
 
+> [!NOTE]
+>
+> The `--filter` argument is used in both `turbo` and `pnpm`. To use it with:
+> * `turbo`: `pnpm run [command] --filter=[workspace]`
+>   * e.g. `pnpm run build --filter=react-workshop`
+> * `pnpm`: `pnpm --filter=[workspace] run [command]`
+>   * e.g. `pnpm --filter=react-workshop run build`
+
 ---
 
 ### Creating components

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,13 @@ pnpm run build --filter=react-workshop
 
 > [!NOTE]
 >
-> The `--filter` argument is used in both `turbo` and `pnpm`. To use it with:
-> * `turbo`: `pnpm run [command] --filter=[workspace]`
->   * e.g. `pnpm run build --filter=react-workshop`
-> * `pnpm`: `pnpm --filter=[workspace] run [command]`
->   * e.g. `pnpm --filter=react-workshop run build`
+> The `--filter` syntax is available in both `turbo` and `pnpm`. The usage looks slightly different:
+> - `turbo`: `pnpm run [command] --filter=[workspace]`
+>   - e.g. `pnpm run build --filter=@itwin/itwinui-react`
+>   - This will also run any dependent tasks defined in the Turbo pipeline, but does not allow args. (See [Turborepo docs](https://turbo.build/repo/docs/core-concepts/monorepos/filtering)).
+> - `pnpm`: `pnpm --filter=[workspace] run [command] [args]`
+>   - e.g. `pnpm --filter=@itwin/itwinui-react run test Alert`
+>   - This will only run the task per-workspace and supports additional args. (See [Pnpm docs](https://pnpm.io/filtering)).
 
 ---
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@AdamMeza-Bentley noticed some issues with running pnpm's `--filter` without an `=` inside of [`spawn`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options). This PR updates the `CONTIRBUTING.md` to use `=` in pnpm's`--filter`, to ensure the filtering always works.

Additionally, it uses `run` instead of having to use `--` to pass args to the inner script.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Tested the modified commands to ensure that they still work as expected.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A