### PR TITLE
lint: allow explicit `any`

### DIFF
--- a/packages/itwinui-react/.eslintrc.cjs
+++ b/packages/itwinui-react/.eslintrc.cjs
@@ -10,4 +10,8 @@ module.exports = {
   ...preset,
   extends: [...preset.extends, 'plugin:require-extensions/recommended'],
   plugins: [...preset.plugins, 'require-extensions'],
+  rules: {
+    ...preset.rules,
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
 };

--- a/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
@@ -193,7 +193,6 @@ const ListItem = ({
   item: React.ReactNode;
   isActive: boolean;
 }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let children = item as any;
 
   if (

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.test.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.test.tsx
@@ -8,11 +8,9 @@ import { DialogMain } from './DialogMain.js';
 import { DialogTitleBar } from './DialogTitleBar.js';
 
 const DOMMatrixMock = vi.fn(() => ({ m41: 0, m42: 0 }));
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).DOMMatrix = DOMMatrixMock;
 
 afterAll(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).DOMMatrix = undefined;
 });
 

--- a/packages/itwinui-react/src/core/Header/HeaderButton.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderButton.tsx
@@ -79,7 +79,7 @@ export const HeaderButton = React.forwardRef((props, ref) => {
     name: htmlName,
     ...(!!menuItems && { menuItems }),
     ...rest,
-  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  } as any;
 
   const headerButton =
     !!props.menuItems && !!props.onClick ? (

--- a/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderLogo.tsx
@@ -35,7 +35,7 @@ export const HeaderLogo = React.forwardRef((props, ref) => {
     children,
     logo,
     onClick,
-    as = (!!onClick ? 'button' : 'div') as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    as = (!!onClick ? 'button' : 'div') as any,
     ...rest
   } = props;
 

--- a/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
+++ b/packages/itwinui-react/src/core/LabeledSelect/LabeledSelect.tsx
@@ -158,7 +158,6 @@ export const LabeledSelect = React.forwardRef(
           {...{ required: props.native ? required : undefined }}
           {...rest}
           ref={forwardedRef}
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           {...({ styleType: 'default' } as any)} // Never allow LabeledSelect to be borderless
         />
         {typeof message === 'string' ? (

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
@@ -11,7 +11,6 @@ import {
 } from './DateRangeFilter.js';
 import { userEvent } from '@testing-library/user-event';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const renderComponent = (initialProps?: Partial<DateRangeFilterProps<any>>) => {
   const props = {
     column: {} as HeaderGroup,
@@ -22,7 +21,6 @@ const renderComponent = (initialProps?: Partial<DateRangeFilterProps<any>>) => {
   } as DateRangeFilterProps<any>;
   return render(<DateRangeFilter {...props} />);
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 it('should render correctly', () => {
   const { container } = renderComponent();
@@ -45,7 +43,6 @@ it('should render correctly with set filter value', () => {
   const { container } = renderComponent({
     column: {
       filterValue: [new Date(2021, 4, 1), new Date(2021, 4, 3)],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as HeaderGroup<any>,
   });
 
@@ -180,7 +177,6 @@ it('should set filter and keep time from existing dates', () => {
         new Date(2021, 4, 1, 10, 20, 30, 400),
         new Date(2021, 4, 3, 20, 30, 40, 500),
       ],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as HeaderGroup<any>,
   });
 
@@ -236,7 +232,6 @@ it('should render with localized DatePicker', async () => {
   const { container, getByText, getByTitle } = renderComponent({
     column: {
       filterValue: [new Date(2021, 0, 1)],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as HeaderGroup<any>,
 
     translatedLabels: {

--- a/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.test.tsx
@@ -8,7 +8,6 @@ import type { HeaderGroup } from '../../../../react-table/react-table.js';
 import { NumberRangeFilter } from './NumberRangeFilter.js';
 import type { NumberRangeFilterProps } from './NumberRangeFilter.js';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const renderComponent = (
   initialProps?: Partial<NumberRangeFilterProps<any>>,
 ) => {
@@ -21,7 +20,6 @@ const renderComponent = (
   } as NumberRangeFilterProps<any>;
   return render(<NumberRangeFilter {...props} />);
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 it('should render correctly', () => {
   const { container } = renderComponent();
@@ -44,7 +42,6 @@ it('should render correctly with set filter value', () => {
   const { container } = renderComponent({
     column: {
       filterValue: [1, 3],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as HeaderGroup<any>,
   });
 

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.test.tsx
@@ -11,7 +11,6 @@ import { TextFilter } from './TextFilter.js';
 const setFilter = vi.fn() as (value: unknown) => void;
 const clearFilter = vi.fn() as () => void;
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 const renderComponent = (initialProps?: Partial<TableFilterProps<any>>) => {
   const props = {
     column: {} as HeaderGroup,
@@ -22,7 +21,6 @@ const renderComponent = (initialProps?: Partial<TableFilterProps<any>>) => {
   } as TableFilterProps<any>;
   return render(<TextFilter {...props} />);
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -57,7 +55,6 @@ it('should call setFilter when Enter is pressed', () => {
 
 it('should load filter with set value and clear it', () => {
   const { container } = renderComponent({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     column: { filterValue: 'test filter' } as HeaderGroup<any>,
   });
 

--- a/packages/itwinui-react/src/core/Table/filters/customFilterFunctions.test.ts
+++ b/packages/itwinui-react/src/core/Table/filters/customFilterFunctions.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Row } from '../../../react-table/react-table.js';
 import { customFilterFunctions } from './customFilterFunctions.js';
 

--- a/packages/itwinui-react/src/core/Tag/Tag.tsx
+++ b/packages/itwinui-react/src/core/Tag/Tag.tsx
@@ -86,7 +86,6 @@ export const Tag = React.forwardRef((props, forwardedRef) => {
         },
         className,
       )}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ref's type doesn't matter internally
       ref={forwardedRef as any}
       onClick={!shouldUseLinkAction ? onClick : undefined}
       {...rest}

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -191,7 +191,6 @@ const useTooltip = (options: TooltipOptions = {}) => {
     /** e.g. onPointerDown --> pointerdown */
     const domEventName = (e: string) => e.toLowerCase().substring(2);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cleanupValues: Record<string, any> = {};
 
     Object.entries({

--- a/packages/itwinui-react/src/core/utils/components/VirtualScroll.test.tsx
+++ b/packages/itwinui-react/src/core/utils/components/VirtualScroll.test.tsx
@@ -30,7 +30,6 @@ afterAll(() => {
 });
 
 it('should render only few elements out of big list', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   heightsMock.mockImplementation(function (this: Record<string, any>) {
     if (Object.values(this)[0].memoizedProps.id === 'scroller') {
       return { height: 400 } as DOMRect;
@@ -96,7 +95,6 @@ it('should render only few elements out of big list', () => {
 });
 
 it('should not crash with empty list items', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   heightsMock.mockImplementation(function (this: Record<string, any>) {
     if (Object.values(this)[0].memoizedProps.id === 'scroller') {
       return { height: 400 } as DOMRect;
@@ -118,7 +116,6 @@ it('should not crash with empty list items', () => {
 });
 
 it('should render 1 item', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   heightsMock.mockImplementation(function (this: Record<string, any>) {
     if (Object.values(this)[0].memoizedProps.id === 'scroller') {
       return { height: 40 } as DOMRect;
@@ -144,7 +141,6 @@ it('should render 1 item', () => {
 });
 
 it('should show provided index on first render', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   heightsMock.mockImplementation(function (this: Record<string, any>) {
     if (Object.values(this)[0].memoizedProps.id === 'scroller') {
       return { height: 400 } as DOMRect;
@@ -186,7 +182,6 @@ it('should show provided index on first render', () => {
 });
 
 it('should render parent as ul', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   heightsMock.mockImplementation(function (this: Record<string, any>) {
     if (Object.values(this)[0].memoizedProps.id === 'scroller') {
       return { height: 400 } as DOMRect;

--- a/packages/itwinui-react/src/core/utils/functions/dev.ts
+++ b/packages/itwinui-react/src/core/utils/functions/dev.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const isJest = typeof (globalThis as any).jest !== 'undefined';
 const isMocha =

--- a/packages/itwinui-react/src/core/utils/functions/dom.test.tsx
+++ b/packages/itwinui-react/src/core/utils/functions/dom.test.tsx
@@ -9,7 +9,6 @@ import { getDocument, getWindow, mergeEventHandlers } from './dom.js';
 describe('getDocument', () => {
   it('should get document when it is defined', () => {
     expect(getDocument()).toBeTruthy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.spyOn(global as any, 'document', 'get').mockReturnValue(undefined);
     expect(getDocument()).toBeFalsy();
     vi.restoreAllMocks();
@@ -19,7 +18,6 @@ describe('getDocument', () => {
 describe('getWindow', () => {
   it('should get window when it is defined', () => {
     expect(getWindow()).toBeTruthy();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.spyOn(global as any, 'window', 'get').mockReturnValue(undefined);
     expect(getWindow()).toBeFalsy();
     vi.restoreAllMocks();

--- a/packages/itwinui-react/src/core/utils/functions/polymorphic.tsx
+++ b/packages/itwinui-react/src/core/utils/functions/polymorphic.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
 import cx from 'classnames';
 import type { PolymorphicForwardRefComponent } from '../props.js';

--- a/packages/itwinui-react/src/core/utils/functions/react.ts
+++ b/packages/itwinui-react/src/core/utils/functions/react.ts
@@ -26,7 +26,6 @@ export const cloneElementWithRef = (
   const props = getProps(children);
   const ref = mergeRefs(
     ...[
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       'ref' in children ? (children as any).ref : null,
       'ref' in props ? props.ref : null,
     ].filter(Boolean),

--- a/packages/itwinui-react/src/core/utils/hooks/useDragAndDrop.test.tsx
+++ b/packages/itwinui-react/src/core/utils/hooks/useDragAndDrop.test.tsx
@@ -8,22 +8,18 @@ import { useDragAndDrop } from './useDragAndDrop.js';
 import * as DomFunctions from '../functions/dom.js';
 
 const DOMMatrixMock = vi.fn();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).DOMMatrix = DOMMatrixMock;
 
 const getBoundingClientRectMock = vi
   .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
   .mockReturnValue({ top: 100, right: 200, bottom: 200, left: 100 } as DOMRect);
 
-vi.spyOn(DomFunctions, 'getWindow')
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  .mockReturnValue({
-    innerWidth: 300,
-    innerHeight: 300,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  } as any);
-/* eslint-enable @typescript-eslint/no-explicit-any */
+vi.spyOn(DomFunctions, 'getWindow').mockReturnValue({
+  innerWidth: 300,
+  innerHeight: 300,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+} as any);
 
 const TestComponent = (props: {
   isVisible?: boolean;
@@ -53,7 +49,6 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).DOMMatrix = undefined;
   vi.clearAllMocks();
 });

--- a/packages/itwinui-react/src/react-table/react-table.ts
+++ b/packages/itwinui-react/src/react-table/react-table.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 /* eslint-disable @typescript-eslint/ban-types */


### PR DESCRIPTION
## Changes

Disabled the `no-explicit-any` lint rule.

typescript-eslint needs to chill out. Explicit `any` is totally fine when used in internal types and tests, as evidenced by the dozens of occurrences.

## Testing

N/A

## Docs

N/A