### PR TITLE
Fix Broken Tabs Demo Styling

### DIFF
--- a/examples/Tabs.actions.css
+++ b/examples/Tabs.actions.css
@@ -1,0 +1,3 @@
+.demo-container {
+  width: 100%;
+}

--- a/examples/Tabs.actions.css
+++ b/examples/Tabs.actions.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.actions.jsx
+++ b/examples/Tabs.actions.jsx
@@ -7,7 +7,7 @@ import { Tabs, Button } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper className='demo-container'>
+    <Tabs.Wrapper>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.actions.jsx
+++ b/examples/Tabs.actions.jsx
@@ -7,7 +7,7 @@ import { Tabs, Button } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper>
+    <Tabs.Wrapper className='demo-container'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.borderless.css
+++ b/examples/Tabs.borderless.css
@@ -1,0 +1,3 @@
+.demo-container {
+  width: 100%;
+}

--- a/examples/Tabs.borderless.css
+++ b/examples/Tabs.borderless.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.borderless.jsx
+++ b/examples/Tabs.borderless.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='borderless' className='demo-container'>
+    <Tabs.Wrapper type='borderless'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.borderless.jsx
+++ b/examples/Tabs.borderless.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='borderless'>
+    <Tabs.Wrapper type='borderless' className='demo-container'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.controlled.css
+++ b/examples/Tabs.controlled.css
@@ -1,0 +1,3 @@
+.demo-container {
+  width: 100%;
+}

--- a/examples/Tabs.controlled.css
+++ b/examples/Tabs.controlled.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.controlled.jsx
+++ b/examples/Tabs.controlled.jsx
@@ -13,6 +13,7 @@ export default () => {
       value={currentTabValue}
       onValueChange={(value) => setCurrentTabValue(value)}
       defaultValue='pear'
+      className='demo-container'
     >
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />

--- a/examples/Tabs.controlled.jsx
+++ b/examples/Tabs.controlled.jsx
@@ -13,7 +13,6 @@ export default () => {
       value={currentTabValue}
       onValueChange={(value) => setCurrentTabValue(value)}
       defaultValue='pear'
-      className='demo-container'
     >
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />

--- a/examples/Tabs.main.css
+++ b/examples/Tabs.main.css
@@ -1,0 +1,3 @@
+.demo-container {
+  width: 100%;
+}

--- a/examples/Tabs.main.css
+++ b/examples/Tabs.main.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.main.jsx
+++ b/examples/Tabs.main.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper className='demo-container'>
+    <Tabs.Wrapper>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.main.jsx
+++ b/examples/Tabs.main.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper>
+    <Tabs.Wrapper className='demo-container'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.pill.css
+++ b/examples/Tabs.pill.css
@@ -1,0 +1,3 @@
+.demo-container {
+  width: 100%;
+}

--- a/examples/Tabs.pill.css
+++ b/examples/Tabs.pill.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.pill.jsx
+++ b/examples/Tabs.pill.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='pill'>
+    <Tabs.Wrapper type='pill' className='demo-container'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.pill.jsx
+++ b/examples/Tabs.pill.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='pill' className='demo-container'>
+    <Tabs.Wrapper type='pill'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -130,6 +130,7 @@ $borderless-horizontal-tab-min-height: calc(
   grid-template-columns: 1fr auto;
   grid-template-rows: auto 1fr;
   contain: inline-size;
+  inline-size: 100%;
 
   .iui-tabs {
     display: flex;

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -130,7 +130,6 @@ $borderless-horizontal-tab-min-height: calc(
   grid-template-columns: 1fr auto;
   grid-template-rows: auto 1fr;
   contain: inline-size;
-  inline-size: 100%;
 
   .iui-tabs {
     display: flex;


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Fixes broken styling for the tabs demos on the documentation site. Does this by defining width for `Tabs.Wrapper` component with css.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Tested the documentation site with local host and found that this style change fixes the issue.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Updated demos with fixed styling.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
