### PR TITLE
only clamp `DefaultCell` for string children

### DIFF
--- a/.changeset/twenty-keys-roll.md
+++ b/.changeset/twenty-keys-roll.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a regression in `Table` where the layout of a custom `Cell` unexpectedly changed from horizontal to vertical.

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -40,7 +40,12 @@ import {
   useMergedRefs,
 } from '../utils/index.js';
 import type { CommonProps } from '../utils/index.js';
-import { getCellStyle, getStickyStyle, getSubRowStyle } from './utils.js';
+import {
+  TableColumnsContext,
+  getCellStyle,
+  getStickyStyle,
+  getSubRowStyle,
+} from './utils.js';
 import { TableRowMemoized } from './TableRowMemoized.js';
 import { FilterToggle } from './filters/index.js';
 import type { TableFilterValue } from './filters/index.js';
@@ -895,7 +900,7 @@ export const Table = <
   const isHeaderDirectClick = React.useRef(false);
 
   return (
-    <>
+    <TableColumnsContext.Provider value={columns}>
       <Box
         ref={useMergedRefs(tableRef, (element) => {
           ownerDocument.current = element?.ownerDocument;
@@ -1167,6 +1172,6 @@ export const Table = <
         )}
         {paginatorRenderer?.(paginatorRendererProps)}
       </Box>
-    </>
+    </TableColumnsContext.Provider>
   );
 };

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import type { CellRendererProps } from '../../../react-table/react-table.js';
 import cx from 'classnames';
 import { Box, LineClamp, ShadowRoot } from '../../utils/index.js';
+import { TableColumnsContext } from '../utils.js';
 
 export type DefaultCellProps<T extends Record<string, unknown>> = {
   /**
@@ -43,6 +44,8 @@ export type DefaultCellProps<T extends Record<string, unknown>> = {
 export const DefaultCell = <T extends Record<string, unknown>>(
   props: DefaultCellProps<T>,
 ) => {
+  const columnsProp = React.useContext(TableColumnsContext);
+
   const {
     cellElementProps: {
       className: cellElementClassName,
@@ -57,7 +60,11 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     className,
     style,
     status,
-    clamp = typeof children === 'string',
+    // Enable line clamp by default only if the cell content is a string and the column doesn't specify a custom Cell component
+    clamp = typeof cellProps.value === 'string' &&
+      !columnsProp
+        .find((col) => col.id === cellProps.column.id)
+        ?.hasOwnProperty('Cell'),
     ...rest
   } = props;
 

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -57,7 +57,7 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     className,
     style,
     status,
-    clamp = typeof cellProps.value === 'string',
+    clamp = typeof children === 'string',
     ...rest
   } = props;
 

--- a/packages/itwinui-react/src/core/Table/utils.ts
+++ b/packages/itwinui-react/src/core/Table/utils.ts
@@ -2,7 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import type { ColumnInstance } from '../../react-table/react-table.js';
+import * as React from 'react';
+import type { ColumnInstance, Column } from '../../react-table/react-table.js';
 
 export const getCellStyle = <T extends Record<string, unknown>>(
   column: ColumnInstance<T>,
@@ -80,3 +81,5 @@ export const getSubRowStyle = ({ density = 'default', depth = 1 }) => {
     paddingInlineStart: cellPadding + depth * multiplier,
   } satisfies React.CSSProperties;
 };
+
+export const TableColumnsContext = React.createContext<Column[]>([]);


### PR DESCRIPTION
## Changes

This is a follow-up to #1863. In addition to checking for `cellProps.value`, we now also check the original `columns` prop. If a custom `Cell` is passed, we bail on setting the default `clamp` value.

Fixes #1965

Note: This is technically a user error, as they are misusing the `Cell` prop (meant for small transformations) to add custom cell content when they really should be using `cellRenderer`+`DefaultCell`. But it is a regression nontheless, and we can't really blame our users because our current documentation leaves a lot to be desired.

## Testing

Tested by recreating the linked issue in vite playground.

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/50785f6f-bb15-4bc2-84c8-9e7889b1cfec) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/ae55ec3f-67ce-4a3a-9f05-b1f576bc1fb5) |

## Docs

Added changeset.