### PR TITLE
v2: inherit theme changes from v3

### DIFF
--- a/.changeset/polite-apricots-prove.md
+++ b/.changeset/polite-apricots-prove.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+ThemeProvider will now correctly inherit theme changes from a v3 ancestor.


### PR DESCRIPTION
## Changes

This essentially backports #1735 to v2. It's necessary for applications to incrementally migrate to v3 while maintaining a coherent look.

(I've already noticed a few places where theme v2 UI stays in light theme when application theme switches to dark)

## Testing

Tested behavior in vite playground by installing `itwinui-v3` as an npm alias.

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/44cb9de7-c720-463a-a830-00d894c9512f) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/2d71fe41-c58b-49f6-81e7-4524b68152e9) |

<details><summary>main.tsx</summary>

```tsx
import * as React from 'react';
import { createRoot } from 'react-dom/client';
import styled from '@emotion/styled';
import { ThemeProvider } from '@itwin/itwinui-react';
import { ThemeProvider as ThemeProviderV3 } from 'itwinui-v3';
import App from './App';
import { SvgMoon, SvgSun } from '@itwin/itwinui-icons-react';

const Shell = () => {
  const [theme, setTheme] = React.useState<'light' | 'dark'>(() =>
    matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
  );
  const [highContrast, setHighContrast] = React.useState(false);

  return (
    <>
      <ThemeProviderV3 theme={theme} themeOptions={{ highContrast }}>
        <Main>
          <ThemeToggle
            aria-label='Toggle theme'
            onClick={() => {
              const newThemeValue = theme === 'dark' ? 'light' : 'dark';
              setTheme(newThemeValue);
            }}
          >
            {theme === 'dark' ? <SvgMoon /> : <SvgSun />}
          </ThemeToggle>

          <HighContrastToggle
            onClick={() => {
              const newHcValue = !highContrast;
              setHighContrast(newHcValue);
            }}
          >
            {highContrast ? 'High Contrast' : 'Regular contrast'}
          </HighContrastToggle>

          <ThemeProvider theme='inherit'>
            <App />
          </ThemeProvider>
        </Main>
      </ThemeProviderV3>
    </>
  );
};

const Main = styled.main`
  padding: 2rem 1rem;
  height: 100vh;
`;

const ThemeToggle = styled.button`
  all: unset;
  display: inline-grid;
  place-items: center;
  position: fixed;
  font-family: system-ui;
  user-select: none;
  top: 0;
  right: 0;
  min-width: 2.5rem;
  height: 2.5rem;
  cursor: pointer;
  border-radius: 50%;

  &:hover {
    background: hsl(0 0% 0% / 0.2);
  }

  & > * {
    width: 1.5rem;
    height: 1.5rem;
    fill: currentColor;
  }
`;

const HighContrastToggle = styled(ThemeToggle)`
  right: 2.5rem;
`;

createRoot(document.getElementById('root')!).render(
  <React.StrictMode>
    <Shell />
  </React.StrictMode>,
);

```

</details> 

Note for reviewers: If you're testing this locally, it probably should be done in a separate clone of the repo, because it is so different from the v3 codebase.

## Docs

Changeset added.