### PR TITLE
create Badge component for css-workshop

### DIFF
--- a/apps/css-workshop/src/components/Badge.astro
+++ b/apps/css-workshop/src/components/Badge.astro
@@ -1,0 +1,32 @@
+---
+type Props = {
+  backgroundColor?:
+    | 'skyblue'
+    | 'celery'
+    | 'froly'
+    | 'steelblue'
+    | 'sunglow'
+    | 'seabuckthorn'
+    | 'montecarlo'
+    | 'poloblue'
+    | 'bouquet'
+    | 'ash'
+    | 'oak';
+  status?: 'informational' | 'positive' | 'warning' | 'negative';
+} & astroHTML.JSX.HTMLAttributes;
+
+const { class: className, backgroundColor, status, ...props } = Astro.props;
+---
+
+<span
+  class:list={['iui-badge', className]}
+  style={{
+    '--iui-badge-background-color': backgroundColor
+      ? `var(--iui-color-background-${backgroundColor})`
+      : undefined,
+  }}
+  data-iui-status={status}
+  {...props}
+>
+  <slot />
+</span>

--- a/apps/css-workshop/src/pages/badge.astro
+++ b/apps/css-workshop/src/pages/badge.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import IuiBadge from '../components/Badge.astro';
 ---
 
 <Layout title='Badge'>
@@ -16,40 +17,28 @@ import Layout from './_layout.astro';
 
   <h2>Soft backgrounds</h2>
   <section id='demo-soft-backgrounds'>
-    <span class='iui-badge'> Default</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(197, 71%, 83%);'>Skyblue</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(72, 51%, 66%);'>Celery</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(2, 90%, 80%);'>Froly</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(207, 44%, 73%);'
-      >Steelblue</span
-    >
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(42, 100%, 70%);'>Sunglow</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(29, 92%, 71%);'
-      >Seabuckthorn
-    </span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(176, 43%, 72%);'
-      >Montecarlo</span
-    >
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(211, 44%, 77%);'
-      >Poloblue
-    </span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(305, 19%, 75%);'>Boquet</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(42, 15%, 85%);'>Ash</span>
-    <span class='iui-badge' style='--iui-badge-background-color: hsl(27, 32%, 72%);'>Oak</span>
-    <span
-      class='iui-badge'
-      style='--iui-badge-background-color: hsl(197, 71%, 83%);'
-      title='A long label that becomes truncated'>A long label that becomes truncated</span
-    >
+    <IuiBadge>Default</IuiBadge>
+    <IuiBadge backgroundColor='skyblue'>Skyblue</IuiBadge>
+    <IuiBadge backgroundColor='celery'>Celery</IuiBadge>
+    <IuiBadge backgroundColor='froly'>Froly</IuiBadge>
+    <IuiBadge backgroundColor='steelblue'>Steelblue</IuiBadge>
+    <IuiBadge backgroundColor='sunglow'>Sunglow</IuiBadge>
+    <IuiBadge backgroundColor='seabuckthorn'>Seabuckthorn</IuiBadge>
+    <IuiBadge backgroundColor='montecarlo'>Montecarlo</IuiBadge>
+    <IuiBadge backgroundColor='poloblue'>Poloblue</IuiBadge>
+    <IuiBadge backgroundColor='bouquet'>Boquet</IuiBadge>
+    <IuiBadge backgroundColor='ash'>Ash</IuiBadge>
+    <IuiBadge backgroundColor='oak'>Oak</IuiBadge>
+    <IuiBadge backgroundColor='skyblue'>A long label that becomes truncated</IuiBadge>
   </section>
 
   <hr />
 
   <h2>Statuses</h2>
   <section id='demo-statuses'>
-    <span class='iui-badge' data-iui-status='informational'>Informational</span>
-    <span class='iui-badge' data-iui-status='positive'>Positive</span>
-    <span class='iui-badge' data-iui-status='negative'>Negative</span>
-    <span class='iui-badge' data-iui-status='warning'>Warning</span>
+    <IuiBadge status='informational'>Informational</IuiBadge>
+    <IuiBadge status='positive'>Positive</IuiBadge>
+    <IuiBadge status='negative'>Negative</IuiBadge>
+    <IuiBadge status='warning'>Warning</IuiBadge>
   </section>
 </Layout>

--- a/apps/css-workshop/src/pages/badge.astro
+++ b/apps/css-workshop/src/pages/badge.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from './_layout.astro';
-import IuiBadge from '../components/Badge.astro';
+import Badge_ from '../components/Badge.astro';
 ---
 
 <Layout title='Badge'>
@@ -17,28 +17,28 @@ import IuiBadge from '../components/Badge.astro';
 
   <h2>Soft backgrounds</h2>
   <section id='demo-soft-backgrounds'>
-    <IuiBadge>Default</IuiBadge>
-    <IuiBadge backgroundColor='skyblue'>Skyblue</IuiBadge>
-    <IuiBadge backgroundColor='celery'>Celery</IuiBadge>
-    <IuiBadge backgroundColor='froly'>Froly</IuiBadge>
-    <IuiBadge backgroundColor='steelblue'>Steelblue</IuiBadge>
-    <IuiBadge backgroundColor='sunglow'>Sunglow</IuiBadge>
-    <IuiBadge backgroundColor='seabuckthorn'>Seabuckthorn</IuiBadge>
-    <IuiBadge backgroundColor='montecarlo'>Montecarlo</IuiBadge>
-    <IuiBadge backgroundColor='poloblue'>Poloblue</IuiBadge>
-    <IuiBadge backgroundColor='bouquet'>Boquet</IuiBadge>
-    <IuiBadge backgroundColor='ash'>Ash</IuiBadge>
-    <IuiBadge backgroundColor='oak'>Oak</IuiBadge>
-    <IuiBadge backgroundColor='skyblue'>A long label that becomes truncated</IuiBadge>
+    <Badge_>Default</Badge_>
+    <Badge_ backgroundColor='skyblue'>Skyblue</Badge_>
+    <Badge_ backgroundColor='celery'>Celery</Badge_>
+    <Badge_ backgroundColor='froly'>Froly</Badge_>
+    <Badge_ backgroundColor='steelblue'>Steelblue</Badge_>
+    <Badge_ backgroundColor='sunglow'>Sunglow</Badge_>
+    <Badge_ backgroundColor='seabuckthorn'>Seabuckthorn</Badge_>
+    <Badge_ backgroundColor='montecarlo'>Montecarlo</Badge_>
+    <Badge_ backgroundColor='poloblue'>Poloblue</Badge_>
+    <Badge_ backgroundColor='bouquet'>Boquet</Badge_>
+    <Badge_ backgroundColor='ash'>Ash</Badge_>
+    <Badge_ backgroundColor='oak'>Oak</Badge_>
+    <Badge_ backgroundColor='skyblue'>A long label that becomes truncated</Badge_>
   </section>
 
   <hr />
 
   <h2>Statuses</h2>
   <section id='demo-statuses'>
-    <IuiBadge status='informational'>Informational</IuiBadge>
-    <IuiBadge status='positive'>Positive</IuiBadge>
-    <IuiBadge status='negative'>Negative</IuiBadge>
-    <IuiBadge status='warning'>Warning</IuiBadge>
+    <Badge_ status='informational'>Informational</Badge_>
+    <Badge_ status='positive'>Positive</Badge_>
+    <Badge_ status='negative'>Negative</Badge_>
+    <Badge_ status='warning'>Warning</Badge_>
   </section>
 </Layout>

--- a/apps/css-workshop/src/pages/tile.astro
+++ b/apps/css-workshop/src/pages/tile.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Badge from '../components/Badge.astro';
 ---
 
 <Layout title='Tile'>
@@ -261,13 +262,9 @@ import Layout from './_layout.astro';
           <svg-star-hollow class='iui-button-icon' aria-hidden='true'></svg-star-hollow>
         </button>
         <div class='iui-tile-thumbnail-badge-container'>
-          <div class='iui-badge' style='--iui-badge-background-color: hsl(197, 71%, 83%);'>
-            Badge
-          </div>
-          <div class='iui-badge' style='--iui-badge-background-color: hsl(72, 51%, 66%);'>
-            Badge
-          </div>
-          <div class='iui-badge' style='--iui-badge-background-color: hsl(2, 90%, 83%);'>Badge</div>
+          <Badge backgroundColor='skyblue'>Badge</Badge>
+          <Badge backgroundColor='celery'>Badge</Badge>
+          <Badge backgroundColor='froly'>Badge</Badge>
         </div>
         <svg-placeholder class='iui-thumbnail-icon' aria-hidden='true'></svg-placeholder>
       </div>
@@ -416,7 +413,7 @@ import Layout from './_layout.astro';
           <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
         </button>
         <div class='iui-tile-thumbnail-badge-container'>
-          <div class='iui-badge' style='--iui-badge-background-color: hsl(2, 90%, 83%);'>Link</div>
+          <Badge backgroundColor='froly'>Link</Badge>
         </div>
       </div>
 


### PR DESCRIPTION
## Changes

- Created reusable `Badge.astro` with props for backgroundColor and status.
- Used it in main `badge.astro` (page).
  - This required renaming the imported component to disambiguate between `badge.astro` and `Badge.astro`. (Workaround for bug in Astro)
- Used it in other pages: `tile.astro`

## Testing

All existing tests should pass.

## Docs

N/A