### PR TITLE
add shim for `useSyncExternalStore`

### DIFF
--- a/packages/itwinui-react/src/core/utils/hooks/index.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/index.ts
@@ -16,3 +16,4 @@ export * from './useIsomorphicLayoutEffect.js';
 export * from './useIsClient.js';
 export * from './useId.js';
 export * from './useControlledState.js';
+export * from './useSyncExternalStore.js';

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -3,36 +3,26 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { getWindow } from '../functions/index.js';
-import { useLayoutEffect } from './useIsomorphicLayoutEffect.js';
+import { useSyncExternalStore } from './useSyncExternalStore.js';
 
 export const useMediaQuery = (queryString: string) => {
-  const [matches, setMatches] = React.useState<boolean>();
+  const [getSnapshot, subscribe] = React.useMemo(() => {
+    const mediaQueryList = window.matchMedia(queryString);
 
-  useLayoutEffect(() => {
-    const mediaQueryList = getWindow()?.matchMedia?.(queryString);
-    const handleChange = ({ matches }: MediaQueryListEvent) =>
-      setMatches(matches);
-
-    if (mediaQueryList != undefined) {
-      setMatches(mediaQueryList.matches);
-      try {
-        mediaQueryList.addEventListener('change', handleChange);
-      } catch {
-        // Safari 13 fallback
-        mediaQueryList.addListener?.(handleChange);
-      }
-    }
-
-    return () => {
-      try {
-        mediaQueryList?.removeEventListener('change', handleChange);
-      } catch {
-        // Safari 13 fallback
-        mediaQueryList?.removeListener?.(handleChange);
-      }
-    };
+    return [
+      () => mediaQueryList.matches,
+      (onChange: () => void) => {
+        mediaQueryList.addEventListener?.('change', onChange);
+        return () => {
+          mediaQueryList.removeEventListener?.('change', onChange);
+        };
+      },
+    ];
   }, [queryString]);
 
-  return !!matches;
+  return useSyncExternalStore(
+    subscribe,
+    typeof window !== 'undefined' ? getSnapshot : () => undefined,
+    () => undefined,
+  );
 };

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -22,7 +22,9 @@ export const useMediaQuery = (queryString: string) => {
 
   return useSyncExternalStore(
     subscribe,
-    typeof window !== 'undefined' ? getSnapshot : () => undefined,
+    isClient ? getSnapshot : () => undefined,
     () => undefined,
   );
 };
+
+const isClient = typeof document !== 'undefined';

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -4,26 +4,22 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { useSyncExternalStore } from './useSyncExternalStore.js';
-import { getWindow } from '../functions/dom.js';
 
 export const useMediaQuery = (queryString: string) => {
-  const [getSnapshot, subscribe] = React.useMemo(() => {
-    const mediaQueryList = getWindow()?.matchMedia?.(queryString);
+  const getSnapshot = () => {
+    return typeof window !== 'undefined'
+      ? window.matchMedia?.(queryString).matches
+      : undefined;
+  };
 
-    return [
-      () => mediaQueryList?.matches,
-      (onChange: () => void) => {
-        mediaQueryList?.addEventListener?.('change', onChange);
-        return () => {
-          mediaQueryList?.removeEventListener?.('change', onChange);
-        };
-      },
-    ];
-  }, [queryString]);
-
-  return useSyncExternalStore(
-    subscribe,
-    typeof document !== 'undefined' ? getSnapshot : () => undefined,
-    () => undefined,
+  const subscribe = React.useCallback(
+    (onChange: () => void) => {
+      const mediaQueryList = window.matchMedia?.(queryString);
+      mediaQueryList?.addEventListener?.('change', onChange);
+      return () => mediaQueryList?.removeEventListener?.('change', onChange);
+    },
+    [queryString],
   );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => undefined);
 };

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -6,11 +6,11 @@ import * as React from 'react';
 import { useSyncExternalStore } from './useSyncExternalStore.js';
 
 export const useMediaQuery = (queryString: string) => {
-  const getSnapshot = () => {
+  const getSnapshot = React.useCallback(() => {
     return typeof window !== 'undefined'
       ? window.matchMedia?.(queryString).matches
       : undefined;
-  };
+  }, [queryString]);
 
   const subscribe = React.useCallback(
     (onChange: () => void) => {

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -4,17 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { useSyncExternalStore } from './useSyncExternalStore.js';
+import { getWindow } from '../functions/dom.js';
 
 export const useMediaQuery = (queryString: string) => {
   const [getSnapshot, subscribe] = React.useMemo(() => {
-    const mediaQueryList = window.matchMedia(queryString);
+    const mediaQueryList = getWindow()?.matchMedia(queryString);
 
     return [
-      () => mediaQueryList.matches,
+      () => mediaQueryList?.matches,
       (onChange: () => void) => {
-        mediaQueryList.addEventListener?.('change', onChange);
+        mediaQueryList?.addEventListener?.('change', onChange);
         return () => {
-          mediaQueryList.removeEventListener?.('change', onChange);
+          mediaQueryList?.removeEventListener?.('change', onChange);
         };
       },
     ];
@@ -22,9 +23,7 @@ export const useMediaQuery = (queryString: string) => {
 
   return useSyncExternalStore(
     subscribe,
-    isClient ? getSnapshot : () => undefined,
+    typeof document !== 'undefined' ? getSnapshot : () => undefined,
     () => undefined,
   );
 };
-
-const isClient = typeof document !== 'undefined';

--- a/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useMediaQuery.ts
@@ -8,7 +8,7 @@ import { getWindow } from '../functions/dom.js';
 
 export const useMediaQuery = (queryString: string) => {
   const [getSnapshot, subscribe] = React.useMemo(() => {
-    const mediaQueryList = getWindow()?.matchMedia(queryString);
+    const mediaQueryList = getWindow()?.matchMedia?.(queryString);
 
     return [
       () => mediaQueryList?.matches,

--- a/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
@@ -46,7 +46,7 @@ function useSESClientShim<T>(
     if (checkIfSnapshotChanged(inst)) {
       forceUpdate({ inst });
     }
-  }, [subscribe, value, getSnapshot]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [subscribe, value, getSnapshot]); // eslint-disable-line
 
   React.useEffect(() => {
     const synchronize = () => {
@@ -56,7 +56,7 @@ function useSESClientShim<T>(
     };
     synchronize();
     return subscribe(synchronize);
-  }, [subscribe]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [subscribe]); // eslint-disable-line
 
   return value;
 }

--- a/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+const _React = React; // prevent bundlers from stripping the namespace import
+
+const useSyncExternalStoreShim =
+  typeof document === 'undefined' ? useSESServerShim : useSESClientShim;
+
+/**
+ * Wrapper around `React.useSyncExternalStore` that uses a shim for React 17.
+ *
+ * Note: The shim does not use `getServerSnapshot` at all, because there is
+ * apparently no way to check "hydrating" state in pre-18.
+ *
+ * @see https://github.com/facebook/react/tree/main/packages/use-sync-external-store
+ */
+export const useSyncExternalStore =
+  _React.useSyncExternalStore || useSyncExternalStoreShim;
+
+// ----------------------------------------------------------------------------
+
+// The shim below is adapted from the React source code to make it ESM-compatible.
+// MIT License: https://github.com/facebook/react/blob/main/LICENSE
+
+/** @see https://github.com/facebook/react/blob/1a6d36b1a3ec43cb5700e28d7315b3aa2822365d/packages/use-sync-external-store/src/useSyncExternalStoreShimServer.js */
+function useSESServerShim<T>(_: () => () => void, getSnapshot: () => T): T {
+  return getSnapshot();
+}
+
+/** @see https://github.com/facebook/react/blob/1a6d36b1a3ec43cb5700e28d7315b3aa2822365d/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js */
+function useSESClientShim<T>(
+  subscribe: (onSubscribe: () => void) => () => void,
+  getSnapshot: () => T,
+): T {
+  const value = getSnapshot();
+  const [{ inst }, forceUpdate] = React.useState({
+    inst: { value, getSnapshot },
+  });
+
+  React.useLayoutEffect(() => {
+    inst.value = value;
+    inst.getSnapshot = getSnapshot;
+
+    if (checkIfSnapshotChanged(inst)) {
+      forceUpdate({ inst });
+    }
+  }, [subscribe, value, getSnapshot]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  React.useEffect(() => {
+    const synchronize = () => {
+      if (checkIfSnapshotChanged(inst)) {
+        forceUpdate({ inst });
+      }
+    };
+    synchronize();
+    return subscribe(synchronize);
+  }, [subscribe]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return value;
+}
+
+function checkIfSnapshotChanged<T>(inst: { value: T; getSnapshot: () => T }) {
+  const latestGetSnapshot = inst.getSnapshot;
+  const prevValue = inst.value;
+  try {
+    const nextValue = latestGetSnapshot();
+    return !Object.is(prevValue, nextValue);
+  } catch (error) {
+    return true;
+  }
+}

--- a/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
+++ b/packages/itwinui-react/src/core/utils/hooks/useSyncExternalStore.ts
@@ -5,30 +5,23 @@
 import * as React from 'react';
 const _React = React; // prevent bundlers from stripping the namespace import
 
-const useSyncExternalStoreShim =
-  typeof document === 'undefined' ? useSESServerShim : useSESClientShim;
-
 /**
  * Wrapper around `React.useSyncExternalStore` that uses a shim for React 17.
- *
- * Note: The shim does not use `getServerSnapshot` at all, because there is
- * apparently no way to check "hydrating" state in pre-18.
- *
- * @see https://github.com/facebook/react/tree/main/packages/use-sync-external-store
  */
 export const useSyncExternalStore =
   _React.useSyncExternalStore || useSyncExternalStoreShim;
 
 // ----------------------------------------------------------------------------
 
-// The shim below is adapted from the React source code to make it ESM-compatible.
-// MIT License: https://github.com/facebook/react/blob/main/LICENSE
-
-function useSESServerShim<T>(_: () => () => void, getSnapshot: () => T): T {
-  return getSnapshot();
-}
-
-function useSESClientShim<T>(
+/**
+ * The shim below is adapted from React's source to make it ESM-compatible.
+ *
+ * Note: This does not use `getServerSnapshot` at all, because there is
+ * apparently no way to check "hydrating" state in pre-18.
+ *
+ * @see https://github.com/facebook/react/tree/main/packages/use-sync-external-store
+ */
+function useSyncExternalStoreShim<T>(
   subscribe: (onSubscribe: () => void) => () => void,
   getSnapshot: () => T,
 ): T {


### PR DESCRIPTION
## Changes

[`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) is a hook added in React 18 that makes it easier to subscribe to DOM APIs and support server-side rendering.

This PR adds a shim that makes it possible for this hook to be used in React 17 (falls back to simple `useLayoutEffect`/`useEffect`). This is adapted from [React's source code](https://github.com/facebook/react/tree/main/packages/use-sync-external-store) and has been shortened to remove unnecessary parts like warnings and comments. I wanted to use the published [npm package](https://www.npmjs.com/use-sync-external-store), but it only supports CJS :/

To start off, `useMediaQuery` has been updated to make use of this hook.

In future PRs, we can add it in other places for more useful things.

## Testing

Tested that `<ThemeProvider theme="os">` works fine in playground.

## Docs

N/A

No changeset necessary because this change should be invisible to the user.