### PR TITLE
use `jest` without `globalThis` when detecting it

### DIFF
--- a/.changeset/fluffy-monkeys-protect.md
+++ b/.changeset/fluffy-monkeys-protect.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed `jest` detection logic to correctly exit from scenarios that should not be executed in unit test environments.

--- a/packages/itwinui-react/src/core/utils/functions/dev.ts
+++ b/packages/itwinui-react/src/core/utils/functions/dev.ts
@@ -3,7 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-const isJest = typeof (globalThis as any).jest !== 'undefined';
+// @ts-expect-error -- jest is not used in iTwinUI but may be used in consuming apps
+const isJest = typeof jest !== 'undefined';
+
 const isMocha =
   typeof (globalThis as any).beforeEach !== 'undefined' &&
   `${(globalThis as any).beforeEach}`.replace(/\s/g, '') ===


### PR DESCRIPTION
## Changes

Fixes https://github.com/iTwin/iTwinUI/discussions/1978

## Testing

N/A. We do not use `jest` in this repo, so attempting to test this is futile.

## Docs

Added changeset.