### PR TITLE
Fix `Table` resizer z-index

### DIFF
--- a/.changeset/modern-games-pump.md
+++ b/.changeset/modern-games-pump.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-css": patch
+---
+
+Fixed a z-index issue in `Table` where the `iui-table-resizer` appeared above the sticky column cells.

--- a/.changeset/modern-games-pump.md
+++ b/.changeset/modern-games-pump.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-css": patch
 ---
 
-Fixed a z-index issue in `Table` where the `iui-table-resizer` appeared above the sticky column cells.
+Fixed a z-index issue in `Table` where the `iui-table-resizer` appeared above the sticky header cells.

--- a/.changeset/warm-ravens-refuse.md
+++ b/.changeset/warm-ravens-refuse.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a z-index issue in `Table` where the table resizer appeared above the sticky column cells.

--- a/.changeset/warm-ravens-refuse.md
+++ b/.changeset/warm-ravens-refuse.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Fixed a z-index issue in `Table` where the table resizer appeared above the sticky column cells.
+Fixed a z-index issue in `Table` where the table resizer appeared above the sticky header cells.

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -66,6 +66,7 @@
       transform: translateX(50%);
       touch-action: none;
       cursor: ew-resize;
+      z-index: 1;
       opacity: 0;
 
       > .iui-table-resizer-bar {
@@ -417,7 +418,7 @@
 
   &.iui-table-cell-sticky {
     position: sticky;
-    z-index: 1;
+    z-index: 2;
     inset-inline-start: var(--iui-table-sticky-left, initial);
     inset-inline-end: var(--iui-table-sticky-right, initial);
   }

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -17,14 +17,14 @@
     position: sticky;
     inset-block-end: 0;
     inset-inline-start: 0;
-    z-index: 2; // Above the table body and sticky columns/cells
+    z-index: 3; // Above the table body and sticky columns/cells
   }
 }
 
 @mixin iui-table-header-wrapper {
   position: sticky;
   inset-block-start: 0;
-  z-index: 2; // Above the table body and sticky columns/cells
+  z-index: 3; // Above the table body and sticky columns/cells
 
   display: flex;
   flex-shrink: 0;

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -66,7 +66,6 @@
       transform: translateX(50%);
       touch-action: none;
       cursor: ew-resize;
-      z-index: 1;
       opacity: 0;
 
       > .iui-table-resizer-bar {

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -418,7 +418,7 @@
 
   &.iui-table-cell-sticky {
     position: sticky;
-    z-index: 2;
+    z-index: 2; // Above the non-sticky columns and the table resizer
     inset-inline-start: var(--iui-table-sticky-left, initial);
     inset-inline-end: var(--iui-table-sticky-right, initial);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I noticed that the `iui-table-resizer` appears above the sticky header cells. This small PR fixes that.

<details>
<summary>Before/After</summary>

[Before](https://itwin.github.io/iTwinUI/react/?story=table--full2&theme=dark):

https://github.com/iTwin/iTwinUI/assets/45748283/3548b793-9848-4257-b7b5-c56fc10c3b5d

[After](https://itwin.github.io/iTwinUI/1943/react/?story=table--full2&theme=dark):

https://github.com/iTwin/iTwinUI/assets/45748283/dcf90a1f-6430-4ee5-b657-89046d1340b7

</details>

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the table resizer now appears below the sticky header cells.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changesets.

## After PR TODOs:

* [ ] The table resizer in sticky columns gets cut off (https://github.com/iTwin/iTwinUI/pull/1943#discussion_r1537932830)