### PR TITLE
add custom release step

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -35,7 +35,24 @@ jobs:
 
       - run: pnpm install
 
-      - name: Create release PR or publish to npm
+      - name: Check for existing changesets
+        id: changesets_files
+        run: |
+          changesets=$(pnpm changeset status)
+          # only true if changesets contains @itwin/itwinui-react or @itwin/itwinui-variables
+          if [[ $changesets == *"@itwin/itwinui-react"* || $changesets == *"@itwin/itwinui-variables"* ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if release PR already exists
+        id: changesets_branch
+        run: |
+          if [[ $(git ls-remote --heads origin refs/heads/changeset-release/main) ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update release PR
+        if: steps.changesets_branch.outputs.exists == 'true' || steps.changesets_files.outputs.exists == 'true'
         uses: changesets/action@v1
         with:
           version: pnpm changeset version --ignore @itwin/itwinui-css
@@ -49,3 +66,10 @@ jobs:
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+
+      - name: Publish to npm (if not already published)
+        if: steps.changesets_files.outputs.exists != 'true'
+        run: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.IMJS_ADMIN_GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPMJS_PUBLISH_ITWIN }}


### PR DESCRIPTION
## Changes

Updates release workflow to add manual checks for changeset files and release PR.
- To check for changeset files, [`changeset status`](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#status) is combined with a simple if-condition to exclude `@itwin/itwinui-css` (since it is supposed to be ignored).
- To check for release PR, [`git ls-remote`](https://stackoverflow.com/a/30524983) is used to find the `changeset-release/main` branch (well-defined name).

Based on the checks, two outcomes are possible:
- When a changeset file or release PR is found, let changesets create/update the release PR.
- If release PR does not exist, manually run `pnpm release`. This will publish to npm or do nothing if already published.

Fixes https://github.com/iTwin/iTwinUI/pull/1912#issuecomment-1992223634

## Testing

Tested a condensed version of the checks locally using [`act`](https://nektosact.com/). Real testing can only be done once this PR merges.

## Docs

N/A