### PR TITLE
Added `includesSome` to `DefaultFilterTypes` in Table

### DIFF
--- a/.changeset/itchy-swans-jog.md
+++ b/.changeset/itchy-swans-jog.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Fixed the Table column `filter`'s type to include `"includesSome"`, which is a default filter function that we already supported.
+Fixed the types for `Table` column `filter` to allow `"includesSome"`, which is an already-supported filter function.

--- a/.changeset/itchy-swans-jog.md
+++ b/.changeset/itchy-swans-jog.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Fixed the types for `Table` column `filter` to allow `"includesSome"`, which is an already-supported filter function.
+Fixed the types for `Table` column `filter` to allow `"includesSome"`, which is an already-supported filter function. Also improved the types for the `filter` prop to improve TS autocompletion.

--- a/.changeset/itchy-swans-jog.md
+++ b/.changeset/itchy-swans-jog.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed the Table column `filter`'s type to include `"includesSome"`, which is a default filter function that we already supported.

--- a/packages/itwinui-react/src/react-table/react-table.ts
+++ b/packages/itwinui-react/src/react-table/react-table.ts
@@ -196,7 +196,7 @@ export interface ColumnInterface<D extends Record<string, unknown> = {}>
   /**
    * String value or custom function to use for filtering.
    * Possible string values: `text`, `exactText`, `exactTextCase`, `includes`, `includesAll`, `exact`, `equals`, `between`.
-   * More info about these filters: https://github.com/tannerlinsley/react-table/blob/master/src/filterTypes.js
+   * More info about these filters: https://github.com/TanStack/table/blob/v7/src/filterTypes.js
    */
   filter?: FilterType<D> | DefaultFilterTypes | string;
   /**
@@ -750,6 +750,7 @@ export type DefaultFilterTypes =
   | 'exactTextCase'
   | 'includes'
   | 'includesAll'
+  | 'includesSome'
   | 'exact'
   | 'equals'
   | 'between';

--- a/packages/itwinui-react/src/react-table/react-table.ts
+++ b/packages/itwinui-react/src/react-table/react-table.ts
@@ -195,7 +195,7 @@ export interface ColumnInterface<D extends Record<string, unknown> = {}>
   Filter?: Renderer<FilterProps<D>> | Renderer<TableFilterProps<D>>;
   /**
    * String value or custom function to use for filtering.
-   * Possible string values: `text`, `exactText`, `exactTextCase`, `includes`, `includesAll`, `exact`, `equals`, `between`.
+   * Possible string values: `text`, `exactText`, `exactTextCase`, `includes`, `includesAll`, `includesSome`, `exact`, `equals`, `between`.
    * More info about these filters: https://github.com/TanStack/table/blob/v7/src/filterTypes.js
    */
   filter?: FilterType<D> | DefaultFilterTypes | string;

--- a/packages/itwinui-react/src/react-table/react-table.ts
+++ b/packages/itwinui-react/src/react-table/react-table.ts
@@ -19,6 +19,12 @@ import type {
   ReactNode,
 } from 'react';
 
+/**
+ * This allows custom strings and keeps intellisense for string unions.
+ * See https://github.com/Microsoft/TypeScript/issues/29729
+ */
+type AnyString = string & {}; // eslint-disable-line @typescript-eslint/ban-types
+
 //-------------------------------------------------------------------------------
 // Custom Additions (parts from the old file called react-table-config.ts)
 
@@ -198,7 +204,7 @@ export interface ColumnInterface<D extends Record<string, unknown> = {}>
    * Possible string values: `text`, `exactText`, `exactTextCase`, `includes`, `includesAll`, `includesSome`, `exact`, `equals`, `between`.
    * More info about these filters: https://github.com/TanStack/table/blob/v7/src/filterTypes.js
    */
-  filter?: FilterType<D> | DefaultFilterTypes | string;
+  filter?: FilterType<D> | DefaultFilterTypes | AnyString;
   /**
    * Function that should return whole cell element not only the content.
    * Must be memoized.
@@ -701,7 +707,7 @@ export type UseFiltersColumnOptions<D extends Record<string, unknown>> =
     Filter: Renderer<FilterProps<D>>;
     disableFilters: boolean;
     defaultCanFilter: boolean;
-    filter: FilterType<D> | DefaultFilterTypes | string;
+    filter: FilterType<D> | DefaultFilterTypes | AnyString;
   }>;
 
 export interface UseFiltersInstanceProps<D extends Record<string, unknown>> {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

A user pointed out that we have an `includesSome` function in `defaultFilterFunctions`:

https://github.com/iTwin/iTwinUI/blob/84007fe670a9ca85f82f230c3458c0a73fd1b622/packages/itwinui-react/src/core/Table/filters/defaultFilterFunctions.ts#L119-L134

… but don't have `includeSome` in `DefaultFilterTypes`:

https://github.com/iTwin/iTwinUI/blob/84007fe670a9ca85f82f230c3458c0a73fd1b622/packages/itwinui-react/src/react-table/react-table.ts#L747-L755

This PR adds `includesSome` to `DefaultFilterTypes` so that users can get `"includesSome"`  as a type suggestion for the `filter` prop and udpates the list of possible values in the JSDocs accordingly.

Unrelated: Fixed the broken GitHub file link in the `filter` JSDocs.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Tested that passing `filter: "includesSome"` to a column even before this PR worked.

This PR only fixes the type. Regarding testing that type, since the storybook and vite playground did not show the TS autocomplete correctly (not sure why), I was unable to properly test it.

<img width="315" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/81931d12-bf6c-44a9-8d8b-9d02b270b8e2">

Open to ideas to test this, if testing it is needed.

**EDIT**: After adding `AnyString` (https://github.com/iTwin/iTwinUI/pull/1934#issuecomment-2012636918), we now get auto completions.

<img width="217" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/987b2395-a270-4571-a8d5-2f1189a13d52">

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changesets.