### PR TITLE
render `null` instead of `undefined`

### DIFF
--- a/.changeset/large-ghosts-unite.md
+++ b/.changeset/large-ghosts-unite.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed an issue where some components (such as `InputGroup`) were trying to render `undefined`, which is not supported in React 17..

--- a/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
+++ b/packages/itwinui-react/src/core/InputGroup/InputGroup.tsx
@@ -170,5 +170,5 @@ const BottomMessage = (
     );
   }
 
-  return undefined;
+  return null;
 };

--- a/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
+++ b/packages/itwinui-react/src/core/NonIdealState/ErrorPage.tsx
@@ -232,9 +232,9 @@ export const ErrorPage = React.forwardRef((props, forwardedRef) => {
     }
   }
 
-  function getPrimaryButton(): JSX.Element | undefined {
+  function getPrimaryButton(): JSX.Element | null {
     if (!primaryButtonHandle || !primaryButtonLabel) {
-      return undefined;
+      return null;
     }
     return (
       <Button styleType='high-visibility' onClick={primaryButtonHandle}>
@@ -243,9 +243,9 @@ export const ErrorPage = React.forwardRef((props, forwardedRef) => {
     );
   }
 
-  function getSecondaryButton(): JSX.Element | undefined {
+  function getSecondaryButton(): JSX.Element | null {
     if (!secondaryButtonHandle || !secondaryButtonLabel) {
-      return undefined;
+      return null;
     }
     return (
       <Button styleType='default' onClick={secondaryButtonHandle}>
@@ -254,12 +254,12 @@ export const ErrorPage = React.forwardRef((props, forwardedRef) => {
     );
   }
 
-  function getActions(): JSX.Element | undefined {
+  function getActions(): JSX.Element | null {
     const primaryButton = getPrimaryButton();
     const secondaryButton = getSecondaryButton();
 
     if (!primaryButton && !secondaryButton) {
-      return undefined;
+      return null;
     }
 
     return (


### PR DESCRIPTION
## Changes

Fixes #1979

`undefined` rendering support was only [added in React 18](https://redirect.github.com/facebook/react/pull/21869).

## Testing

N/A. Our repo uses React 18.

## Docs

Added changeset.