### PR TITLE
ButtonGroup: conditionally run overflow logic

### DIFF
--- a/.changeset/tricky-vans-jam.md
+++ b/.changeset/tricky-vans-jam.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed an issue in `ButtonGroup` where the overflow logic was running even when `overflowButton` prop was not passed.

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -93,7 +93,7 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
     !overflowButton,
     orientation,
   );
-  const refs = useMergedRefs(overflowRef, ref);
+  const refs = useMergedRefs(!!overflowButton ? overflowRef : null, ref);
 
   return (
     <FloatingDelayGroup delay={{ open: 50, close: 250 }}>
@@ -114,6 +114,10 @@ export const ButtonGroup = React.forwardRef((props, ref) => {
           {...rest}
         >
           {(() => {
+            if (!overflowButton) {
+              return children;
+            }
+
             if (!(visibleCount < items.length)) {
               return items;
             }


### PR DESCRIPTION
## Changes

When `overflowButton` is not passed to `ButtonGroup`:

1. Early return `children`
2. Don't attach `overflowRef` 

Fixes #1923

## Testing

Recreated the sandbox from linked issue and verified that `children.length` is 4 (not 2) after clicking "Calculate overflow".

![](https://github.com/iTwin/iTwinUI/assets/9084735/3229a365-8cf1-445d-bf4a-6f5bb382663e)


No tested added, since this is more of an optimization (the final result is correct even before this PR, because it eventually re-renders into correct state).

## Docs

Added changeset.