### PR TITLE
Removes unnecessary global mixins.

### DIFF
--- a/packages/itwinui-css/src/global.scss
+++ b/packages/itwinui-css/src/global.scss
@@ -23,7 +23,27 @@
 // box-sizing, text selection and scrollbar styling on iui-root and all elements under it
 :where(.iui-root, .iui-root *) {
   @include mixins.iui-text-selection;
-  @include mixins.iui-scrollbar;
+  scrollbar-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4)) transparent;
+  scrollbar-width: thin;
+
+  &::-webkit-scrollbar {
+    max-inline-size: var(--iui-size-xs);
+    max-block-size: var(--iui-size-xs);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4));
+    border-radius: var(--iui-border-radius-round);
+
+    &:hover {
+      background-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-3));
+    }
+  }
+
+  &::-webkit-scrollbar-track,
+  &::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
 
   &,
   &::before,

--- a/packages/itwinui-css/src/global.scss
+++ b/packages/itwinui-css/src/global.scss
@@ -2,27 +2,7 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 @use 'mixins';
 
-:where(.iui-root) {
-  color: var(--iui-color-text);
-  font-size: var(--iui-font-size-1);
-  line-height: 1.5;
-  font-family: var(--iui-font-sans);
-}
-
-// reset margin only for <body> element.
-:where(body.iui-root) {
-  margin: 0;
-}
-
-// auto apply background only if <body> is used as root.
-// for other elements, user will have to opt in by adding .iui-root-background
-:where(body.iui-root, .iui-root.iui-root-background) {
-  background-color: var(--iui-color-background-backdrop);
-}
-
-// box-sizing, text selection and scrollbar styling on iui-root and all elements under it
-:where(.iui-root, .iui-root *) {
-  @include mixins.iui-text-selection;
+@mixin iui-scrollbar {
   scrollbar-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4)) transparent;
   scrollbar-width: thin;
 
@@ -44,6 +24,30 @@
   &::-webkit-scrollbar-corner {
     background-color: transparent;
   }
+}
+
+:where(.iui-root) {
+  color: var(--iui-color-text);
+  font-size: var(--iui-font-size-1);
+  line-height: 1.5;
+  font-family: var(--iui-font-sans);
+}
+
+// reset margin only for <body> element.
+:where(body.iui-root) {
+  margin: 0;
+}
+
+// auto apply background only if <body> is used as root.
+// for other elements, user will have to opt in by adding .iui-root-background
+:where(body.iui-root, .iui-root.iui-root-background) {
+  background-color: var(--iui-color-background-backdrop);
+}
+
+// box-sizing, text selection and scrollbar styling on iui-root and all elements under it
+:where(.iui-root, .iui-root *) {
+  @include mixins.iui-text-selection;
+  @include iui-scrollbar;
 
   &,
   &::before,

--- a/packages/itwinui-css/src/mixins.scss
+++ b/packages/itwinui-css/src/mixins.scss
@@ -23,30 +23,6 @@
   }
 }
 
-@mixin iui-scrollbar {
-  scrollbar-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4)) transparent;
-  scrollbar-width: thin;
-
-  &::-webkit-scrollbar {
-    max-inline-size: var(--iui-size-xs);
-    max-block-size: var(--iui-size-xs);
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4));
-    border-radius: var(--iui-border-radius-round);
-
-    &:hover {
-      background-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-3));
-    }
-  }
-
-  &::-webkit-scrollbar-track,
-  &::-webkit-scrollbar-corner {
-    background-color: transparent;
-  }
-}
-
 @mixin iui-line-clamp($lines: 1) {
   overflow: hidden;
   display: -webkit-box; /* stylelint-disable-line */
@@ -93,44 +69,6 @@
     @media (prefers-reduced-motion: no-preference) {
       transition: $transition-rule;
     }
-  }
-}
-
-/// Adds the ability to toggle vertical scroll snapping by setting `.iui-scroll-snapping` as a modifier (if used inside a class) or at root level.
-/// @arg $selector - selector to apply `scroll-snap-align: start` on. Defaults to '> *'
-@mixin iui-scroll-snapping($selector: '> *') {
-  #{if(&, '&.iui-scroll-snapping', '.iui-scroll-snapping')} {
-    scroll-snap-type: y mandatory;
-
-    #{$selector} {
-      scroll-snap-align: start none;
-    }
-  }
-}
-
-@mixin iui-ripple($hoverColor, $rippleColor) {
-  background-position: center;
-  transition: background var(--iui-duration-2) ease-out;
-
-  &:hover {
-    background: $hoverColor radial-gradient(circle, transparent 1%, #{$hoverColor} 1%) center/15000%;
-  }
-
-  &:active {
-    background-color: $rippleColor;
-    background-size: 100%;
-    transition: background var(--iui-duration-0);
-  }
-}
-
-/// Helper mixin to add ::before or ::after pseudo element that will
-/// be absolutely positioned and will have the same size as the parent element.
-@mixin pseudo-content($beforeOrAfter: before) {
-  &::#{$beforeOrAfter} {
-    content: '';
-    position: absolute;
-    inset: 0;
-    @content;
   }
 }
 

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -354,7 +354,13 @@
   flex-grow: 1;
   // Allows columns with static width to take more space than the table width
   align-items: flex-start;
-  @include mixins.iui-scroll-snapping('.iui-table-row');
+  #{if(&, '&.iui-scroll-snapping', '.iui-scroll-snapping')} {
+    scroll-snap-type: y mandatory;
+
+    .iui-table-row {
+      scroll-snap-align: start none;
+    }
+  }
   background-color: var(--iui-color-background);
 
   &:last-child {
@@ -475,7 +481,11 @@
 
 @mixin iui-table-cell-status($status) {
   @include mixins.iui-text-selection($status);
-  @include mixins.pseudo-content {
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
     background-color: hsl(var(--iui-color-#{$status}-hsl) / var(--iui-opacity-6));
   }
 }

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -354,7 +354,8 @@
   flex-grow: 1;
   // Allows columns with static width to take more space than the table width
   align-items: flex-start;
-  #{if(&, '&.iui-scroll-snapping', '.iui-scroll-snapping')} {
+
+  &.iui-scroll-snapping {
     scroll-snap-type: y mandatory;
 
     .iui-table-row {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Removes four sass mixins from the global mixins file in the css package. These mixins are:

- `iui-ripple`
- `iui-scroll-snapping`
- `pseudo-content`
- `iui-scrollbar`

In the cases where these mixins were used, their styles were placed instead. Therefore, there should be no changes to end users from this PR.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Ran css and react visual tests to make sure there were no visual changes from the removal of these mixins.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

N/A
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
