### PR TITLE
fix: :bug: Do not auto-scroll vertically when enabling/disabling table columns

### DIFF
--- a/.changeset/ten-mayflies-compete.md
+++ b/.changeset/ten-mayflies-compete.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Do not auto-scroll vertically when enabling/disabling table columns
+Fixed a bug in `Table` where resizing the columns and then toggling the column visibility in the column manager would trigger an unnecessary auto-scroll in the vertical direction.

--- a/.changeset/ten-mayflies-compete.md
+++ b/.changeset/ten-mayflies-compete.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Do not auto-scroll vertically when enabling/disabling table columns

--- a/packages/itwinui-react/src/core/Table/columns/actionColumn.tsx
+++ b/packages/itwinui-react/src/core/Table/columns/actionColumn.tsx
@@ -86,7 +86,7 @@ export const ActionColumn = <T extends Record<string, unknown>>({
               // and table is scrolled to the very left which means our visibility dropdown menu is not visible.
               // So for better UX we need to scroll to that dropdown menu.
               queueMicrotask(() => {
-                buttonRef.current?.scrollIntoView();
+                buttonRef.current?.scrollIntoView({ block: 'nearest' });
               });
             };
             return (


### PR DESCRIPTION
## Changes

After column is resized and user enables/disables some column, will no longer scroll down to the action column

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Did not add tests, this is pretty simple scenario

See https://github.com/iTwin/iTwinUI/pull/1946#pullrequestreview-1958154941 for repro code and testing results.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
"N/A"

Issue: #1945