### PR TITLE
expose `showYearSelection` from `DateRangeFilter`

### DIFF
--- a/.changeset/thick-years-shake.md
+++ b/.changeset/thick-years-shake.md
@@ -1,0 +1,9 @@
+---
+"@itwin/itwinui-react": minor
+---
+
+`tableFilters.DateRangeFilter` now accepts `showYearSelection` to enable year-selection buttons.
+
+```js
+tableFilters.DateRangeFilter({ showYearSelection: true })
+```

--- a/.changeset/tricky-seas-appear.md
+++ b/.changeset/tricky-seas-appear.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Updated the date pickers to in `tableFilters.DateRangeFilter` to _not_ display dates outside the current month.
+Updated the date pickers in `tableFilters.DateRangeFilter` to _not_ display dates outside the current month.

--- a/.changeset/tricky-seas-appear.md
+++ b/.changeset/tricky-seas-appear.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Updated the date pickers to in `tableFilters.DateRangeFilter` to _not_ display dates outside the current month.

--- a/apps/react-workshop/src/Table.stories.tsx
+++ b/apps/react-workshop/src/Table.stories.tsx
@@ -389,6 +389,7 @@ export const Filters = () => {
         },
         Filter: tableFilters.DateRangeFilter({
           translatedLabels,
+          showYearSelection: true,
         }),
         filter: 'betweenDate',
       },
@@ -402,6 +403,7 @@ export const Filters = () => {
         },
         Filter: tableFilters.DateRangeFilter({
           translatedLabels,
+          showYearSelection: true,
         }),
         filter: 'betweenDate',
       },

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DatePickerInput.tsx
@@ -33,7 +33,8 @@ export type DatePickerInputProps = {
 } & Omit<
   React.ComponentProps<typeof LabeledInput>,
   'value' | 'onChange' | 'svgIcon' | 'displayStyle'
->;
+> &
+  Pick<React.ComponentProps<typeof DatePicker>, 'showYearSelection'>;
 
 export const DatePickerInput = React.forwardRef((props, forwardedRef) => {
   const uid = useId();
@@ -52,6 +53,7 @@ export const DatePickerInput = React.forwardRef((props, forwardedRef) => {
     inputWrapperProps,
     id = uid,
     localizedNames,
+    showYearSelection,
     ...rest
   } = props;
 
@@ -130,6 +132,8 @@ export const DatePickerInput = React.forwardRef((props, forwardedRef) => {
               isDateDisabled={isDateDisabled}
               localizedNames={localizedNames}
               applyBackground={false}
+              showDatesOutsideMonth={false}
+              showYearSelection={showYearSelection}
             />
           }
           placement='bottom-end'

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import type { HeaderGroup } from '../../../../react-table/react-table.js';
 import {
@@ -248,4 +248,14 @@ it('should render with localized DatePicker', async () => {
   getByText('January-custom');
   getByText('Su-custom');
   getByTitle('Sunday-custom');
+});
+
+it('should support showYearSelection prop', () => {
+  const { getByRole, container } = renderComponent({
+    showYearSelection: true,
+  });
+  act(() => container.querySelector('button')?.click());
+
+  expect(getByRole('button', { name: 'Previous year' })).toBeTruthy();
+  expect(getByRole('button', { name: 'Next year' })).toBeTruthy();
 });

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -45,7 +45,7 @@ export type DateRangeFilterProps<T extends Record<string, unknown>> =
     parseInput?: (text: string) => Date;
     placeholder?: string;
     translatedLabels?: DateRangeTranslation & FilterButtonBarTranslation;
-  };
+  } & Pick<React.ComponentProps<typeof DatePickerInput>, 'showYearSelection'>;
 
 export const DateRangeFilter = <T extends Record<string, unknown>>(
   props: DateRangeFilterProps<T>,
@@ -58,6 +58,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
     formatDate = defaultFormatDate,
     parseInput = defaultParseInput,
     placeholder = 'MMM dd, yyyy',
+    showYearSelection,
   } = props;
 
   useGlobals();
@@ -137,6 +138,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         selectedDate={to}
         isFromOrTo='from'
         localizedNames={translatedStrings.datePicker}
+        showYearSelection={showYearSelection}
       />
       <DatePickerInput
         label={translatedStrings.to}
@@ -149,6 +151,7 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         selectedDate={from}
         isFromOrTo='to'
         localizedNames={translatedStrings.datePicker}
+        showYearSelection={showYearSelection}
       />
       <FilterButtonBar
         setFilter={() => setFilter([from, to])}

--- a/packages/itwinui-react/src/core/Table/filters/tableFilters.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/tableFilters.tsx
@@ -33,7 +33,7 @@ export type DateRangeFilterOptions = {
    * Translated filter labels.
    */
   translatedLabels?: DateRangeTranslation & FilterButtonBarTranslation;
-};
+} & Pick<React.ComponentProps<typeof DateRangeFilter>, 'showYearSelection'>;
 
 export const tableFilters = {
   /**


### PR DESCRIPTION
## Changes

Resolves #1984 by forwarding the `showYearSelection` prop from `DatePicker`

Unrelated: also set `showDatesOutsideMonth` to `false` (the recommended value after #1822)

![image](https://github.com/iTwin/iTwinUI/assets/9084735/899ecc29-6521-473a-b544-abd477614806)


## Testing

Added unit test.

## Docs

Added changeset, updated story.