### PR TITLE
fix clearing of existing `shadowRoot` in strict mode

### DIFF
--- a/apps/react-workshop/.ladle/components.tsx
+++ b/apps/react-workshop/.ladle/components.tsx
@@ -50,12 +50,14 @@ export const Provider: GlobalProvider = ({ children }) => {
   }, []);
 
   return (
-    <ThemeProvider
-      theme={theme}
-      themeOptions={{ applyBackground: false, highContrast }}
-    >
-      {children}
-    </ThemeProvider>
+    <React.StrictMode>
+      <ThemeProvider
+        theme={theme}
+        themeOptions={{ applyBackground: false, highContrast }}
+      >
+        {children}
+      </ThemeProvider>
+    </React.StrictMode>
   );
 };
 

--- a/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
+++ b/packages/itwinui-react/src/core/utils/components/ShadowRoot.tsx
@@ -79,6 +79,7 @@ function useShadowRoot(
   const [shadowRoot, setShadowRoot] = React.useState<ShadowRoot | null>(null);
   const styleSheet = React.useRef<CSSStyleSheet>();
   const latestCss = useLatestRef(css);
+  const latestShadowRoot = useLatestRef(shadowRoot);
 
   useLayoutEffect(() => {
     const parent = templateRef.current?.parentElement;
@@ -86,8 +87,8 @@ function useShadowRoot(
       return;
     }
 
-    const setupShadowRoot = () => {
-      if (parent.shadowRoot) {
+    const setupOrReuseShadowRoot = () => {
+      if (parent.shadowRoot && latestShadowRoot.current === null) {
         parent.shadowRoot.replaceChildren(); // Remove previous shadowroot content
       }
 
@@ -113,11 +114,11 @@ function useShadowRoot(
     };
 
     queueMicrotask(() => {
-      setupShadowRoot();
+      setupOrReuseShadowRoot();
     });
 
     return () => void setShadowRoot(null);
-  }, [templateRef, latestCss]);
+  }, [templateRef, latestCss, latestShadowRoot]);
 
   // Synchronize `css` with contents of the existing stylesheet
   useLayoutEffect(() => {


### PR DESCRIPTION
## Changes

This is left over from #1962

Basically, in [strict mode](https://react.dev/reference/react/StrictMode), react executes all effects a bunch of times, so the shadow-root was getting cleared right after its content was mounted. The only way around this is to avoid clearing a shadow-root if the `shadowRoot` state variable has already been set.

## Testing

I used this code in vite playground `App.tsx` to test manually in dev:

```tsx
export { Full2 as default } from '../../../apps/react-workshop/src/Table.stories.tsx';
```

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/2f4a6b24-c847-421e-bcb4-4690fbfbdd98) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/15253179-0022-4427-8844-f5d454dd8830) |

It isn't possible to write a reliable test for this, since it's a dev + strict mode thing (not reproducible in prod).

However, I've added strict mode to ladle to help catch such issues in our stories during development.

## Docs

N/A
