### PR TITLE
setup partial premajor releases for css

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create release PR or publish to npm
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version
+          version: pnpm changeset version --ignore @itwin/itwinui-css
           publish: pnpm release
           title: Release packages
           commit: Release packages

--- a/apps/css-workshop/package.json
+++ b/apps/css-workshop/package.json
@@ -5,8 +5,6 @@
   "description": "Workshop environment containing HTML pages demonstrating itwinui-css",
   "dependencies": {},
   "devDependencies": {
-    "@itwin/itwinui-variables": "*",
-    "@itwin/itwinui-css": "*",
     "@itwin/itwinui-icons-elements": "0.20.0",
     "autoprefixer": "^10",
     "backstopjs": "~6.2.1",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -11,8 +11,6 @@
     "clean": "rimraf .turbo && rimraf node_modules && rimraf dist"
   },
   "dependencies": {
-    "@itwin/itwinui-css": "*",
-    "@itwin/itwinui-variables": "*",
     "astro": "4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@itwin/itwinui-css": "workspace:*",
+    "@itwin/itwinui-variables": "workspace:*",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^8.2.2",
     "husky": "^9.0.10",

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@itwin/itwinui-css",
+  "private": true,
   "version": "2.5.0",
   "author": "Bentley Systems",
   "license": "MIT",

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -85,8 +85,6 @@
     "tslib": "^2.6.0"
   },
   "devDependencies": {
-    "@itwin/itwinui-css": "workspace:*",
-    "@itwin/itwinui-variables": "workspace:*",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.68",
     "@testing-library/jest-dom": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
 
   .:
     devDependencies:
+      '@itwin/itwinui-css':
+        specifier: workspace:*
+        version: link:packages/itwinui-css
+      '@itwin/itwinui-variables':
+        specifier: workspace:*
+        version: link:packages/itwinui-variables
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
@@ -49,15 +55,9 @@ importers:
 
   apps/css-workshop:
     devDependencies:
-      '@itwin/itwinui-css':
-        specifier: '*'
-        version: link:../../packages/itwinui-css
       '@itwin/itwinui-icons-elements':
         specifier: 0.20.0
         version: 0.20.0
-      '@itwin/itwinui-variables':
-        specifier: '*'
-        version: link:../../packages/itwinui-variables
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.17(postcss@8.4.34)
@@ -76,12 +76,6 @@ importers:
 
   apps/portal:
     dependencies:
-      '@itwin/itwinui-css':
-        specifier: '*'
-        version: link:../../packages/itwinui-css
-      '@itwin/itwinui-variables':
-        specifier: '*'
-        version: link:../../packages/itwinui-variables
       astro:
         specifier: '4'
         version: 4.0.7(lightningcss@1.22.1)(sass@1.69.5)(typescript@5.1.6)
@@ -329,12 +323,6 @@ importers:
         specifier: ^2.6.0
         version: 2.6.1
     devDependencies:
-      '@itwin/itwinui-css':
-        specifier: workspace:*
-        version: link:../itwinui-css
-      '@itwin/itwinui-variables':
-        specifier: workspace:*
-        version: link:../itwinui-variables
       '@swc/cli':
         specifier: ^0.1.62
         version: 0.1.62(@swc/core@1.3.101)

--- a/turbo.json
+++ b/turbo.json
@@ -11,16 +11,20 @@
       "outputs": ["css/**"]
     },
     "@itwin/itwinui-react#build": {
-      "dependsOn": [
-        "^build",
-        "@itwin/itwinui-css#build",
-        "@itwin/itwinui-variables#build"
-      ],
+      "dependsOn": ["^build", "@itwin/itwinui-css#build"],
       "outputs": ["esm/**", "cjs/**"]
+    },
+    "css-workshop#build": {
+      "dependsOn": ["@itwin/itwinui-css#build"],
+      "outputs": ["dist/**", "build/**"]
     },
     "react-workshop#build": {
       "dependsOn": ["^build"],
       "outputs": ["build/**"]
+    },
+    "portal": {
+      "dependsOn": ["@itwin/itwinui-css#build"],
+      "outputs": ["dist/**"]
     },
     "test": {},
     "react-workshop#test": {
@@ -28,8 +32,7 @@
       "outputs": ["dist/**", "build/**"]
     },
     "css-workshop#test": {
-      "dependsOn": ["build"],
-      "outputs": ["dist/**", "build/**"]
+      "dependsOn": ["build"]
     },
     "a11y#test": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,11 @@
       "outputs": ["css/**"]
     },
     "@itwin/itwinui-react#build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build",
+        "@itwin/itwinui-css#build",
+        "@itwin/itwinui-variables#build"
+      ],
       "outputs": ["esm/**", "cjs/**"]
     },
     "react-workshop#build": {


### PR DESCRIPTION
## Changes

After lots of iteration and experimentation, this PR makes the following changes:
- Ignores `@itwin/itwinui-css` from `pnpm changeset version`, so that its version does not get bumped.
- Makes it `private` to prevent accidental publish (until major release is ready).
- Removes it from dependencies of all workspaces, and adjusts turbo pipeline to manually depend on it.
  - This is necessary because `pnpm changeset` does not allow adding changesets to packages that depend on ignored workspaces.

As a result, the `main` branch can be used to add `major` changesets to `@itwin/itwinui-css`. When releasing, it will be ignored without blocking the normal release of other packages.

Only difference to regular workflow is that itwinui-css changesets now always need to be standalone, rather than being grouped with itwinui-react.

## Testing

Tested creating changesets for `@itwin/itwinui-css` and `@itwin/itwinui-react`, then running `pnpm changeset version --ignore @itwin/itwinui-css` to ensure that only react package gets versioned. The css changesets do not get deleted.

## Docs

N/A