### PR TITLE
Adds inline-size to horizontal tabs wrapper.

### DIFF
--- a/.changeset/great-news-beg.md
+++ b/.changeset/great-news-beg.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Adds `inline-size` to `Tabs.Wrapper` to counteract visual change to the width of horizontal tabs wrappers.

--- a/.changeset/great-news-beg.md
+++ b/.changeset/great-news-beg.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Adds `inline-size` to `Tabs.Wrapper` to counteract visual change to the width of horizontal tabs wrappers.
+Fixed a regression in `Tabs` where the panel content was not occupying the full width of the container.

--- a/.changeset/little-mugs-tap.md
+++ b/.changeset/little-mugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-css": patch
+---
+
+Adds `inline-size` to `iui-tabs-horizontal` to counteract visual change to the width of horizontal tabs wrappers.

--- a/.changeset/little-mugs-tap.md
+++ b/.changeset/little-mugs-tap.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-css": patch
 ---
 
-Adds `inline-size` to `iui-tabs-horizontal` to counteract visual change to the width of horizontal tabs wrappers.
+Fixed a regression in `iui-tabs` where the panel content was not occupying the full width of the container.

--- a/examples/Tabs.actions.css
+++ b/examples/Tabs.actions.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.actions.jsx
+++ b/examples/Tabs.actions.jsx
@@ -7,7 +7,7 @@ import { Tabs, Button } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper className='demo-container'>
+    <Tabs.Wrapper>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.borderless.css
+++ b/examples/Tabs.borderless.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.borderless.jsx
+++ b/examples/Tabs.borderless.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='borderless' className='demo-container'>
+    <Tabs.Wrapper type='borderless'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.controlled.css
+++ b/examples/Tabs.controlled.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.controlled.jsx
+++ b/examples/Tabs.controlled.jsx
@@ -13,7 +13,6 @@ export default () => {
       value={currentTabValue}
       onValueChange={(value) => setCurrentTabValue(value)}
       defaultValue='pear'
-      className='demo-container'
     >
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />

--- a/examples/Tabs.main.css
+++ b/examples/Tabs.main.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.main.jsx
+++ b/examples/Tabs.main.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper className='demo-container'>
+    <Tabs.Wrapper>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/examples/Tabs.pill.css
+++ b/examples/Tabs.pill.css
@@ -1,3 +1,0 @@
-.demo-container {
-  width: 100%;
-}

--- a/examples/Tabs.pill.jsx
+++ b/examples/Tabs.pill.jsx
@@ -7,7 +7,7 @@ import { Tabs } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <Tabs.Wrapper type='pill' className='demo-container'>
+    <Tabs.Wrapper type='pill'>
       <Tabs.TabList>
         <Tabs.Tab value='apple' label='Apple' key='apple' />
         <Tabs.Tab value='orange' label='Orange' key='orange' />

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -130,6 +130,7 @@ $borderless-horizontal-tab-min-height: calc(
   grid-template-columns: 1fr auto;
   grid-template-rows: auto 1fr;
   contain: inline-size;
+  inline-size: 100%;
 
   .iui-tabs {
     display: flex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3712,7 +3712,7 @@ packages:
       esbuild-plugins-node-modules-polyfill: 1.6.3(esbuild@0.17.6)
       execa: 5.1.1
       exit-hook: 2.2.1
-      express: 4.18.2
+      express: 4.19.2
       fs-extra: 10.1.0
       get-port: 5.1.1
       gunzip-maybe: 1.4.2
@@ -3756,7 +3756,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@remix-run/express@2.8.0(express@4.18.2)(typescript@5.1.6):
+  /@remix-run/express@2.8.0(express@4.19.2)(typescript@5.1.6):
     resolution: {integrity: sha512-15qnPt+vrvv66pvdcRiodNF5I5Rot07HoKjVlrXYSO4KbSg9WTE0jCPX0rFStD4QNTa2hIl8YftPlmZXjFxQoQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -3767,7 +3767,7 @@ packages:
         optional: true
     dependencies:
       '@remix-run/node': 2.8.0(typescript@5.1.6)
-      express: 4.18.2
+      express: 4.19.2
       typescript: 5.1.6
 
   /@remix-run/node@2.8.0(typescript@5.1.6):
@@ -3818,11 +3818,11 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      '@remix-run/express': 2.8.0(express@4.18.2)(typescript@5.1.6)
+      '@remix-run/express': 2.8.0(express@4.19.2)(typescript@5.1.6)
       '@remix-run/node': 2.8.0(typescript@5.1.6)
       chokidar: 3.6.0
       compression: 1.7.4
-      express: 4.18.2
+      express: 4.19.2
       get-port: 5.1.1
       morgan: 1.10.0
       source-map-support: 0.5.21
@@ -5393,25 +5393,6 @@ packages:
   /bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  /body-parser@1.20.1:
-    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.11.0
-      raw-body: 2.5.1
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   /body-parser@1.20.2:
     resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -5430,7 +5411,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -6120,6 +6100,7 @@ packages:
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -7516,46 +7497,8 @@ packages:
     requiresBuild: true
     optional: true
 
-  /express@4.18.2:
-    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
-    engines: {node: '>= 0.10.0'}
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.1
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.5.0
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.2.0
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.1
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.7
-      proxy-addr: 2.0.7
-      qs: 6.11.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  /express@4.18.3:
-    resolution: {integrity: sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==}
+  /express@4.19.2:
+    resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
     engines: {node: '>= 0.10.0'}
     dependencies:
       accepts: 1.3.8
@@ -7563,7 +7506,7 @@ packages:
       body-parser: 1.20.2
       content-disposition: 0.5.4
       content-type: 1.0.5
-      cookie: 0.5.0
+      cookie: 0.6.0
       cookie-signature: 1.0.6
       debug: 2.6.9
       depd: 2.0.0
@@ -7591,7 +7534,6 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /expressive-code@0.33.5:
     resolution: {integrity: sha512-UPg2jSvZEfXPiCa4MKtMoMQ5Hwiv7In5/LSCa/ukhjzZqPO48iVsCcEBgXWEUmEAQ02P0z00/xFfBmVnUKH+Zw==}
@@ -12673,15 +12615,6 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  /raw-body@2.5.1:
-    resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
-
   /raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
@@ -12690,7 +12623,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
   /rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -14301,7 +14233,7 @@ packages:
   /super-simple-web-server@1.1.4:
     resolution: {integrity: sha512-sQdVXz8ZDBMloocL63mifyVVzhxP55MlO2F0MiYJAJQiHTp42M2C3m2dZBIxGkcC7NUDr1/p0UhvGQvOsxZLpw==}
     dependencies:
-      express: 4.18.3
+      express: 4.19.2
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Adds `inline-size: 100%` to horizontal tabs wrappers. This change is meant to counteract an issue caused by this [PR](https://github.com/iTwin/iTwinUI/pull/1884), where adding `contain: inline-size` caused the tabs wrapper to change it's implicit width.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Ran css and react visual tests to make sure that there are no unintended visual changes.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Added patch changesets to both the react and css packages.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
