### PR TITLE
Corrected `@itwin/itwinui-react@3.6.0` changelog

### DIFF
--- a/packages/itwinui-react/CHANGELOG.md
+++ b/packages/itwinui-react/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - [#1879](https://github.com/iTwin/iTwinUI/pull/1879): Added a new `native` prop to `Select` and `LabeledSelect`. When true, a native `<select>` element will be rendered.
 - [#1886](https://github.com/iTwin/iTwinUI/pull/1886): Native `Select` (`<Select native>`) offers a new `styleType` prop that accepts the values: `default` (pre-existing) and `borderless` (new).
-- [#1877](https://github.com/iTwin/iTwinUI/pull/1877): Fixed a bug in `LabeledSelect` where nested `<StatusMessage>`s were rendered when using `message={<StatusMessage>}`. As a result, non-string `message` values are no longer automatically wrapped in `<StatusMessage>`.
+- [#1877](https://github.com/iTwin/iTwinUI/pull/1877): Fixed a bug in `InputGroup` where nested `<StatusMessage>`s were rendered when using `message={<StatusMessage>}`. As a result, non-string `message` values are no longer automatically wrapped in `<StatusMessage>`.
   - If you were passing a custom `ReactNode`, you might need to wrap it with `<StatusMessage>` for proper styling of `message`.
 - [#1881](https://github.com/iTwin/iTwinUI/pull/1881): Added a new subcomponent `InputWithDecorations.Icon` to replace direct usage of `Icon` inside `InputWithDecorations`.
 - Visual changes:


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

In #1877, I had made a mistake in the [changeset file](https://github.com/iTwin/iTwinUI/pull/1877/files#diff-c03ef64bfbfbe72b8b344d4a3469daa68af3d3590934b6b70c5e87761a6b019a) where I mentioned `LabeledSelect` instead of `InputGroup`. This PR fixes the changelog to correctly mention `InputGroup` in that bullet point.

I realized that I also would need to update the [v3.6.0 GitHub release](https://github.com/iTwin/iTwinUI/releases/tag/%40itwin%2Fitwinui-react%403.6.0). But before doing that, I wanted to confirm if this is alright by first having this PR and then changing the GitHub release. 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A