### PR TITLE
Improves Deploy Preview PR Check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,13 @@ jobs:
               head_sha: '${{ github.event.pull_request.head.sha }}',
               conclusion: 'neutral',
               name: 'Deploy preview',
+              output: {
+                title: 'Deploy preview',
+                summary: 'Live preview of the current branch',
+                text: '[Portal](https://itwin.github.io/iTwinUI/${{ github.event.number }})
+                [css](https://itwin.github.io/iTwinUI/${{ github.event.number }}/css)
+                [react](https://itwin.github.io/iTwinUI/${{ github.event.number }}/react)'
+              }
             })
 
   unit-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,14 +180,12 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            github.rest.repos.createCommitStatus({
+            github.rest.repos.createCheckRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ github.event.pull_request.head.sha }}',
-              state: 'success',
-              context: 'Deploy preview',
-              description: 'Live preview of the current branch',
-              target_url: 'https://itwin.github.io/iTwinUI/${{ github.event.number }}',
+              head_sha: '${{ github.event.pull_request.head.sha }}',
+              conclusion: 'neutral',
+              name: 'Deploy preview',
             })
 
   unit-test:


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Improves the deploy preview PR check by converting the output from a commit status to a check run, which allows us to make the check neutral. Also removed the custom url that was attached to the details button and adds custom output to the check with the link to the preview instead.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Using this draft PR to test the checks output for correctness.

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

N/A
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
