### PR TITLE
add `adoptedStyleSheets` fallback for older safari

### DIFF
--- a/.changeset/nine-fishes-itch.md
+++ b/.changeset/nine-fishes-itch.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed an issue in older Safari versions where visually-hidden styles inside `ProgressRadial` were not being applied.


### PR DESCRIPTION
## Changes

Slight refactoring of `ShadowRoot`, but the gist is that when `adoptedStyleSheets` is not supported, an inline `<style>` tag will be used instead. Fixes https://github.com/iTwin/iTwinUI/issues/1930#issuecomment-2020360095

All the `attachShadowRef` has been moved into a `useShadowRoot` hook, and all the client code itself has been moved into a separate local component. This hopefully makes it easier to maintain.

Also, I fixed some issues I noticed in the existing logic and made it more resilient to work with existing shadow-roots, re-renders, and popout windows.

## Testing

To emulate older Safari behavior, I manually set `supportsAdoptedStylesheets` to `false` and verified that 

## Docs

Added changeset.
