### PR TITLE
use relative base for gh-pages deployment

### DIFF
--- a/apps/css-workshop/astro.config.mjs
+++ b/apps/css-workshop/astro.config.mjs
@@ -12,4 +12,5 @@ export default defineConfig({
   server: {
     port: 3050,
   },
+  base: './',
 });


### PR DESCRIPTION
## Changes

This should fix the gh-pages deployment (which uses a subpath).

## Testing

Pending.

## Docs

N/A
