### PR TITLE
Adds `Button` Astro Component.

### DIFF
--- a/apps/css-workshop/src/components/Button.astro
+++ b/apps/css-workshop/src/components/Button.astro
@@ -1,0 +1,21 @@
+---
+type Props = {
+  variant?: 'high-visibility' | 'borderless' | 'cta' | 'idea';
+  size?: 'small' | 'large';
+  active?: 'true';
+  shift?: 'left' | 'right';
+} & astroHTML.JSX.ButtonHTMLAttributes;
+
+const { class: className, variant, size, active, shift, ...props } = Astro.props;
+---
+
+<button
+  class:list={['iui-button', className]}
+  data-iui-variant={variant}
+  data-iui-size={size}
+  data-iui-active={active}
+  data-iui-shift={shift}
+  {...props}
+>
+  <slot />
+</button>

--- a/apps/css-workshop/src/pages/alert.astro
+++ b/apps/css-workshop/src/pages/alert.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Alert'>
@@ -46,15 +47,9 @@ import Layout from './_layout.astro';
           data-iui-status='informational'>Learn more</a
         >
       </span>
-      <button
-        aria-label='Close'
-        type='button'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-alert' data-iui-status='positive'>
@@ -68,15 +63,9 @@ import Layout from './_layout.astro';
           data-iui-status='positive'>Learn more</a
         >
       </span>
-      <button
-        aria-label='Close'
-        type='button'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-alert' data-iui-status='warning'>
@@ -90,15 +79,9 @@ import Layout from './_layout.astro';
           data-iui-status='warning'>Learn more</a
         >
       </span>
-      <button
-        aria-label='Close'
-        type='button'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-alert' data-iui-status='negative' id='test-single-alert'>
@@ -112,15 +95,9 @@ import Layout from './_layout.astro';
           data-iui-status='negative'>Learn more</a
         >
       </span>
-      <button
-        aria-label='Close'
-        type='button'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-alert' data-iui-status='informational'>
@@ -138,15 +115,9 @@ import Layout from './_layout.astro';
           data-iui-status='informational'>Learn more</a
         >
       </span>
-      <button
-        aria-label='Close'
-        type='button'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
   </section>
 
@@ -165,15 +136,9 @@ import Layout from './_layout.astro';
             data-iui-underline='true'>Learn more</a
           >
         </span>
-        <button
-          aria-label='Close'
-          type='button'
-          class='iui-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
-        >
+        <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </div>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut

--- a/apps/css-workshop/src/pages/breadcrumbs.astro
+++ b/apps/css-workshop/src/pages/breadcrumbs.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Breadcrumbs'>
@@ -30,10 +31,10 @@ import Layout from './_layout.astro';
   <h2>Breadcrumbs anchor</h2>
   <section id='demo-anchors'>
     <nav class='iui-breadcrumbs' aria-label='Breadcrumbs'>
-      <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+      <Button_ class='iui-button-dropdown' variant='borderless'>
         <svg-folder class='iui-button-icon' aria-hidden='true'></svg-folder>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
       <ol class='iui-breadcrumbs-list'>
         <li class='iui-breadcrumbs-item'>
           <a class='iui-anchor iui-breadcrumbs-content' href='#'> Root</a>
@@ -71,10 +72,10 @@ import Layout from './_layout.astro';
   <h2>Breadcrumbs button</h2>
   <section id='demo-buttons-1'>
     <nav class='iui-breadcrumbs' aria-label='Breadcrumbs'>
-      <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+      <Button_ class='iui-button-dropdown' variant='borderless'>
         <svg-folder class='iui-button-icon' aria-hidden='true'></svg-folder>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
       <ol class='iui-breadcrumbs-list'>
         <li class='iui-breadcrumbs-item'>
           <button class='iui-breadcrumbs-content'>
@@ -118,10 +119,10 @@ import Layout from './_layout.astro';
   <h2>Overflow button</h2>
   <section id='demo-buttons-2'>
     <nav class='iui-breadcrumbs' aria-label='Breadcrumbs'>
-      <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+      <Button_ class='iui-button-dropdown' variant='borderless'>
         <svg-folder class='iui-button-icon' aria-hidden='true'></svg-folder>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
       <ol class='iui-breadcrumbs-list'>
         <li class='iui-breadcrumbs-item'>
           <button class='iui-breadcrumbs-content'>
@@ -167,19 +168,19 @@ import Layout from './_layout.astro';
   <h2>After clicking "you are here"</h2>
   <section id='demo-not-tested'>
     <nav class='iui-breadcrumbs' aria-label='Breadcrumbs'>
-      <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+      <Button_ class='iui-button-dropdown' variant='borderless'>
         <svg-folder class='iui-button-icon' aria-hidden='true'></svg-folder>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
       <label class='iui-input-grid iui-inline-label iui-inline-icon'>
         <input
           value='C:/Root/Lorem/Ipsum/Nested/Double nested folder with truncation/You are here/'
           class='iui-input'
           spellcheck='false'
         />
-        <button class='iui-button' data-iui-variant='borderless' aria-label='Close'>
+        <Button_ variant='borderless' aria-label='Close'>
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </label>
     </nav>
   </section>

--- a/apps/css-workshop/src/pages/button.astro
+++ b/apps/css-workshop/src/pages/button.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Button'>
@@ -53,296 +54,288 @@ import Layout from './_layout.astro';
 
   <section id='demo-high-visibility'>
     <div id='demo-high-visibility-small' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      <Button_ variant='high-visibility' size='small'>
         <span>Small</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='high-visibility' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='high-visibility' size='small'>
         <span>Small right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='high-visibility' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small' disabled>
+      </Button_>
+      <Button_ variant='high-visibility' size='small' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-high-visibility-normal' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      <Button_ variant='high-visibility'>
         <span>Normal</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      </Button_>
+      <Button_ variant='high-visibility'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      </Button_>
+      <Button_ variant='high-visibility'>
         <span>Normal right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      </Button_>
+      <Button_ variant='high-visibility'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' disabled>
+      </Button_>
+      <Button_ variant='high-visibility' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-high-visibility-large' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      <Button_ variant='high-visibility' size='large'>
         <span>Large</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='high-visibility' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='high-visibility' size='large'>
         <span>Large right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='high-visibility' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large' disabled>
+      </Button_>
+      <Button_ variant='high-visibility' size='large' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large disabled</span>
-      </button>
+      </Button_>
     </div>
   </section>
 
   <h3>Call to action</h3>
   <section id='demo-cta'>
     <div id='demo-cta-small' class='demo-container'>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      <Button_ variant='cta' size='small'>
         <span>Small</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='cta' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='cta' size='small'>
         <span>Small right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='cta' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small' disabled>
+      </Button_>
+      <Button_ variant='cta' size='small' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-cta-medium' class='demo-container'>
-      <button class='iui-button' data-iui-variant='cta'>
+      <Button_ variant='cta'>
         <span>Normal</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta'>
+      </Button_>
+      <Button_ variant='cta'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta'>
+      </Button_>
+      <Button_ variant='cta'>
         <span>Normal right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta'>
+      </Button_>
+      <Button_ variant='cta'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' disabled>
+      </Button_>
+      <Button_ variant='cta' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-cta-large' class='demo-container'>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      <Button_ variant='cta' size='large'>
         <span>Large</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='cta' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='cta' size='large'>
         <span>Large right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='cta' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large' disabled>
+      </Button_>
+      <Button_ variant='cta' size='large' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large disabled</span>
-      </button>
+      </Button_>
     </div>
   </section>
 
   <h3>Default</h3>
   <section id='demo-default'>
     <div id='demo-default-small' class='demo-container'>
-      <button class='iui-button' data-iui-size='small'>
+      <Button_ size='small'>
         <span>Small</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small left icon</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <span>Small right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button iui-button-dropdown' data-iui-size='small'>
+      </Button_>
+      <Button_ class='iui-button-dropdown' size='small'>
         <span>Small dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' data-iui-size='small' disabled>
+      </Button_>
+      <Button_ size='small' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-default-medium' class='demo-container'>
-      <button class='iui-button'>
+      <Button_>
         <span>Normal</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal left icon</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <span>Normal right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button iui-button-dropdown'>
+      </Button_>
+      <Button_ class='iui-button-dropdown'>
         <span>Normal dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' disabled>
+      </Button_>
+      <Button_ disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-default-large' class='demo-container'>
-      <button class='iui-button' data-iui-size='large'>
+      <Button_ size='large'>
         <span>Large</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large left icon</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <span>Large right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button iui-button-dropdown' data-iui-size='large'>
+      </Button_>
+      <Button_ class='iui-button-dropdown' size='large'>
         <span>Large dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' data-iui-size='large' disabled>
+      </Button_>
+      <Button_ size='large' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large disabled</span>
-      </button>
+      </Button_>
     </div>
   </section>
 
   <h3>Borderless</h3>
   <section id='demo-borderless'>
     <div id='demo-borderless-small' class='demo-container'>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      <Button_ variant='borderless' size='small'>
         <span>Small</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <span>Small right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button
-        class='iui-button iui-button-dropdown'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      </Button_>
+      <Button_ class='iui-button-dropdown' variant='borderless' size='small'>
         <span>Small dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small' disabled>
+      </Button_>
+      <Button_ variant='borderless' size='small' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Small disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-borderless-medium' class='demo-container'>
-      <button class='iui-button' data-iui-variant='borderless'>
+      <Button_ variant='borderless'>
         <span>Normal</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <span>Normal right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ class='iui-button-dropdown' variant='borderless'>
         <span>Normal dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' disabled>
+      </Button_>
+      <Button_ variant='borderless' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Normal disabled</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-borderless-large' class='demo-container'>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      <Button_ variant='borderless' size='large'>
         <span>Large</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large left icon</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <span>Large right icon</span>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-      </button>
-      <button
-        class='iui-button iui-button-dropdown'
-        data-iui-variant='borderless'
-        data-iui-size='large'
-      >
+      </Button_>
+      <Button_ class='iui-button-dropdown' variant='borderless' size='large'>
         <span>Large dropdown</span>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large' disabled>
+      </Button_>
+      <Button_ variant='borderless' size='large' disabled>
         <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         <span>Large disabled</span>
-      </button>
+      </Button_>
     </div>
   </section>
 
@@ -351,7 +344,7 @@ import Layout from './_layout.astro';
   <h2>With notifications</h2>
   <section id='demo-notification'>
     <div id='demo-notification-small' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      <Button_ variant='high-visibility' size='small'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -360,8 +353,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='cta' size='small'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -370,8 +363,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='informational'
@@ -380,8 +373,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='primary'
@@ -390,11 +383,11 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-notification-medium' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      <Button_ variant='high-visibility'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -403,8 +396,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta'>
+      </Button_>
+      <Button_ variant='cta'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -413,8 +406,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='informational'
@@ -423,8 +416,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='primary'
@@ -433,11 +426,11 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
+      </Button_>
     </div>
 
     <div id='demo-notification-large' class='demo-container'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      <Button_ variant='high-visibility' size='large'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -446,8 +439,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='cta' size='large'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='white'
@@ -456,8 +449,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='informational'
@@ -466,8 +459,8 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <span
           class='iui-button-icon iui-notification-marker'
           data-iui-variant='primary'
@@ -476,7 +469,7 @@ import Layout from './_layout.astro';
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
         </span>
         <span>Notification</span>
-      </button>
+      </Button_>
     </div>
   </section>
 
@@ -487,134 +480,134 @@ import Layout from './_layout.astro';
   <h3>Default</h3>
   <section id='demo-grouped-default'>
     <span class='iui-button-group'>
-      <button class='iui-button' data-iui-size='small'>
+      <Button_ size='small'>
         <span>Left</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <span>Middle</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button class='iui-button'>
+      <Button_>
         <span>Left</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <span>Middle</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button class='iui-button' data-iui-size='large'>
+      <Button_ size='large'>
         <span>Left</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <span>Middle</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button title='Download' class='iui-button'>
+      <Button_ title='Download'>
         <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-      </button>
-      <button title='Move' class='iui-button'>
+      </Button_>
+      <Button_ title='Move'>
         <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-      </button>
-      <button title='Delete' class='iui-button' disabled>
+      </Button_>
+      <Button_ title='Delete' disabled>
         <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-      </button>
-      <button title='Rename' class='iui-button'>
+      </Button_>
+      <Button_ title='Rename'>
         <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-      </button>
-      <button title='More options…' class='iui-button'>
+      </Button_>
+      <Button_ title='More options…'>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button disabled title='Download' class='iui-button'>
+      <Button_ disabled title='Download'>
         <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-      </button>
-      <button disabled title='Move' class='iui-button'>
+      </Button_>
+      <Button_ disabled title='Move'>
         <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-      </button>
-      <button title='Delete' class='iui-button' disabled>
+      </Button_>
+      <Button_ title='Delete' disabled>
         <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-      </button>
-      <button disabled title='Rename' class='iui-button'>
+      </Button_>
+      <Button_ disabled title='Rename'>
         <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-      </button>
-      <button disabled title='More options…' class='iui-button'>
+      </Button_>
+      <Button_ disabled title='More options…'>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button title='List view' class='iui-button'>
+      <Button_ title='List view'>
         <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-      </button>
-      <button title='Tile view' class='iui-button' data-iui-active='true'>
+      </Button_>
+      <Button_ title='Tile view' active='true'>
         <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button disabled title='List view' class='iui-button'>
+      <Button_ disabled title='List view'>
         <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-      </button>
-      <button disabled title='Tile view' class='iui-button' data-iui-active='true'>
+      </Button_>
+      <Button_ disabled title='Tile view' active='true'>
         <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group' data-iui-orientation='vertical'>
-      <button class='iui-button'>
+      <Button_>
         <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-      </button>
-      <button class='iui-button' disabled>
+      </Button_>
+      <Button_ disabled>
         <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-      </button>
-      <button class='iui-button' disabled>
+      </Button_>
+      <Button_ disabled>
         <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </span>
 
     <span class='iui-button-group' data-iui-orientation='vertical'>
-      <button class='iui-button'>
+      <Button_>
         <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-      </button>
-      <button class='iui-button' data-iui-active='true'>
+      </Button_>
+      <Button_ active='true'>
         <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-      </button>
+      </Button_>
     </span>
   </section>
 
@@ -623,116 +616,105 @@ import Layout from './_layout.astro';
   <h3>Borderless</h3>
   <section id='demo-grouped-borderless'>
     <span class='iui-button-group'>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      <Button_ variant='borderless' size='small'>
         <span>Left</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <span>Middle</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='borderless' size='small'>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button class='iui-button' data-iui-variant='borderless'>
+      <Button_ variant='borderless'>
         <span>Left</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <span>Middle</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ variant='borderless'>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      <Button_ variant='borderless' size='large'>
         <span>Left</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <span>Middle</span>
-      </button>
-      <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='borderless' size='large'>
         <span>Right</span>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button title='Download' class='iui-button' data-iui-variant='borderless'>
+      <Button_ title='Download' variant='borderless'>
         <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-      </button>
-      <button title='Move' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ title='Move' variant='borderless'>
         <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-      </button>
-      <button title='Delete' class='iui-button' data-iui-variant='borderless' disabled>
+      </Button_>
+      <Button_ title='Delete' variant='borderless' disabled>
         <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-      </button>
-      <button title='Rename' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ title='Rename' variant='borderless'>
         <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-      </button>
-      <button title='More options…' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ title='More options…' variant='borderless'>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button disabled title='Download' class='iui-button' data-iui-variant='borderless'>
+      <Button_ disabled title='Download' variant='borderless'>
         <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-      </button>
-      <button disabled title='Move' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ disabled title='Move' variant='borderless'>
         <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-      </button>
-      <button title='Delete' class='iui-button' data-iui-variant='borderless' disabled>
+      </Button_>
+      <Button_ title='Delete' variant='borderless' disabled>
         <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-      </button>
-      <button disabled title='Rename' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ disabled title='Rename' variant='borderless'>
         <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-      </button>
-      <button disabled title='More options…' class='iui-button' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ disabled title='More options…' variant='borderless'>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button title='List view' class='iui-button' data-iui-variant='borderless'>
+      <Button_ title='List view' variant='borderless'>
         <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-      </button>
-      <button
-        title='Tile view'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-active='true'
-      >
+      </Button_>
+      <Button_ title='Tile view' variant='borderless' active='true'>
         <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-group'>
-      <button disabled title='List view' class='iui-button' data-iui-variant='borderless'>
+      <Button_ disabled title='List view' variant='borderless'>
         <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-      </button>
-      <button
-        disabled
-        title='Tile view'
-        class='iui-button'
-        data-iui-variant='borderless'
-        data-iui-active='true'
-      >
+      </Button_>
+      <Button_ disabled title='Tile view' variant='borderless' active='true'>
         <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-      </button>
+      </Button_>
     </span>
   </section>
 
@@ -741,106 +723,106 @@ import Layout from './_layout.astro';
   <h3>Split menu</h3>
   <section id='demo-split'>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      <Button_ variant='high-visibility' size='small'>
         <span>Small split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='high-visibility' size='small'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      <Button_ variant='cta' size='small'>
         <span>Small split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='small'>
+      </Button_>
+      <Button_ variant='cta' size='small'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-size='small'>
+      <Button_ size='small'>
         <span>Small split menu</span>
-      </button>
-      <button class='iui-button' data-iui-size='small'>
+      </Button_>
+      <Button_ size='small'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-size='small' disabled>
+      <Button_ size='small' disabled>
         <span>Small split menu</span>
-      </button>
-      <button class='iui-button' data-iui-size='small' disabled>
+      </Button_>
+      <Button_ size='small' disabled>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      <Button_ variant='high-visibility'>
         <span>Split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      </Button_>
+      <Button_ variant='high-visibility'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='cta'>
+      <Button_ variant='cta'>
         <span>Split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta'>
+      </Button_>
+      <Button_ variant='cta'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button'>
+      <Button_>
         <span>Split menu</span>
-      </button>
-      <button class='iui-button'>
+      </Button_>
+      <Button_>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' disabled>
+      <Button_ disabled>
         <span>Split menu</span>
-      </button>
-      <button class='iui-button' disabled>
+      </Button_>
+      <Button_ disabled>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      <Button_ variant='high-visibility' size='large'>
         <span>Large split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='high-visibility' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='high-visibility' size='large'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      <Button_ variant='cta' size='large'>
         <span>Large split menu</span>
-      </button>
-      <button class='iui-button' data-iui-variant='cta' data-iui-size='large'>
+      </Button_>
+      <Button_ variant='cta' size='large'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-size='large'>
+      <Button_ size='large'>
         <span>Large split menu</span>
-      </button>
-      <button class='iui-button' data-iui-size='large'>
+      </Button_>
+      <Button_ size='large'>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
     <span class='iui-button-split'>
-      <button class='iui-button' data-iui-size='large' disabled>
+      <Button_ size='large' disabled>
         <span>Large split menu</span>
-      </button>
-      <button class='iui-button' data-iui-size='large' disabled>
+      </Button_>
+      <Button_ size='large' disabled>
         <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-      </button>
+      </Button_>
     </span>
   </section>
 
@@ -850,25 +832,25 @@ import Layout from './_layout.astro';
 
   <section id='demo-combo-group'>
     <div class='iui-button-group'>
-      <button class='iui-button'>
+      <Button_>
         <span>Button 1</span>
-      </button>
+      </Button_>
       <input class='iui-input' />
-      <button class='iui-button'>
+      <Button_>
         <span>Button 2</span>
-      </button>
+      </Button_>
     </div>
 
     <br />
 
     <div class='iui-button-group'>
-      <button class='iui-button'>
+      <Button_>
         <span>Button 1</span>
-      </button>
+      </Button_>
       <input class='iui-input' placeholder='Disabled input' disabled />
-      <button class='iui-button'>
+      <Button_>
         <span>Button 2</span>
-      </button>
+      </Button_>
     </div>
 
     <br />
@@ -877,9 +859,9 @@ import Layout from './_layout.astro';
       <div class='iui-input-flex-container' data-iui-disabled='true'>
         <input value='https://itwin.github.io/iTwinUI' disabled />
       </div>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      <Button_ variant='high-visibility'>
         <span>Copy</span>
-      </button>
+      </Button_>
     </div>
 
     <br />
@@ -887,13 +869,13 @@ import Layout from './_layout.astro';
     <div class='iui-button-group'>
       <div class='iui-input-flex-container'>
         <input value='https://itwin.github.io/iTwinUI' />
-        <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+        <Button_ class='iui-input-flex-container-icon' variant='borderless'>
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </div>
-      <button class='iui-button'>
+      <Button_>
         <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-      </button>
+      </Button_>
     </div>
   </section>
 
@@ -903,9 +885,9 @@ import Layout from './_layout.astro';
   <p class='iui-text-small iui-text-muted'>Look to the bottom right of your browser window.</p>
   <br />
   <section>
-    <button class='iui-button' data-iui-variant='idea' id='demo-ideas'>
+    <Button_ variant='idea' id='demo-ideas'>
       <svg-smiley-happy class='iui-button-icon' aria-hidden='true'></svg-smiley-happy>
       <span>Feedback</span>
-    </button>
+    </Button_>
   </section>
 </Layout>

--- a/apps/css-workshop/src/pages/carousel.astro
+++ b/apps/css-workshop/src/pages/carousel.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Carousel'>
@@ -77,28 +78,28 @@ import Layout from './_layout.astro';
     >
       <div class='iui-carousel-navigation'>
         <div class='iui-carousel-navigation-left'>
-          <button
-            class='iui-button iui-carousel-navigation-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+          <Button_
+            class='iui-carousel-navigation-button'
+            variant='borderless'
+            size='small'
             type='button'
             aria-controls='myCarousel-items'
             aria-label='Previous slide'
             tabindex='-1'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
-          <button
-            class='iui-button iui-carousel-navigation-animation-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+          </Button_>
+          <Button_
+            class='iui-carousel-navigation-animation-button'
+            variant='borderless'
+            size='small'
             type='button'
             aria-label='Play animation'
             data-action='play'
             tabindex='-1'
           >
             <svg-play class='iui-button-icon' aria-hidden='true'></svg-play>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-carousel-navigation-dots' role='tablist' aria-label='Slides' tabindex='-1'>
@@ -195,17 +196,17 @@ import Layout from './_layout.astro';
         </div>
 
         <div class='iui-carousel-navigation-right'>
-          <button
-            class='iui-button iui-carousel-navigation-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+          <Button_
+            class='iui-carousel-navigation-button'
+            variant='borderless'
+            size='small'
             type='button'
             aria-controls='myCarousel-items'
             aria-label='Next slide'
             tabindex='-1'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
       </div>
 

--- a/apps/css-workshop/src/pages/code.astro
+++ b/apps/css-workshop/src/pages/code.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Code_ from '../components/Code.astro';
 ---
 
@@ -16,10 +17,10 @@ import Code_ from '../components/Code.astro';
     <div class='iui-codeblock' style='width: 770px;'>
       <div class='iui-title-bar'>
         <span class='iui-title'>HTML</span>
-        <button class='iui-button' data-iui-variant='borderless' aria-label='Copy' type='button'>
+        <Button_ variant='borderless' aria-label='Copy' type='button'>
           <svg-copy class='iui-button-icon' aria-hidden='true'></svg-copy>
           <span>Copy</span>
-        </button>
+        </Button_>
       </div>
 
       <pre

--- a/apps/css-workshop/src/pages/color-picker.astro
+++ b/apps/css-workshop/src/pages/color-picker.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='ColorPicker'>
@@ -205,9 +206,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-input-wrapper'>
         <div class='iui-color-picker-section-label'>RGBA</div>
         <div class='iui-color-input'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-swap class='iui-button-icon' aria-hidden='true'></svg-swap>
-          </button>
+          </Button_>
           <div class='iui-color-input-fields'>
             <div class='iui-input-grid'>
               <input
@@ -257,9 +258,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-palette-wrapper'>
         <div class='iui-color-picker-section-label'>Saved colors</div>
         <div class='iui-color-palette'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-          </button>
+          </Button_>
           <span
             style='--iui-color-swatch-background: hsl(0, 100%, 40%);'
             class='iui-color-swatch'
@@ -343,9 +344,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-input-wrapper'>
         <div class='iui-color-picker-section-label'>HSLA</div>
         <div class='iui-color-input'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-swap class='iui-button-icon' aria-hidden='true'></svg-swap>
-          </button>
+          </Button_>
           <div class='iui-color-input-fields'>
             <div class='iui-input-grid'>
               <input
@@ -395,9 +396,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-palette-wrapper'>
         <div class='iui-color-picker-section-label'>Saved colors</div>
         <div class='iui-color-palette'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-          </button>
+          </Button_>
           <span
             style='--iui-color-swatch-background: hsl(0, 100%, 40%);'
             class='iui-color-swatch'
@@ -462,9 +463,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-input-wrapper'>
         <div class='iui-color-picker-section-label'>HEX</div>
         <div class='iui-color-input'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-swap class='iui-button-icon' aria-hidden='true'></svg-swap>
-          </button>
+          </Button_>
           <div class='iui-color-input-fields'>
             <div class='iui-input-grid'>
               <input value='#ffc335' maxlength='7' class='iui-input' data-iui-size='small' />
@@ -476,9 +477,9 @@ import Layout from './_layout.astro';
       <div class='iui-color-palette-wrapper'>
         <div class='iui-color-picker-section-label'>Saved colors</div>
         <div class='iui-color-palette'>
-          <button class='iui-button' data-iui-variant='borderless' data-iui-size='small'>
+          <Button_ variant='borderless' size='small'>
             <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-          </button>
+          </Button_>
           <span
             style='--iui-color-swatch-background: hsl(0, 100%, 40%);'
             class='iui-color-swatch'

--- a/apps/css-workshop/src/pages/column-filter.astro
+++ b/apps/css-workshop/src/pages/column-filter.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Column filter'>
@@ -31,12 +32,12 @@ import Layout from './_layout.astro';
       </label>
       <input class='iui-input' />
       <div class='iui-button-bar'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Filter</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Clear</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </section>
@@ -50,26 +51,26 @@ import Layout from './_layout.astro';
         <div class='iui-input-label'>From</div>
         <div class='iui-input-flex-container'>
           <input value='Feb 6, 2020' />
-          <button
-            class='iui-button iui-input-flex-container-icon'
-            data-iui-variant='borderless'
+          <Button_
+            class='iui-input-flex-container-icon'
+            variant='borderless'
             aria-label='Choose date'
           >
             <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
-          </button>
+          </Button_>
         </div>
       </label>
       <label class='iui-input-grid' data-iui-label-placement='inline'>
         <div class='iui-input-label'>To</div>
         <div class='iui-input-flex-container'>
           <input value='Feb 6, 2020' />
-          <button
-            class='iui-button iui-input-flex-container-icon'
-            data-iui-variant='borderless'
+          <Button_
+            class='iui-input-flex-container-icon'
+            variant='borderless'
             aria-label='Choose date'
           >
             <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
-          </button>
+          </Button_>
         </div>
       </label>
 
@@ -78,12 +79,12 @@ import Layout from './_layout.astro';
           <input class='iui-toggle-switch' type='checkbox' role='switch' checked />
           <span class='iui-toggle-switch-label'>All day</span>
         </label>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Filter</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Clear</span>
-        </button>
+        </Button_>
       </div>
     </div>
 
@@ -94,26 +95,26 @@ import Layout from './_layout.astro';
         <div class='iui-input-label'>From</div>
         <div class='iui-input-flex-container'>
           <input value='Feb 6, 2020 9:00 AM' />
-          <button
-            class='iui-button iui-input-flex-container-icon'
-            data-iui-variant='borderless'
+          <Button_
+            class='iui-input-flex-container-icon'
+            variant='borderless'
             aria-label='Choose date'
           >
             <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
-          </button>
+          </Button_>
         </div>
       </label>
       <label class='iui-input-grid' data-iui-label-placement='inline'>
         <div class='iui-input-label'>To</div>
         <div class='iui-input-flex-container'>
           <input value='Feb 6, 2020 12:00 PM' />
-          <button
-            class='iui-button iui-input-flex-container-icon'
-            data-iui-variant='borderless'
+          <Button_
+            class='iui-input-flex-container-icon'
+            variant='borderless'
             aria-label='Choose date'
           >
             <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
-          </button>
+          </Button_>
         </div>
       </label>
 
@@ -122,12 +123,12 @@ import Layout from './_layout.astro';
           <input class='iui-toggle-switch' type='checkbox' role='switch' />
           <span class='iui-toggle-switch-label'>All day</span>
         </label>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Filter</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Clear</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </section>

--- a/apps/css-workshop/src/pages/date-picker.astro
+++ b/apps/css-workshop/src/pages/date-picker.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Date picker'>
@@ -23,29 +24,27 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>
@@ -378,51 +377,47 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous year'
             type='button'
             role='year-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-left-double>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Next year'
             type='button'
             role='year-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-right-double>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>
@@ -843,29 +838,27 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>
@@ -1347,29 +1340,27 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>
@@ -1890,51 +1881,47 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous year'
             type='button'
             role='year-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-left-double>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Next year'
             type='button'
             role='year-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
           >
             <svg-chevron-right-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-right-double>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>
@@ -2353,55 +2340,51 @@ import Layout from './_layout.astro';
     <div class='iui-date-picker iui-popover-surface' role='dialog' aria-modal='true'>
       <div>
         <div class='iui-calendar-month-year'>
-          <button
+          <Button_
             aria-label='Previous year'
             type='button'
             role='year-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             disabled=''
           >
             <svg-chevron-left-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-left-double>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Previous month'
             type='button'
             role='month-previous'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             disabled=''
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span aria-live='polite'><span class='iui-calendar-month'>August</span>&nbsp;2020</span>
 
-          <button
+          <Button_
             aria-label='Next month'
             type='button'
             role='month-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             disabled=''
           >
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
-          <button
+          </Button_>
+          <Button_
             aria-label='Next year'
             type='button'
             role='year-next'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             disabled=''
           >
             <svg-chevron-right-double class='iui-button-icon' aria-hidden='true'
             ></svg-chevron-right-double>
-          </button>
+          </Button_>
         </div>
         <div class='iui-calendar-weekdays'>
           <div title='Sunday' abbr='Sunday'>Su</div>

--- a/apps/css-workshop/src/pages/dialog.astro
+++ b/apps/css-workshop/src/pages/dialog.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Dialog'>
@@ -55,56 +56,52 @@ import Layout from './_layout.astro';
     </div>
   </div>
 
-  <button
+  <Button_
     aria-label='Open dialog'
     id='open-dialog'
     type='button'
-    class='iui-button'
     onclick="toggleDialog('default-dialog')"
   >
     Open dialog
-  </button>
+  </Button_>
 
   <br />
 
-  <button
+  <Button_
     aria-label='Open full page dialog'
     id='open-full-page-dialog'
     type='button'
-    class='iui-button'
     onclick="toggleDialog('full-page-dialog')"
   >
     Open full page dialog
-  </button>
+  </Button_>
 
   <br />
 
-  <button
+  <Button_
     aria-label='Toggle draggable dialog'
     id='toggle-draggable-dialog'
     type='button'
-    class='iui-button'
     onclick="toggleDialog('draggable-dialog')"
   >
     Toggle draggable dialog
-  </button>
+  </Button_>
 
   <div id='default-dialog'>
     <div class='iui-backdrop iui-backdrop-fixed'></div>
     <div class='iui-dialog iui-dialog-default' id='dialog-click'>
       <div class='iui-dialog-title-bar'>
         <div class='iui-dialog-title'>Title</div>
-        <button
+        <Button_
           aria-label='Close'
           type='button'
-          class='iui-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          variant='borderless'
+          size='small'
           onclick="toggleDialog('default-dialog')"
-          data-iui-shift='right'
+          shift='right'
         >
           <svg-close class='iui-button-icon' aria-hidden='true'></svg-close>
-        </button>
+        </Button_>
       </div>
       <div class='iui-dialog-content'>
         <p>
@@ -117,16 +114,12 @@ import Layout from './_layout.astro';
         </p>
       </div>
       <div class='iui-dialog-button-bar'>
-        <button
-          class='iui-button'
-          data-iui-variant='high-visibility'
-          onclick="toggleDialog('default-dialog')"
-        >
+        <Button_ variant='high-visibility' onclick="toggleDialog('default-dialog')">
           <span>Proceed</span>
-        </button>
-        <button class='iui-button' onclick="toggleDialog('default-dialog')">
+        </Button_>
+        <Button_ onclick="toggleDialog('default-dialog')">
           <span>Cancel</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -136,17 +129,16 @@ import Layout from './_layout.astro';
     <div class='iui-dialog iui-dialog-full-page'>
       <div class='iui-dialog-title-bar'>
         <div class='iui-dialog-title'>Title</div>
-        <button
+        <Button_
           aria-label='Close'
           type='button'
-          class='iui-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          variant='borderless'
+          size='small'
           onclick="toggleDialog('full-page-dialog')"
-          data-iui-shift='right'
+          shift='right'
         >
           <svg-close class='iui-button-icon' aria-hidden='true'></svg-close>
-        </button>
+        </Button_>
       </div>
       <div class='iui-dialog-content'>
         <p>
@@ -159,16 +151,12 @@ import Layout from './_layout.astro';
         </p>
       </div>
       <div class='iui-dialog-button-bar'>
-        <button
-          class='iui-button'
-          data-iui-variant='high-visibility'
-          onclick="toggleDialog('full-page-dialog')"
-        >
+        <Button_ variant='high-visibility' onclick="toggleDialog('full-page-dialog')">
           <span>Proceed</span>
-        </button>
-        <button class='iui-button' onclick="toggleDialog('full-page-dialog')">
+        </Button_>
+        <Button_ onclick="toggleDialog('full-page-dialog')">
           <span>Cancel</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -177,17 +165,16 @@ import Layout from './_layout.astro';
     <div class='iui-dialog iui-dialog-default iui-dialog-draggable'>
       <div class='iui-dialog-title-bar iui-dialog-title-bar-filled'>
         <div class='iui-dialog-title'>Title</div>
-        <button
+        <Button_
           aria-label='Close'
           type='button'
-          class='iui-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          variant='borderless'
+          size='small'
           onclick="toggleDialog('draggable-dialog')"
-          data-iui-shift='right'
+          shift='right'
         >
           <svg-close class='iui-button-icon' aria-hidden='true'></svg-close>
-        </button>
+        </Button_>
       </div>
       <div class='iui-dialog-content'>
         <p>
@@ -200,46 +187,40 @@ import Layout from './_layout.astro';
         </p>
       </div>
       <div class='iui-dialog-button-bar'>
-        <button
-          class='iui-button'
-          data-iui-variant='high-visibility'
-          onclick="toggleDialog('draggable-dialog')"
-        >
+        <Button_ variant='high-visibility' onclick="toggleDialog('draggable-dialog')">
           <span>Proceed</span>
-        </button>
-        <button class='iui-button' onclick="toggleDialog('draggable-dialog')">
+        </Button_>
+        <Button_ onclick="toggleDialog('draggable-dialog')">
           <span>Cancel</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
 
   <test-container-section>
     <div>
-      <button
+      <Button_
         aria-label='Open relative to container dialog'
         id='open-relative-to-container-dialog'
         type='button'
-        class='iui-button'
         onclick="toggleDialog('draggable-dialog-relative')"
       >
         Open relative to container dialog
-      </button>
+      </Button_>
       <div class='iui-dialog-wrapper' id='draggable-dialog-relative' data-iui-relative='true'>
         <div class='iui-dialog iui-dialog-default iui-dialog-draggable'>
           <div class='iui-dialog-title-bar iui-dialog-title-bar-filled'>
             <div class='iui-dialog-title'>Title</div>
-            <button
+            <Button_
               aria-label='Close'
               type='button'
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+              variant='borderless'
+              size='small'
               onclick="toggleDialog('draggable-dialog-relative')"
-              data-iui-shift='right'
+              shift='right'
             >
               <svg-close class='iui-button-icon' aria-hidden='true'></svg-close>
-            </button>
+            </Button_>
           </div>
           <div class='iui-dialog-content'>
             <p>
@@ -252,47 +233,41 @@ import Layout from './_layout.astro';
             </p>
           </div>
           <div class='iui-dialog-button-bar'>
-            <button
-              class='iui-button'
-              data-iui-variant='high-visibility'
-              onclick="toggleDialog('draggable-dialog-relative')"
-            >
+            <Button_ variant='high-visibility' onclick="toggleDialog('draggable-dialog-relative')">
               <span>Proceed</span>
-            </button>
-            <button class='iui-button' onclick="toggleDialog('draggable-dialog-relative')">
+            </Button_>
+            <Button_ onclick="toggleDialog('draggable-dialog-relative')">
               <span>Cancel</span>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>
     </div>
 
     <div>
-      <button
+      <Button_
         aria-label='Open with backdrop relative to container dialog'
         id='open-with-backdrop-relative-to-container-dialog'
         type='button'
-        class='iui-button'
         onclick="toggleDialog('relative-dialog-with-backdrop')"
       >
         Open with backdrop relative to container dialog
-      </button>
+      </Button_>
       <div class='iui-dialog-wrapper' id='relative-dialog-with-backdrop' data-iui-relative='true'>
         <div class='iui-backdrop'></div>
         <div class='iui-dialog iui-dialog-default'>
           <div class='iui-dialog-title-bar'>
             <div class='iui-dialog-title'>Title</div>
-            <button
+            <Button_
               aria-label='Close'
               type='button'
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+              variant='borderless'
+              size='small'
               onclick="toggleDialog('relative-dialog-with-backdrop')"
-              data-iui-shift='right'
+              shift='right'
             >
               <svg-close class='iui-button-icon' aria-hidden='true'></svg-close>
-            </button>
+            </Button_>
           </div>
           <div class='iui-dialog-content'>
             <p>
@@ -305,16 +280,15 @@ import Layout from './_layout.astro';
             </p>
           </div>
           <div class='iui-dialog-button-bar'>
-            <button
-              class='iui-button'
-              data-iui-variant='high-visibility'
+            <Button_
+              variant='high-visibility'
               onclick="toggleDialog('relative-dialog-with-backdrop')"
             >
               <span>Proceed</span>
-            </button>
-            <button class='iui-button' onclick="toggleDialog('relative-dialog-with-backdrop')">
+            </Button_>
+            <Button_ onclick="toggleDialog('relative-dialog-with-backdrop')">
               <span>Cancel</span>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>

--- a/apps/css-workshop/src/pages/file-upload.astro
+++ b/apps/css-workshop/src/pages/file-upload.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='File Upload'>
@@ -96,16 +97,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Name
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -115,16 +116,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell iui-sorted'>
                 Modified
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -134,15 +135,15 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Modified by
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button iui-active'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button iui-active'
+                    variant='borderless'
+                    size='small'
                     aria-label='Modify filter'
                     type='button'
                   >
                     <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -152,16 +153,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Size
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -169,15 +170,10 @@ import Layout from './_layout.astro';
                 </div>
               </div>
               <div class='iui-table-cell iui-slot'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  aria-label='Modify columns'
-                  type='button'
-                >
+                <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                   <svg-column-manager class='iui-button-icon' aria-hidden='true'
                   ></svg-column-manager>
-                </button>
+                </Button_>
               </div>
             </div>
           </div>
@@ -200,14 +196,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>7 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -227,14 +223,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>18 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -254,14 +250,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>1 GB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -283,16 +279,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Name
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -302,16 +298,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell iui-sorted'>
                 Modified
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -321,15 +317,15 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Modified by
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button iui-active'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button iui-active'
+                    variant='borderless'
+                    size='small'
                     aria-label='Modify filter'
                     type='button'
                   >
                     <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -339,16 +335,16 @@ import Layout from './_layout.astro';
               <div class='iui-table-cell'>
                 Size
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-down class='iui-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-down>
@@ -356,15 +352,10 @@ import Layout from './_layout.astro';
                 </div>
               </div>
               <div class='iui-table-cell iui-slot'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  aria-label='Modify columns'
-                  type='button'
-                >
+                <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                   <svg-column-manager class='iui-button-icon' aria-hidden='true'
                   ></svg-column-manager>
-                </button>
+                </Button_>
               </div>
             </div>
           </div>
@@ -387,14 +378,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>7 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -414,14 +405,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>18 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -441,14 +432,14 @@ import Layout from './_layout.astro';
             </div>
             <div class='iui-table-cell demo-right-align'>1 GB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>

--- a/apps/css-workshop/src/pages/header.astro
+++ b/apps/css-workshop/src/pages/header.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Header'>
@@ -129,21 +130,20 @@ import Layout from './_layout.astro';
         <div class='iui-page-header-center'>
           <label class='iui-input-flex-container demo-searchbar'>
             <input placeholder='Search within Version Gamma…' />
-            <button
-              class='iui-button demo-searchbar-button iui-input-flex-container-icon'
-              data-iui-variant='borderless'
+            <Button_
+              class='demo-searchbar-button iui-input-flex-container-icon'
+              variant='borderless'
               aria-label='Search'
             >
               <svg-search class='iui-button-icon' aria-hidden='true'></svg-search>
-            </button>
+            </Button_>
           </label>
         </div>
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
@@ -152,41 +152,28 @@ import Layout from './_layout.astro';
             <span class='iui-button-icon iui-notification-marker' aria-hidden='true'>
               <svg-notification></svg-notification>
             </span>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
 
@@ -258,9 +245,8 @@ import Layout from './_layout.astro';
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
@@ -272,41 +258,28 @@ import Layout from './_layout.astro';
             >
               <svg-notification></svg-notification>
             </span>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
     </section>
@@ -374,9 +347,8 @@ import Layout from './_layout.astro';
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
@@ -389,41 +361,28 @@ import Layout from './_layout.astro';
             >
               <svg-notification></svg-notification>
             </span>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2' size='small'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
 
@@ -480,9 +439,8 @@ import Layout from './_layout.astro';
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
@@ -494,41 +452,28 @@ import Layout from './_layout.astro';
             >
               <svg-notification></svg-notification>
             </span>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2' size='small'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
     </section>
@@ -650,49 +595,35 @@ import Layout from './_layout.astro';
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
           >
             <svg-notification class='iui-button-icon' aria-hidden='true'></svg-notification>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2' size='small'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
 
@@ -800,49 +731,35 @@ import Layout from './_layout.astro';
 
         <div class='iui-page-header-right'>
           <!-- Notifications -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='Notifications'
             aria-expanded='false'
           >
             <svg-notification class='iui-button-icon' aria-hidden='true'></svg-notification>
-          </button>
+          </Button_>
 
           <!-- Help -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='Help'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
             <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
             ></svg-help-circular-hollow>
-          </button>
+          </Button_>
 
           <!-- Profile -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            type='button'
-            aria-label='My account'
-            aria-expanded='false'
-          >
+          <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
             <x-avatar type='2'></x-avatar>
-          </button>
+          </Button_>
 
           <!-- More menu -->
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
+          <Button_
+            variant='borderless'
             type='button'
             aria-label='More options'
             aria-expanded='false'
           >
             <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-          </button>
+          </Button_>
         </div>
       </header>
     </section>
@@ -917,9 +834,8 @@ import Layout from './_layout.astro';
 
       <div class='iui-page-header-right'>
         <!-- Notifications -->
-        <button
-          class='iui-button'
-          data-iui-variant='borderless'
+        <Button_
+          variant='borderless'
           type='button'
           aria-label='Notifications'
           aria-expanded='false'
@@ -927,41 +843,23 @@ import Layout from './_layout.astro';
           <span class='iui-button-icon iui-notification-marker' data-iui-urgent='true'>
             <svg-notification></svg-notification>
           </span>
-        </button>
+        </Button_>
 
         <!-- Help -->
-        <button
-          class='iui-button'
-          data-iui-variant='borderless'
-          type='button'
-          aria-label='Help'
-          aria-expanded='false'
-        >
+        <Button_ variant='borderless' type='button' aria-label='Help' aria-expanded='false'>
           <svg-help-circular-hollow class='iui-button-icon' aria-hidden='true'
           ></svg-help-circular-hollow>
-        </button>
+        </Button_>
 
         <!-- Profile -->
-        <button
-          class='iui-button'
-          data-iui-variant='borderless'
-          type='button'
-          aria-label='My account'
-          aria-expanded='false'
-        >
+        <Button_ variant='borderless' type='button' aria-label='My account' aria-expanded='false'>
           <x-avatar type='2' showPlaceholder='true'></x-avatar>
-        </button>
+        </Button_>
 
         <!-- More menu -->
-        <button
-          class='iui-button'
-          data-iui-variant='borderless'
-          type='button'
-          aria-label='More options'
-          aria-expanded='false'
-        >
+        <Button_ variant='borderless' type='button' aria-label='More options' aria-expanded='false'>
           <svg-more-vertical class='iui-button-icon' aria-hidden='true'></svg-more-vertical>
-        </button>
+        </Button_>
       </div>
     </header>
 
@@ -969,33 +867,23 @@ import Layout from './_layout.astro';
       <!-- Rest of the tabs -->
       <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
         <div class='iui-top'>
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
-            data-iui-active='true'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
+            active='true'
             role='tab'
             aria-selected='true'
           >
             <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-          </button>
+          </Button_>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
-            role='tab'
-            aria-selected='false'
-          >
+          <Button_ class='iui-sidenav-button' size='large' role='tab' aria-selected='false'>
             <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-          </button>
+          </Button_>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
-            role='tab'
-            aria-selected='false'
-          >
+          <Button_ class='iui-sidenav-button' size='large' role='tab' aria-selected='false'>
             <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>

--- a/apps/css-workshop/src/pages/information-panel.astro
+++ b/apps/css-workshop/src/pages/information-panel.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Checkbox_ from '../components/Checkbox.astro';
 ---
 
@@ -126,41 +127,41 @@ import Checkbox_ from '../components/Checkbox.astro';
 
   <section id='demo-default'>
     <div class='demo-button-bar'>
-      <button class='iui-button' data-iui-variant='high-visibility'>
+      <Button_ variant='high-visibility'>
         <svg-add class='iui-button-icon' aria-hidden='true'></svg-add>
         <span>New</span>
-      </button>
+      </Button_>
 
       <span class='iui-button-group' style='margin-right: auto;'>
-        <button title='Download' class='iui-button'>
+        <Button_ title='Download'>
           <svg-download class='iui-button-icon' aria-hidden='true'></svg-download>
-        </button>
-        <button title='Move' class='iui-button'>
+        </Button_>
+        <Button_ title='Move'>
           <svg-arrow-right class='iui-button-icon' aria-hidden='true'></svg-arrow-right>
-        </button>
-        <button title='Delete' class='iui-button' disabled>
+        </Button_>
+        <Button_ title='Delete' disabled>
           <svg-delete class='iui-button-icon' aria-hidden='true'></svg-delete>
-        </button>
-        <button title='Rename' class='iui-button'>
+        </Button_>
+        <Button_ title='Rename'>
           <svg-rename class='iui-button-icon' aria-hidden='true'></svg-rename>
-        </button>
-        <button title='More options…' class='iui-button'>
+        </Button_>
+        <Button_ title='More options…'>
           <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-        </button>
+        </Button_>
       </span>
 
       <span class='iui-button-group'>
-        <button title='List view' class='iui-button' data-iui-active='true'>
+        <Button_ title='List view' active='true'>
           <svg-list class='iui-button-icon' aria-hidden='true'></svg-list>
-        </button>
-        <button title='Tile view' class='iui-button'>
+        </Button_>
+        <Button_ title='Tile view'>
           <svg-thumbnails class='iui-button-icon' aria-hidden='true'></svg-thumbnails>
-        </button>
+        </Button_>
       </span>
 
-      <button title='View info' class='iui-button' onclick='openInfoPanel(this)'>
+      <Button_ title='View info' onclick='openInfoPanel(this)'>
         <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-information-panel-wrapper'>
@@ -174,16 +175,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
                 Name
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -196,16 +197,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Modified
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -218,16 +219,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Modified by
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Modify filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -240,16 +241,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Size
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -257,15 +258,10 @@ import Checkbox_ from '../components/Checkbox.astro';
                 </div>
               </div>
               <div class='iui-table-cell iui-slot'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  aria-label='Modify columns'
-                  type='button'
-                >
+                <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                   <svg-column-manager class='iui-button-icon' aria-hidden='true'
                   ></svg-column-manager>
-                </button>
+                </Button_>
               </div>
             </div>
           </div>
@@ -280,25 +276,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
               </div>
-              alpha.dgn
+               alpha.dgn
             </div>
             <div class='iui-table-cell'>Jan 13, 2021 12:26 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>20 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -310,25 +306,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-audio aria-hidden='true'></svg-filetype-audio>
               </div>
-              beta.mp3
+               beta.mp3
             </div>
             <div class='iui-table-cell'>Aug 10, 2021 2:26 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='1'></x-avatar>
               </div>
-              Robin Mercer
+               Robin Mercer
             </div>
             <div class='iui-table-cell demo-right-align'>10 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -340,25 +336,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
               </div>
-              charlie.pdf
+               charlie.pdf
             </div>
             <div class='iui-table-cell'>Mar 1, 2020 8:00 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>10 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -370,25 +366,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-image aria-hidden='true'></svg-filetype-image>
               </div>
-              delta.jpg
+               delta.jpg
             </div>
             <div class='iui-table-cell'>Sep 7, 2015 11:30 AM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>963 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -400,25 +396,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
               </div>
-              echo.svg
+               echo.svg
             </div>
             <div class='iui-table-cell'>Apr 14, 2019 11:59 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>64 KB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -436,15 +432,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           </span>
 
           <div class='iui-information-header-actions'>
-            <button class='iui-button' data-iui-variant='borderless'>
+            <Button_ variant='borderless'>
               <svg-edit class='iui-button-icon' aria-hidden='true'></svg-edit>
-            </button><button
-              class='iui-button'
-              data-iui-variant='borderless'
-              onclick='openInfoPanel()'
-            >
+            </Button_><Button_ variant='borderless' onclick='openInfoPanel()'>
               <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -465,7 +457,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <span class='iui-input-label'> Owner</span>
             <div class='demo-avatar-with-label'>
               <x-avatar size='small' type='2'></x-avatar>
-              Terry Rivers
+               Terry Rivers
             </div>
 
             <span class='iui-input-label'> Last modified</span>
@@ -474,7 +466,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <span class='iui-input-label'> Modified by</span>
             <div class='demo-avatar-with-label'>
               <x-avatar size='small' type='1'></x-avatar>
-              Robin Mercer
+               Robin Mercer
             </div>
           </div>
 
@@ -526,16 +518,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
                 Name
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -548,16 +540,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Modified
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -570,16 +562,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Modified by
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Modify filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -592,16 +584,16 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell iui-actionable' tabindex='0'>
                 Size
                 <div class='iui-table-header-actions-container'>
-                  <button
-                    class='iui-button iui-table-filter-button'
-                    data-iui-variant='borderless'
-                    data-iui-size='small'
+                  <Button_
+                    class='iui-table-filter-button'
+                    variant='borderless'
+                    size='small'
                     aria-label='Apply filter'
                     type='button'
                   >
                     <svg-filter-hollow class='iui-button-icon' aria-hidden='true'
                     ></svg-filter-hollow>
-                  </button>
+                  </Button_>
                   <div class='iui-table-cell-end-icon'>
                     <svg-sort-up class='iui-button-icon iui-table-sort' aria-hidden='true'
                     ></svg-sort-up>
@@ -609,15 +601,10 @@ import Checkbox_ from '../components/Checkbox.astro';
                 </div>
               </div>
               <div class='iui-table-cell iui-slot'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  aria-label='Modify columns'
-                  type='button'
-                >
+                <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                   <svg-column-manager class='iui-button-icon' aria-hidden='true'
                   ></svg-column-manager>
-                </button>
+                </Button_>
               </div>
             </div>
           </div>
@@ -632,25 +619,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
               </div>
-              alpha.dgn
+               alpha.dgn
             </div>
             <div class='iui-table-cell'>Jan 13, 2021 12:26 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>20 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -662,25 +649,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-audio aria-hidden='true'></svg-filetype-audio>
               </div>
-              beta ipsum dolor sit amet.mp3
+               beta ipsum dolor sit amet.mp3
             </div>
             <div class='iui-table-cell'>Aug 10, 2021 2:26 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='1'></x-avatar>
               </div>
-              Robin Mercer
+               Robin Mercer
             </div>
             <div class='iui-table-cell demo-right-align'>10 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -692,25 +679,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
               </div>
-              charlie.pdf
+               charlie.pdf
             </div>
             <div class='iui-table-cell'>Mar 1, 2020 8:00 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>10 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -722,25 +709,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-image aria-hidden='true'></svg-filetype-image>
               </div>
-              delta.jpg
+               delta.jpg
             </div>
             <div class='iui-table-cell'>Sep 7, 2015 11:30 AM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>963 MB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -752,25 +739,25 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-cell-start-icon'>
                 <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
               </div>
-              echo.svg
+               echo.svg
             </div>
             <div class='iui-table-cell'>Apr 14, 2019 11:59 PM</div>
             <div class='iui-table-cell'>
               <div class='iui-table-cell-start-icon'>
                 <x-avatar size='small' type='2'></x-avatar>
               </div>
-              Terry Rivers
+               Terry Rivers
             </div>
             <div class='iui-table-cell demo-right-align'>64 KB</div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -788,11 +775,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           </span>
 
           <div class='iui-information-header-actions'>
-            <button class='iui-button' data-iui-variant='borderless' data-iui-active='true'>
+            <Button_ variant='borderless' active='true'>
               <svg-edit class='iui-button-icon' aria-hidden='true'></svg-edit>
-            </button><button class='iui-button' data-iui-variant='borderless'>
+            </Button_><Button_ variant='borderless'>
               <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -813,7 +800,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <span class='iui-input-label'> Owner</span>
             <div class='demo-avatar-with-label'>
               <x-avatar size='small' type='2'></x-avatar>
-              Terry Rivers
+               Terry Rivers
             </div>
 
             <span class='iui-input-label'> Last modified</span>
@@ -822,7 +809,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <span class='iui-input-label'> Modified by</span>
             <div class='demo-avatar-with-label'>
               <x-avatar size='small' type='1'></x-avatar>
-              Robin Mercer
+               Robin Mercer
             </div>
           </div>
 
@@ -904,20 +891,16 @@ import Checkbox_ from '../components/Checkbox.astro';
           </span>
 
           <div class='iui-information-header-actions'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              onclick='switchInfoPanelOrientation(this);'
-            >
+            <Button_ variant='borderless' onclick='switchInfoPanelOrientation(this);'>
               <!-- Docked right -->
               <span class='iui-button-icon' aria-hidden='true'>
                 <svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'>
                   <path d='m0 2v12h16v-12zm15 7h-14v-6h14z'></path>
                 </svg>
               </span>
-            </button><button class='iui-button' data-iui-variant='borderless'>
+            </Button_><Button_ variant='borderless'>
               <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-            </button>
+            </Button_>
           </div>
         </div>
 

--- a/apps/css-workshop/src/pages/input.astro
+++ b/apps/css-workshop/src/pages/input.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Input'>
@@ -196,13 +197,9 @@ import Layout from './_layout.astro';
           id='input-14'
           value='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
         />
-        <button
-          class='iui-button iui-input-flex-container-icon'
-          data-iui-variant='borderless'
-          aria-label='Clear'
-        >
+        <Button_ class='iui-input-flex-container-icon' variant='borderless' aria-label='Clear'>
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </div>
     </div>
   </section>
@@ -407,13 +404,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' id='search-2' value='test search input' />
-      <button
-        class='iui-button iui-input-flex-container-icon'
-        data-iui-variant='borderless'
-        data-iui-size='small'
-      >
+      <Button_ class='iui-input-flex-container-icon' variant='borderless' size='small'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox' data-iui-disabled='true'>
       <span
@@ -423,13 +416,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' id='search-3' disabled />
-      <button
-        class='iui-button iui-input-flex-container-icon'
-        data-iui-variant='borderless'
-        disabled
-      >
+      <Button_ class='iui-input-flex-container-icon' variant='borderless' disabled>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox' id='demo-search-hover'>
       <span
@@ -439,9 +428,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' />
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox' data-iui-status='positive'>
       <span
@@ -451,9 +440,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' />
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox' data-iui-status='warning'>
       <span
@@ -463,9 +452,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' />
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox' data-iui-status='negative'>
       <span
@@ -475,9 +464,9 @@ import Layout from './_layout.astro';
         <svg-search class='iui-button-icon' aria-hidden='true'></svg-search></span
       >
       <input placeholder='Placeholder…' type='text' />
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
     <div class='iui-input-flex-container iui-searchbox'>
       <span
@@ -490,15 +479,15 @@ import Layout from './_layout.astro';
       <p class='iui-text-block iui-text-muted' style='padding-right: var(--iui-size-s);'>0/3</p>
       <hr class='iui-divider' aria-orientation='vertical' />
 
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-chevron-down class='iui-button-icon' aria-hidden='true'></svg-chevron-down>
-      </button>
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-chevron-up class='iui-button-icon' aria-hidden='true'></svg-chevron-up>
-      </button>
-      <button class='iui-button iui-input-flex-container-icon' data-iui-variant='borderless'>
+      </Button_>
+      <Button_ class='iui-input-flex-container-icon' variant='borderless'>
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </div>
   </section>
 </Layout>

--- a/apps/css-workshop/src/pages/menu.astro
+++ b/apps/css-workshop/src/pages/menu.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Menu'>
@@ -759,11 +760,11 @@ import Layout from './_layout.astro';
 
   <h3>Default button</h3>
   <section id='demo-button'>
-    <button class='iui-button iui-button-dropdown' data-iui-size='small'>
+    <Button_ class='iui-button-dropdown' size='small'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Small dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'
@@ -819,11 +820,11 @@ import Layout from './_layout.astro';
     </ul>
     <br />
 
-    <button class='iui-button iui-button-dropdown'>
+    <Button_ class='iui-button-dropdown'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Default dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'
@@ -879,11 +880,11 @@ import Layout from './_layout.astro';
     </ul>
     <br />
 
-    <button class='iui-button iui-button-dropdown' data-iui-size='large'>
+    <Button_ class='iui-button-dropdown' size='large'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Large dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'
@@ -942,15 +943,11 @@ import Layout from './_layout.astro';
 
   <h3>Borderless button</h3>
   <section id='demo-borderless-button'>
-    <button
-      class='iui-button iui-button-dropdown'
-      data-iui-variant='borderless'
-      data-iui-size='small'
-    >
+    <Button_ class='iui-button-dropdown' variant='borderless' size='small'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Small dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'
@@ -1006,11 +1003,11 @@ import Layout from './_layout.astro';
     </ul>
     <br />
 
-    <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+    <Button_ class='iui-button-dropdown' variant='borderless'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Default dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'
@@ -1066,15 +1063,11 @@ import Layout from './_layout.astro';
     </ul>
     <br />
 
-    <button
-      class='iui-button iui-button-dropdown'
-      data-iui-variant='borderless'
-      data-iui-size='large'
-    >
+    <Button_ class='iui-button-dropdown' variant='borderless' size='large'>
       <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
       <span>Large dropdown</span>
       <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-    </button>
+    </Button_>
     <ul class='iui-menu' role='menu'>
       <li
         class='iui-list-item iui-large iui-active'

--- a/apps/css-workshop/src/pages/non-ideal-state.astro
+++ b/apps/css-workshop/src/pages/non-ideal-state.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Checkbox_ from '../components/Checkbox.astro';
 ---
 
@@ -180,15 +181,15 @@ import Checkbox_ from '../components/Checkbox.astro';
       <div class='iui-non-ideal-state-description'>
         You do not have permission to access this server.
         <br />
-        Unable to fulfill request.
+         Unable to fulfill request.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -346,15 +347,15 @@ import Checkbox_ from '../components/Checkbox.astro';
       <div class='iui-non-ideal-state-description'>
         You do not have permission to access this server.
         <br />
-        Unable to fulfill request.
+         Unable to fulfill request.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -531,15 +532,15 @@ import Checkbox_ from '../components/Checkbox.astro';
       <div class='iui-non-ideal-state-description'>
         We can't find the iModel that you are looking for or it does not exist.
         <br />
-        Visit the iModel HUB or contact our support team.
+         Visit the iModel HUB or contact our support team.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -682,12 +683,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         the iModel HUB.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -853,12 +854,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         HUB.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -1005,12 +1006,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         This service is being worked on. Please come back in a little bit or visit iModel HUB.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -1212,12 +1213,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         or contact our support team.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Visit iModel HUB</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span>Contact Us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -1262,12 +1263,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         Select a destination below to be redirected.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
-          <span>Web Portal</span></button
-        >
-        <button class='iui-button'>
+        <Button_ variant='high-visibility'>
+          <span>Web Portal</span>
+        </Button_>
+        <Button_>
           <span>ProjectWise Explorer</span>
-        </button>
+        </Button_>
       </div>
       <Checkbox_ checked style={{ flexDirection: 'row-reverse' }}>Remember my choice</Checkbox_>
     </div>
@@ -1320,9 +1321,9 @@ import Checkbox_ from '../components/Checkbox.astro';
             ></svg-caret-down-small>
           </div>
         </label>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Open</span>
-        </button>
+        </Button_>
       </div>
       <Checkbox_ checked style={{ flexDirection: 'row-reverse' }}>Remember my choice</Checkbox_>
     </div>
@@ -1470,12 +1471,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         Your session has been terminated due to inactivity. Sign back in to resume.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Sign in</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span class='iui-button-text'>Contact us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>
@@ -1490,12 +1491,12 @@ import Checkbox_ from '../components/Checkbox.astro';
         Your session has been terminated due to inactivity. Sign back in to resume.
       </div>
       <div class='iui-non-ideal-state-actions'>
-        <button class='iui-button' data-iui-variant='high-visibility'>
+        <Button_ variant='high-visibility'>
           <span>Sign in</span>
-        </button>
-        <button class='iui-button'>
+        </Button_>
+        <Button_>
           <span class='iui-button-text'>Contact us</span>
-        </button>
+        </Button_>
       </div>
     </div>
   </div>

--- a/apps/css-workshop/src/pages/select.astro
+++ b/apps/css-workshop/src/pages/select.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Select'>
@@ -526,9 +527,9 @@ import Layout from './_layout.astro';
       <svg-caret-down-small class='iui-svg-icon iui-end-icon' aria-hidden='true'
       ></svg-caret-down-small>
     </div>
-    <button class='iui-button'>
+    <Button_>
       <span>Add</span>
-    </button>
+    </Button_>
   </section>
 
   <hr />

--- a/apps/css-workshop/src/pages/side-navigation.astro
+++ b/apps/css-workshop/src/pages/side-navigation.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Side navigation'>
@@ -49,23 +50,23 @@ import Layout from './_layout.astro';
   <section id='demo-side-navigation'>
     <div class='iui-side-navigation iui-collapsed' id='demo-sidenav-container'>
       <!-- Expand arrow -->
-      <button
-        class='iui-button iui-sidenav-button iui-expand'
+      <Button_
+        class='iui-sidenav-button iui-expand'
         role='button'
         aria-label='Expand menu'
         onclick='togglePanelExpansion(this)'
         id='test-expand'
       >
         <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-      </button>
+      </Button_>
 
       <!-- Rest of the tabs -->
       <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
         <div class='iui-top'>
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
-            data-iui-active='true'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
+            active='true'
             role='tab'
             aria-selected='true'
             aria-label='Home'
@@ -74,12 +75,12 @@ import Layout from './_layout.astro';
           >
             <svg-home class='iui-button-icon' aria-hidden='true'></svg-home>
             <span>Home</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip'>Home</span>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
             role='tab'
             aria-selected='false'
             aria-label='Documents'
@@ -94,12 +95,12 @@ import Layout from './_layout.astro';
               <svg-document></svg-document>
             </span>
             <span>Documents</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip'>Documents</span>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
             role='tab'
             aria-selected='false'
             aria-label='Map'
@@ -110,12 +111,12 @@ import Layout from './_layout.astro';
               <svg-map></svg-map>
             </span>
             <span>Map</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip'>Map</span>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
             role='tab'
             aria-selected='false'
             aria-label='Archives'
@@ -125,12 +126,12 @@ import Layout from './_layout.astro';
           >
             <svg-archive class='iui-button-icon' aria-hidden='true'></svg-archive>
             <span>Archives</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip'>Archives</span>
 
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
             role='tab'
             aria-selected='false'
             aria-label='Calendar'
@@ -140,14 +141,14 @@ import Layout from './_layout.astro';
           >
             <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
             <span>Calendar</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip'>Calendar</span>
         </div>
 
         <div class='iui-bottom'>
-          <button
-            class='iui-button iui-sidenav-button'
-            data-iui-size='large'
+          <Button_
+            class='iui-sidenav-button'
+            size='large'
             role='tab'
             aria-selected='false'
             aria-label='Administration'
@@ -157,7 +158,7 @@ import Layout from './_layout.astro';
           >
             <svg-setup class='iui-button-icon' aria-hidden='true'></svg-setup>
             <span>Administration</span>
-          </button>
+          </Button_>
           <span class='iui-tooltip' style='margin-bottom: 10px;'>Administration</span>
         </div>
       </div>
@@ -173,10 +174,10 @@ import Layout from './_layout.astro';
         <!-- Rest of the tabs -->
         <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
           <div class='iui-top'>
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
-              data-iui-active='true'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
+              active='true'
               role='tab'
               aria-selected='false'
               aria-label='Home'
@@ -184,12 +185,12 @@ import Layout from './_layout.astro';
             >
               <svg-home class='iui-button-icon' aria-hidden='true'></svg-home>
               <span>Home</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Home</span>
 
-            <button
-              class='iui-button iui-sidenav-button iui-submenu-open'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button iui-submenu-open'
+              size='large'
               role='tab'
               aria-selected='true'
               aria-label='Documents'
@@ -197,12 +198,12 @@ import Layout from './_layout.astro';
             >
               <svg-document class='iui-button-icon' aria-hidden='true'></svg-document>
               <span>Documents</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Documents</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Map'
@@ -210,12 +211,12 @@ import Layout from './_layout.astro';
             >
               <svg-map class='iui-button-icon' aria-hidden='true'></svg-map>
               <span>Map</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Map</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Archives'
@@ -224,12 +225,12 @@ import Layout from './_layout.astro';
             >
               <svg-archive class='iui-button-icon' aria-hidden='true'></svg-archive>
               <span>Archives</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Archives</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Calendar'
@@ -237,14 +238,14 @@ import Layout from './_layout.astro';
             >
               <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
               <span>Calendar</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Calendar</span>
           </div>
 
           <div class='iui-bottom'>
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Administration'
@@ -252,36 +253,36 @@ import Layout from './_layout.astro';
             >
               <svg-setup class='iui-button-icon' aria-hidden='true'></svg-setup>
               <span>Administration</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip' style='margin-bottom: 10px;'>Administration</span>
           </div>
         </div>
 
         <!-- Expand arrow -->
-        <button
-          class='iui-button iui-sidenav-button iui-expand'
+        <Button_
+          class='iui-sidenav-button iui-expand'
           role='button'
           aria-label='Expand menu'
           onclick='togglePanelExpansion(this)'
           id='test-expand-2'
         >
           <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-side-navigation-submenu' style='width: 384px;'>
         <div class='iui-side-navigation-submenu-content'>
           <div class='iui-side-navigation-submenu-header'>
             <div class='iui-side-navigation-submenu-header-label'>
-              <button class='iui-button' data-iui-variant='borderless'>
+              <Button_ variant='borderless'>
                 <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-              </button>
+              </Button_>
               <span>Documents with a long label to test for truncation</span>
             </div>
             <div class='iui-side-navigation-submenu-header-actions'>
-              <button class='iui-button' data-iui-variant='borderless'>
+              <Button_ variant='borderless'>
                 <svg-settings class='iui-button-icon' aria-hidden='true'></svg-settings>
-              </button>
+              </Button_>
             </div>
           </div>
 
@@ -329,9 +330,9 @@ import Layout from './_layout.astro';
         <!-- Rest of the tabs -->
         <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
           <div class='iui-top'>
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Home'
@@ -339,13 +340,13 @@ import Layout from './_layout.astro';
             >
               <svg-home class='iui-button-icon' aria-hidden='true'></svg-home>
               <span>Home</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Home</span>
 
-            <button
-              class='iui-button iui-sidenav-button iui-submenu-open'
-              data-iui-active='true'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button iui-submenu-open'
+              active='true'
+              size='large'
               role='tab'
               aria-selected='true'
               aria-label='Documents'
@@ -353,12 +354,12 @@ import Layout from './_layout.astro';
             >
               <svg-document class='iui-button-icon' aria-hidden='true'></svg-document>
               <span>Documents</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Documents</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Map'
@@ -366,12 +367,12 @@ import Layout from './_layout.astro';
             >
               <svg-map class='iui-button-icon' aria-hidden='true'></svg-map>
               <span>Map</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Map</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Archives'
@@ -380,12 +381,12 @@ import Layout from './_layout.astro';
             >
               <svg-archive class='iui-button-icon' aria-hidden='true'></svg-archive>
               <span>Archives</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Archives</span>
 
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Calendar'
@@ -393,14 +394,14 @@ import Layout from './_layout.astro';
             >
               <svg-calendar class='iui-button-icon' aria-hidden='true'></svg-calendar>
               <span>Calendar</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip'>Calendar</span>
           </div>
 
           <div class='iui-bottom'>
-            <button
-              class='iui-button iui-sidenav-button'
-              data-iui-size='large'
+            <Button_
+              class='iui-sidenav-button'
+              size='large'
               role='tab'
               aria-selected='false'
               aria-label='Administration'
@@ -408,36 +409,36 @@ import Layout from './_layout.astro';
             >
               <svg-setup class='iui-button-icon' aria-hidden='true'></svg-setup>
               <span>Administration</span>
-            </button>
+            </Button_>
             <span class='iui-tooltip' style='margin-bottom: 10px;'>Administration</span>
           </div>
         </div>
 
         <!-- Expand arrow -->
-        <button
-          class='iui-button iui-sidenav-button iui-expand'
+        <Button_
+          class='iui-sidenav-button iui-expand'
           role='button'
           aria-label='Expand menu'
           onclick='togglePanelExpansion(this)'
           id='test-expand-2'
         >
           <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-side-navigation-submenu' style='width: 384px;'>
         <div class='iui-side-navigation-submenu-content'>
           <div class='iui-side-navigation-submenu-header'>
             <div class='iui-side-navigation-submenu-header-label'>
-              <button class='iui-button' data-iui-variant='borderless'>
+              <Button_ variant='borderless'>
                 <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-              </button>
+              </Button_>
               <span>Documents with a long label to test for truncation</span>
             </div>
             <div class='iui-side-navigation-submenu-header-actions'>
-              <button class='iui-button' data-iui-variant='borderless'>
+              <Button_ variant='borderless'>
                 <svg-settings class='iui-button-icon' aria-hidden='true'></svg-settings>
-              </button>
+              </Button_>
             </div>
           </div>
 

--- a/apps/css-workshop/src/pages/surface.astro
+++ b/apps/css-workshop/src/pages/surface.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Surface'>
@@ -79,9 +80,9 @@ import Layout from './_layout.astro';
       <div class='iui-surface-header'>
         <div class='demo-flex-component'>
           <h2 class='iui-text-subheading'>Default surface</h2>
-          <button class='iui-button' data-iui-variant='borderless'>
+          <Button_ variant='borderless'>
             <svg-settings class='iui-button-icon' aria-hidden='true'></svg-settings>
-          </button>
+          </Button_>
         </div>
       </div>
       <div class='iui-surface-body' data-iui-padded='true'>
@@ -116,9 +117,9 @@ import Layout from './_layout.astro';
         </p>
       </div>
       <hr class='iui-divider' />
-      <button class='iui-button' data-iui-variant='borderless' style='align-self: stretch;'>
+      <Button_ variant='borderless' style='align-self: stretch;'>
         <span>View all</span>
-      </button>
+      </Button_>
     </div>
 
     <div class='iui-surface' data-iui-layout='true'>

--- a/apps/css-workshop/src/pages/table.astro
+++ b/apps/css-workshop/src/pages/table.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Checkbox_ from '../components/Checkbox.astro';
 ---
 
@@ -145,15 +146,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -174,15 +175,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Modified
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -203,16 +204,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  data-iui-active='true'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
+                  active='true'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -233,15 +234,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Size
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -249,14 +250,9 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-reorder-bar'></div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -271,25 +267,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
+             A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
           </div>
           <div class='iui-table-cell' title='Jul 16, 2020 9:50am'>Last week</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>252 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -301,25 +297,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 2
+             Folder name 2
           </div>
           <div class='iui-table-cell' title='Jul 23, 2020 10:21am'>Yesterday</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>1.2 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -331,25 +327,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 3
+             Folder name 3
           </div>
           <div class='iui-table-cell' title='Jul 19, 2020 4:20pm'>5 days ago</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>36 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -361,7 +357,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
             </div>
-            alpha.dgn
+             alpha.dgn
             <div class='iui-table-cell-end-icon'>
               <div
                 class='iui-progress-indicator-radial'
@@ -376,18 +372,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>Calculating&mldr;</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -399,25 +395,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-audio aria-hidden='true'></svg-filetype-audio>
             </div>
-            beta.mp3
+             beta.mp3
           </div>
           <div class='iui-table-cell' title='Jul 24, 2020 2:12pm'>Just now</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>15 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -429,7 +425,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
             </div>
-            charlie.pdf
+             charlie.pdf
             <div class='iui-table-cell-end-icon'>
               <svg-status-success aria-hidden='true'></svg-status-success>
             </div>
@@ -441,18 +437,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>9 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -464,7 +460,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-image aria-hidden='true'></svg-filetype-image>
             </div>
-            delta.jpg
+             delta.jpg
             <div class='iui-table-cell-end-icon'>
               <svg-status-warning aria-hidden='true'></svg-status-warning>
             </div>
@@ -476,18 +472,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>963 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -499,7 +495,8 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+             MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+
 
             <div class='iui-table-cell-end-icon'>
               <svg-status-error aria-hidden='true'></svg-status-error>
@@ -512,18 +509,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>64 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -535,25 +532,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-video aria-hidden='true'></svg-filetype-video>
             </div>
-            unavailable.mov
+             unavailable.mov
           </div>
           <div class='iui-table-cell' aria-disabled='true'>A few minutes ago</div>
           <div class='iui-table-cell' aria-disabled='true'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>
@@ -571,15 +568,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
               Name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -591,15 +588,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -611,16 +608,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  data-iui-active='true'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
+                  active='true'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -632,30 +629,24 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Size
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
               </div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                data-iui-size='small'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' size='small' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -670,26 +661,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
+             A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
           </div>
           <div class='iui-table-cell' title='Jul 16, 2020 9:50am'>Last week</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>252 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -701,26 +692,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 2
+             Folder name 2
           </div>
           <div class='iui-table-cell' title='Jul 23, 2020 10:21am'>Yesterday</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>1.2 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -732,26 +723,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 3
+             Folder name 3
           </div>
           <div class='iui-table-cell' title='Jul 19, 2020 4:20pm'>5 days ago</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>36 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -763,7 +754,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
             </div>
-            alpha.dgn
+             alpha.dgn
             <div class='iui-table-cell-end-icon'>
               <div
                 class='iui-progress-indicator-radial'
@@ -778,19 +769,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>Calculating&mldr;</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -802,26 +793,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-audio aria-hidden='true'></svg-filetype-audio>
             </div>
-            beta.mp3
+             beta.mp3
           </div>
           <div class='iui-table-cell' title='Jul 24, 2020 2:12pm'>Just now</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>15 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -833,7 +824,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
             </div>
-            charlie.pdf
+             charlie.pdf
             <div class='iui-table-cell-end-icon'>
               <svg-status-success aria-hidden='true'></svg-status-success>
             </div>
@@ -845,19 +836,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>9 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -869,7 +860,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-image aria-hidden='true'></svg-filetype-image>
             </div>
-            delta.jpg
+             delta.jpg
             <div class='iui-table-cell-end-icon'>
               <svg-status-warning aria-hidden='true'></svg-status-warning>
             </div>
@@ -881,19 +872,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>963 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -905,7 +896,8 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+             MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+
 
             <div class='iui-table-cell-end-icon'>
               <svg-status-error aria-hidden='true'></svg-status-error>
@@ -918,19 +910,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>64 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -942,26 +934,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-video aria-hidden='true'></svg-filetype-video>
             </div>
-            unavailable.mov
+             unavailable.mov
           </div>
           <div class='iui-table-cell' aria-disabled='true'>A few minutes ago</div>
           <div class='iui-table-cell' aria-disabled='true'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>
@@ -979,15 +971,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
               Name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -999,15 +991,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1019,16 +1011,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  data-iui-active='true'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
+                  active='true'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1040,30 +1032,24 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Size
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
               </div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                data-iui-size='small'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' size='small' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -1078,26 +1064,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
+             A Folder With A Really Long Name That Will Be Split Into Multiple Lines After So Long
           </div>
           <div class='iui-table-cell' title='Jul 16, 2020 9:50am'>Last week</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>252 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1109,26 +1095,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 2
+             Folder name 2
           </div>
           <div class='iui-table-cell' title='Jul 23, 2020 10:21am'>Yesterday</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>1.2 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1140,26 +1126,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-folder aria-hidden='true'></svg-folder>
             </div>
-            Folder name 3
+             Folder name 3
           </div>
           <div class='iui-table-cell' title='Jul 19, 2020 4:20pm'>5 days ago</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>36 GB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1171,7 +1157,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
             </div>
-            alpha.dgn
+             alpha.dgn
             <div class='iui-table-cell-end-icon'>
               <div
                 class='iui-progress-indicator-radial'
@@ -1186,19 +1172,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>Calculating&mldr;</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1210,26 +1196,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-audio aria-hidden='true'></svg-filetype-audio>
             </div>
-            beta.mp3
+             beta.mp3
           </div>
           <div class='iui-table-cell' title='Jul 24, 2020 2:12pm'>Just now</div>
           <div class='iui-table-cell'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='1'></x-avatar>
             </div>
-            Robin Mercer
+             Robin Mercer
           </div>
           <div class='iui-table-cell demo-right-align'>15 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1241,7 +1227,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
             </div>
-            charlie.pdf
+             charlie.pdf
             <div class='iui-table-cell-end-icon'>
               <svg-status-success aria-hidden='true'></svg-status-success>
             </div>
@@ -1253,19 +1239,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>9 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1277,7 +1263,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-image aria-hidden='true'></svg-filetype-image>
             </div>
-            delta.jpg
+             delta.jpg
             <div class='iui-table-cell-end-icon'>
               <svg-status-warning aria-hidden='true'></svg-status-warning>
             </div>
@@ -1289,19 +1275,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>963 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1313,7 +1299,8 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+             MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+
 
             <div class='iui-table-cell-end-icon'>
               <svg-status-error aria-hidden='true'></svg-status-error>
@@ -1326,19 +1313,19 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>64 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1350,26 +1337,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-video aria-hidden='true'></svg-filetype-video>
             </div>
-            unavailable.mov
+             unavailable.mov
           </div>
           <div class='iui-table-cell' aria-disabled='true'>A few minutes ago</div>
           <div class='iui-table-cell' aria-disabled='true'>
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
-              data-iui-size='small'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
+              size='small'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>
@@ -1398,15 +1385,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1427,15 +1414,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Modified
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1456,16 +1443,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  data-iui-active='true'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
+                  active='true'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter class='iui-button-icon' aria-hidden='true'></svg-filter>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1486,15 +1473,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Size
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1502,14 +1489,9 @@ import Checkbox_ from '../components/Checkbox.astro';
               <div class='iui-table-reorder-bar'></div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -1524,7 +1506,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-imodel aria-hidden='true'></svg-filetype-imodel>
             </div>
-            alpha.dgn
+             alpha.dgn
             <div class='iui-table-cell-end-icon'>
               <div
                 class='iui-progress-indicator-radial'
@@ -1539,18 +1521,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>Calculating&mldr;</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1562,7 +1544,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-pdf aria-hidden='true'></svg-filetype-pdf>
             </div>
-            charlie.pdf
+             charlie.pdf
             <div class='iui-table-cell-end-icon'>
               <svg-status-success aria-hidden='true'></svg-status-success>
             </div>
@@ -1574,18 +1556,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>9 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1597,7 +1579,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-image aria-hidden='true'></svg-filetype-image>
             </div>
-            delta.jpg
+             delta.jpg
             <div class='iui-table-cell-end-icon'>
               <svg-status-warning aria-hidden='true'></svg-status-warning>
             </div>
@@ -1609,18 +1591,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>963 MB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1632,7 +1614,8 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+             MyFileWithAReallyLongNameThatWillBeSplitIntoMultipleLinesAfterSoLong_FinalVersion_V2.svg
+
 
             <div class='iui-table-cell-end-icon'>
               <svg-status-error aria-hidden='true'></svg-status-error>
@@ -1645,18 +1628,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align'>64 KB</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1668,7 +1651,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            disabled-positive-row.svg
+             disabled-positive-row.svg
             <div class='iui-table-cell-end-icon'>
               <svg-status-success aria-hidden='true'></svg-status-success>
             </div>
@@ -1680,18 +1663,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1703,7 +1686,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            disabled-warning-row.svg
+             disabled-warning-row.svg
             <div class='iui-table-cell-end-icon'>
               <svg-status-warning aria-hidden='true'></svg-status-warning>
             </div>
@@ -1715,18 +1698,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1738,7 +1721,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-vector aria-hidden='true'></svg-filetype-vector>
             </div>
-            disabled-negative-row.svg
+             disabled-negative-row.svg
             <div class='iui-table-cell-end-icon'>
               <svg-status-error aria-hidden='true'></svg-status-error>
             </div>
@@ -1750,18 +1733,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -1773,7 +1756,7 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <svg-filetype-video aria-hidden='true'></svg-filetype-video>
             </div>
-            unavailable.mov
+             unavailable.mov
             <div class='iui-table-cell-end-icon'>
               <svg-camera aria-hidden='true'></svg-camera>
             </div>
@@ -1783,18 +1766,18 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell-start-icon'>
               <x-avatar size='small' type='2'></x-avatar>
             </div>
-            Terry Rivers
+             Terry Rivers
           </div>
           <div class='iui-table-cell demo-right-align' aria-disabled='true'>1.9 GB</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
       </div>
@@ -1825,15 +1808,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Product
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1845,15 +1828,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Price
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1862,15 +1845,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Quantity
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1879,15 +1862,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Rating
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1896,15 +1879,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Delivery time
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -1914,14 +1897,9 @@ import Checkbox_ from '../components/Checkbox.astro';
               class='iui-table-cell iui-slot iui-table-cell-sticky'
               style='--iui-table-sticky-right: 0;'
             >
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
               <div class='iui-table-cell-shadow-left'></div>
             </div>
           </div>
@@ -1954,14 +1932,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -1988,14 +1966,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2022,14 +2000,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2056,14 +2034,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2090,14 +2068,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2124,14 +2102,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2158,14 +2136,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2192,14 +2170,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2226,14 +2204,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2260,14 +2238,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2277,15 +2255,9 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-left'></div>
 
         <div class='iui-center'>
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            aria-label='Previous page'
-            type='button'
-            disabled
-          >
+          <Button_ variant='borderless' aria-label='Previous page' type='button' disabled>
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span class='iui-table-paginator-pages-group'>
             <button
@@ -2328,22 +2300,17 @@ import Checkbox_ from '../components/Checkbox.astro';
             </button>
           </span>
 
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            aria-label='Next page'
-            type='button'
-          >
+          <Button_ variant='borderless' aria-label='Next page' type='button'>
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-right'>
           <span class='iui-table-paginator-page-size-label'>Rows per page</span>
-          <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+          <Button_ class='iui-button-dropdown' variant='borderless'>
             <span>1-10 of 300</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -2366,15 +2333,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             >
               Product
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2386,15 +2353,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Price
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2403,15 +2370,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Quantity
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2420,15 +2387,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Rating
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2437,15 +2404,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Delivery time
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2455,14 +2422,14 @@ import Checkbox_ from '../components/Checkbox.astro';
               class='iui-table-cell iui-slot iui-table-cell-sticky'
               style='--iui-table-sticky-right: 0;'
             >
-              <button
-                class='iui-button iui-table-more-options'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-more-options'
+                variant='borderless'
                 aria-label='More options'
                 type='button'
               >
                 <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-              </button>
+              </Button_>
               <div class='iui-table-cell-shadow-left'></div>
             </div>
           </div>
@@ -2492,14 +2459,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2526,14 +2493,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             class='iui-table-cell iui-slot iui-table-cell-sticky'
             style='--iui-table-sticky-right: 0;'
           >
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
             <div class='iui-table-cell-shadow-left'></div>
           </div>
         </div>
@@ -2543,15 +2510,9 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-left'></div>
 
         <div class='iui-center'>
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            aria-label='Previous page'
-            type='button'
-            disabled
-          >
+          <Button_ variant='borderless' aria-label='Previous page' type='button' disabled>
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span class='iui-table-paginator-pages-group'>
             <button class='iui-table-paginator-page-button' aria-label='Page 1' type='button'>
@@ -2594,22 +2555,17 @@ import Checkbox_ from '../components/Checkbox.astro';
             </button>
           </span>
 
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            aria-label='Next page'
-            type='button'
-          >
+          <Button_ variant='borderless' aria-label='Next page' type='button'>
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-right'>
           <span class='iui-table-paginator-page-size-label'>Rows per page</span>
-          <button class='iui-button iui-button-dropdown' data-iui-variant='borderless'>
+          <Button_ class='iui-button-dropdown' variant='borderless'>
             <span>290-292 of 292</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -2623,15 +2579,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted'>
               Product
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2643,15 +2599,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Price
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2717,15 +2673,9 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-left'></div>
 
         <div class='iui-center'>
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-            aria-label='Previous page'
-            type='button'
-          >
+          <Button_ variant='borderless' size='small' aria-label='Previous page' type='button'>
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span class='iui-table-paginator-pages-group'>
             <button
@@ -2794,27 +2744,17 @@ import Checkbox_ from '../components/Checkbox.astro';
             </button>
           </span>
 
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-            aria-label='Next page'
-            type='button'
-          >
+          <Button_ variant='borderless' size='small' aria-label='Next page' type='button'>
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-right'>
           <span class='iui-table-paginator-page-size-label'>Rows per page</span>
-          <button
-            class='iui-button iui-button-dropdown'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ class='iui-button-dropdown' variant='borderless' size='small'>
             <span>150-160 of 300</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -2828,15 +2768,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted'>
               Product
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2848,15 +2788,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               Price
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -2922,16 +2862,15 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-left'></div>
 
         <div class='iui-center'>
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+          <Button_
+            variant='borderless'
+            size='small'
             aria-label='Previous page'
             type='button'
             disabled
           >
             <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-          </button>
+          </Button_>
 
           <span class='iui-table-paginator-pages-group'>
             <button
@@ -3003,27 +2942,17 @@ import Checkbox_ from '../components/Checkbox.astro';
             </div>
           </span>
 
-          <button
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-            aria-label='Next page'
-            type='button'
-          >
+          <Button_ variant='borderless' size='small' aria-label='Next page' type='button'>
             <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-right'>
           <span class='iui-table-paginator-page-size-label'>Rows per page</span>
-          <button
-            class='iui-button iui-button-dropdown'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ class='iui-button-dropdown' variant='borderless' size='small'>
             <span>1-10&mldr;</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -3044,15 +2973,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted'>
               Project name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3064,29 +2993,24 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable'>
               File count
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
               </div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -3098,26 +3022,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>Alpha</div>
           <div class='iui-table-cell'>$5.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
 
@@ -3126,26 +3050,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>Beta</div>
           <div class='iui-table-cell'>$12.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content'>
@@ -3157,26 +3081,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' checked />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>Charlie</div>
           <div class='iui-table-cell'>$2.50</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content'>
@@ -3188,14 +3112,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ disabled basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>
             Delta
@@ -3210,14 +3134,14 @@ import Checkbox_ from '../components/Checkbox.astro';
           </div>
           <div class='iui-table-cell'>$1.99</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content iui-loading'>
@@ -3229,26 +3153,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>Echo</div>
           <div class='iui-table-cell'>$12.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content'>
@@ -3260,14 +3184,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>
             Foxtrot
@@ -3281,14 +3205,14 @@ import Checkbox_ from '../components/Checkbox.astro';
           </div>
           <div class='iui-table-cell'>$12.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content'>
@@ -3300,14 +3224,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>
             Foxtrot
@@ -3321,14 +3245,14 @@ import Checkbox_ from '../components/Checkbox.astro';
           </div>
           <div class='iui-table-cell'>$12.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content'>
@@ -3340,14 +3264,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' />
           </div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column'>
             Foxtrot
@@ -3359,14 +3283,14 @@ import Checkbox_ from '../components/Checkbox.astro';
           </div>
           <div class='iui-table-cell'>$12.00</div>
           <div class='iui-table-cell iui-slot'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content' aria-disabled='true'>
@@ -3378,26 +3302,26 @@ import Checkbox_ from '../components/Checkbox.astro';
             <Checkbox_ basic id='select-all-checkboxes' disabled />
           </div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-row-expander'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-row-expander'
+              variant='borderless'
               type='button'
               aria-label='Expand row'
             >
               <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
           </div>
           <div class='iui-table-cell iui-main-column' aria-disabled='true'>Golf</div>
           <div class='iui-table-cell' aria-disabled='true'>$18.99</div>
           <div class='iui-table-cell iui-slot' aria-disabled='true'>
-            <button
-              class='iui-button iui-table-more-options'
-              data-iui-variant='borderless'
+            <Button_
+              class='iui-table-more-options'
+              variant='borderless'
               aria-label='More options'
               type='button'
             >
               <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-            </button>
+            </Button_>
           </div>
         </div>
         <div class='iui-table-row iui-table-expanded-content' aria-disabled='true'>
@@ -3421,15 +3345,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
               Name
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3440,14 +3364,14 @@ import Checkbox_ from '../components/Checkbox.astro';
             </div>
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified
-              <button
-                class='iui-button iui-table-filter-button'
-                data-iui-variant='borderless'
+              <Button_
+                class='iui-table-filter-button'
+                variant='borderless'
                 aria-label='Apply filter'
                 type='button'
               >
                 <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-              </button>
+              </Button_>
               <div class='iui-table-cell-end-icon'>
                 <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
               </div>
@@ -3458,15 +3382,15 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3478,29 +3402,24 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Size
               <div class='iui-table-header-actions-container'>
-                <button
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                <Button_
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
               </div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>
@@ -3530,11 +3449,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable iui-sorted' tabindex='0'>
               Name
               <div class='iui-table-header-actions-container'>
-                <button
+                <Button_
                   disabled
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
@@ -3542,7 +3461,7 @@ import Checkbox_ from '../components/Checkbox.astro';
                   <div class='iui-table-resizer'>
                     <div class='iui-table-resizer-bar'></div>
                   </div>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3554,16 +3473,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified
               <div class='iui-table-header-actions-container'>
-                <button
+                <Button_
                   disabled
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3575,16 +3494,16 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Modified by
               <div class='iui-table-header-actions-container'>
-                <button
+                <Button_
                   disabled
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Modify filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
@@ -3596,30 +3515,25 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-table-cell iui-actionable' tabindex='0'>
               Size
               <div class='iui-table-header-actions-container'>
-                <button
+                <Button_
                   disabled
-                  class='iui-button iui-table-filter-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
+                  class='iui-table-filter-button'
+                  variant='borderless'
+                  size='small'
                   aria-label='Apply filter'
                   type='button'
                 >
                   <svg-filter-hollow class='iui-button-icon' aria-hidden='true'></svg-filter-hollow>
-                </button>
+                </Button_>
                 <div class='iui-table-cell-end-icon'>
                   <svg-sort-up class='iui-table-sort' aria-hidden='true'></svg-sort-up>
                 </div>
               </div>
             </div>
             <div class='iui-table-cell iui-slot'>
-              <button
-                class='iui-button'
-                data-iui-variant='borderless'
-                aria-label='Modify columns'
-                type='button'
-              >
+              <Button_ variant='borderless' aria-label='Modify columns' type='button'>
                 <svg-column-manager class='iui-button-icon' aria-hidden='true'></svg-column-manager>
-              </button>
+              </Button_>
             </div>
           </div>
         </div>

--- a/apps/css-workshop/src/pages/tabs.astro
+++ b/apps/css-workshop/src/pages/tabs.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Tabs'>
@@ -63,17 +64,17 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        <Button_ variant='borderless'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown' data-iui-size='small'>
+          <Button_ class='iui-button-dropdown' size='small'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -135,17 +136,17 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        <Button_ variant='borderless'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown'>
+          <Button_ class='iui-button-dropdown'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -209,20 +210,20 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+        <Button_ variant='borderless' size='large'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -290,20 +291,20 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+        <Button_ variant='borderless' size='large'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -367,17 +368,17 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        <Button_ variant='borderless'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown'>
+          <Button_ class='iui-button-dropdown'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -439,20 +440,20 @@ import Layout from './_layout.astro';
         >
           <span class='iui-tab-label'>None</span>
         </button>
-        <button class='iui-button' data-iui-variant='borderless' data-iui-size='large'>
+        <Button_ variant='borderless' size='large'>
           <svg-add-circular class='iui-button-icon' aria-hidden='true'></svg-add-circular>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -570,10 +571,10 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown' data-iui-size='small'>
+          <Button_ class='iui-button-dropdown' size='small'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -657,10 +658,10 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown'>
+          <Button_ class='iui-button-dropdown'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -729,10 +730,10 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown' data-iui-size='small'>
+          <Button_ class='iui-button-dropdown' size='small'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -802,10 +803,10 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown'>
+          <Button_ class='iui-button-dropdown'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -877,13 +878,13 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -960,13 +961,13 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -1034,10 +1035,10 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button iui-button-dropdown'>
+          <Button_ class='iui-button-dropdown'>
             <span>Actions</span>
             <svg-caret-down-small class='iui-button-icon' aria-hidden='true'></svg-caret-down-small>
-          </button>
+          </Button_>
         </div>
       </div>
 
@@ -1107,13 +1108,13 @@ import Layout from './_layout.astro';
 
       <div class='iui-tabs-actions-wrapper'>
         <div class='iui-tabs-actions'>
-          <button class='iui-button'>
+          <Button_>
             <span>Trial</span>
-          </button>
+          </Button_>
 
-          <button class='iui-button' data-iui-variant='high-visibility'>
+          <Button_ variant='high-visibility'>
             <span>Purchase</span>
-          </button>
+          </Button_>
         </div>
       </div>
 

--- a/apps/css-workshop/src/pages/tag.astro
+++ b/apps/css-workshop/src/pages/tag.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Tag'>
@@ -21,31 +22,31 @@ import Layout from './_layout.astro';
   <section id='demo-default'>
     <span class='iui-tag' id='test-tag-1'>
       <span class='iui-tag-label' title='Tag'>Tag</span>
-      <button
-        class='iui-button iui-tag-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
+      <Button_
+        class='iui-tag-button'
+        variant='borderless'
+        size='small'
         aria-label='Delete tag'
         type='button'
       >
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </span>
 
     <br />
 
     <span class='iui-tag' style='max-width: 125px;'>
       <span class='iui-tag-label' title='Overflowing tag'>Overflowing tag</span>
-      <button
-        class='iui-button iui-tag-button'
-        data-iui-variant='borderless'
-        data-iui-size='small'
+      <Button_
+        class='iui-tag-button'
+        variant='borderless'
+        size='small'
         aria-label='Delete overflowing tag'
         type='button'
         id='test-tag-2'
       >
         <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-      </button>
+      </Button_>
     </span>
 
     <br />
@@ -61,126 +62,126 @@ import Layout from './_layout.astro';
   <section id='demo-default-container'>
     <div class='iui-tag-container iui-visible' aria-label='My tags'>
       <span class='iui-tag'>
-        <span class='iui-tag-label' title='Tag'>Tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Tag'>Tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Long tag'>Long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Long tag'>Long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Very long tag'>Very long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Very long tag'>Very long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Tag'>Tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Tag'>Tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Long tag'>Long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Long tag'>Long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
-        <span class='iui-tag-label' title='Very long tag'>Very long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <span class='iui-tag-label' title='Very long tag'>Very long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'
-        ><span class='iui-tag-label' title='Very very long tag'>Very very long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        ><span class='iui-tag-label' title='Very very long tag'>Very very long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'
-        ><span class='iui-tag-label' title='Tag'>Tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        ><span class='iui-tag-label' title='Tag'>Tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'
-        ><span class='iui-tag-label' title='Long tag'>Long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        ><span class='iui-tag-label' title='Long tag'>Long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'
-        ><span class='iui-tag-label' title='Very long tag'>Very long tag</span><button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        ><span class='iui-tag-label' title='Very long tag'>Very long tag</span><Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'
         ><span class='iui-tag-label' title='Very very long tag'>Very very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span>
     </div>
 
@@ -189,48 +190,48 @@ import Layout from './_layout.astro';
     <div class='iui-tag-container iui-visible iui-truncate' aria-label='My tags'>
       <span class='iui-tag'>
         <span class='iui-tag-label' title='Tag'>Tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Long tag'>Long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very long tag'>Very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span>
     </div>
 
@@ -239,136 +240,136 @@ import Layout from './_layout.astro';
     <div class='iui-tag-container iui-visible iui-scroll' aria-label='My tags'>
       <span class='iui-tag'>
         <span class='iui-tag-label' title='Tag'>Tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Long tag'>Long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very long tag'>Very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Tag'>Tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Long tag'>Long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very long tag'>Very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Tag'>Tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Long tag'>Long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very long tag'>Very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span><span class='iui-tag'>
         <span class='iui-tag-label' title='Very very long tag'>Very very long tag</span>
-        <button
-          class='iui-button iui-tag-button'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+        <Button_
+          class='iui-tag-button'
+          variant='borderless'
+          size='small'
           aria-label='Delete very very long tag'
           type='button'
         >
           <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-        </button>
+        </Button_>
       </span>
     </div>
   </section>

--- a/apps/css-workshop/src/pages/tile.astro
+++ b/apps/css-workshop/src/pages/tile.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from './_layout.astro';
 import Badge from '../components/Badge.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Tile'>
@@ -108,25 +109,25 @@ import Badge from '../components/Badge.astro';
       </div>
 
       <div class='iui-tile-thumbnail'>
-        <button
+        <Button_
           aria-label='Type indicator'
           type='button'
-          class='iui-button iui-tile-thumbnail-type-indicator'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-type-indicator'
+          variant='borderless'
+          size='small'
         >
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-        </button>
-        <button
+        </Button_>
+        <Button_
           aria-label='Favorited'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
-          data-iui-active='true'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
+          active='true'
         >
           <svg-star class='iui-button-icon' aria-hidden='true'></svg-star>
-        </button>
+        </Button_>
         <svg-placeholder class='iui-thumbnail-icon' aria-hidden='true'></svg-placeholder>
       </div>
 
@@ -159,22 +160,21 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
+          <Button_
             aria-label='More options'
             type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             id='test-button'
           >
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
 
       <div class='iui-tile-buttons'>
-        <button class='iui-button'> Button 1</button>
-        <button class='iui-button'> Button 2</button>
+        <Button_>Button 1</Button_>
+        <Button_>Button 2</Button_>
       </div>
     </div>
 
@@ -186,25 +186,25 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Type indicator'
           type='button'
-          class='iui-button iui-tile-thumbnail-type-indicator'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-type-indicator'
+          variant='borderless'
+          size='small'
         >
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-        </button>
-        <button
+        </Button_>
+        <Button_
           aria-label='Favorited'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
-          data-iui-active='true'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
+          active='true'
         >
           <svg-star class='iui-button-icon' aria-hidden='true'></svg-star>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tile-content'>
@@ -217,20 +217,14 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
 
       <div class='iui-tile-buttons'>
-        <button class='iui-button'> Only button</button>
+        <Button_>Only button</Button_>
       </div>
     </div>
 
@@ -243,24 +237,24 @@ import Badge from '../components/Badge.astro';
       </div>
 
       <div class='iui-tile-thumbnail'>
-        <button
+        <Button_
           aria-label='Type indicator'
           type='button'
-          class='iui-button iui-tile-thumbnail-type-indicator'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-type-indicator'
+          variant='borderless'
+          size='small'
         >
           <svg-placeholder class='iui-button-icon' aria-hidden='true'></svg-placeholder>
-        </button>
-        <button
+        </Button_>
+        <Button_
           aria-label='Add to favorites'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-star-hollow class='iui-button-icon' aria-hidden='true'></svg-star-hollow>
-        </button>
+        </Button_>
         <div class='iui-tile-thumbnail-badge-container'>
           <Badge backgroundColor='skyblue'>Badge</Badge>
           <Badge backgroundColor='celery'>Badge</Badge>
@@ -273,16 +267,15 @@ import Badge from '../components/Badge.astro';
         <div class='iui-tile-description'>This tile uses many badges.</div>
 
         <div class='iui-tile-more-options'>
-          <button
+          <Button_
             aria-label='More options'
             type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
+            variant='borderless'
+            size='small'
             id='test-button'
           >
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -301,15 +294,15 @@ import Badge from '../components/Badge.astro';
       </div>
 
       <div class='iui-tile-thumbnail'>
-        <button
+        <Button_
           aria-label='Info'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
-        </button>
+        </Button_>
         <svg-imodel-hollow class='iui-thumbnail-icon' aria-hidden='true'></svg-imodel-hollow>
       </div>
 
@@ -329,15 +322,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -352,15 +339,15 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Info'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tile-content'>
@@ -379,15 +366,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -403,15 +384,15 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Info'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
-        </button>
+        </Button_>
         <div class='iui-tile-thumbnail-badge-container'>
           <Badge backgroundColor='froly'>Link</Badge>
         </div>
@@ -433,15 +414,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -455,15 +430,15 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Info'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-info class='iui-button-icon' aria-hidden='true'></svg-info>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tile-content'>
@@ -482,15 +457,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -515,15 +484,9 @@ import Badge from '../components/Badge.astro';
         <div class='iui-tile-description'>CEO</div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -544,15 +507,9 @@ import Badge from '../components/Badge.astro';
         <div class='iui-tile-description'>CEO</div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -566,12 +523,12 @@ import Badge from '../components/Badge.astro';
     <div class='iui-tile'>
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-map'></div>
-        <button
+        <Button_
           aria-label='Assetwise'
           type='button'
-          class='iui-button iui-tile-thumbnail-type-indicator'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-type-indicator'
+          variant='borderless'
+          size='small'
         >
           <span class='iui-button-icon' aria-hidden='true'>
             <svg viewBox='0 0 16 16'>
@@ -580,7 +537,7 @@ import Badge from '../components/Badge.astro';
               ></path>
             </svg>
           </span>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tile-content'>
@@ -596,21 +553,15 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
 
       <div class='iui-tile-buttons'>
-        <button class='iui-button'> Manage</button>
-        <button class='iui-button'> Projects</button>
+        <Button_>Manage</Button_>
+        <Button_>Projects</Button_>
       </div>
     </div>
 
@@ -622,12 +573,12 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Assetwise'
           type='button'
-          class='iui-button iui-tile-thumbnail-type-indicator'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-type-indicator'
+          variant='borderless'
+          size='small'
         >
           <span class='iui-button-icon' aria-hidden='true'>
             <svg viewBox='0 0 16 16'>
@@ -636,7 +587,7 @@ import Badge from '../components/Badge.astro';
               ></path>
             </svg>
           </span>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-tile-content'>
@@ -648,20 +599,14 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
       <div class='iui-tile-buttons'>
-        <button class='iui-button'> Manage</button>
-        <button class='iui-button'> Projects</button>
+        <Button_>Manage</Button_>
+        <Button_>Projects</Button_>
       </div>
     </div>
   </section>
@@ -677,15 +622,15 @@ import Badge from '../components/Badge.astro';
       </div>
 
       <div class='iui-tile-thumbnail'>
-        <button
+        <Button_
           aria-label='Favorite'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-star-hollow class='iui-button-icon' aria-hidden='true'></svg-star-hollow>
-        </button>
+        </Button_>
         <svg-play-circular class='iui-thumbnail-icon' aria-hidden='true'></svg-play-circular>
       </div>
 
@@ -701,15 +646,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -722,15 +661,15 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Favorite'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-star-hollow class='iui-button-icon' aria-hidden='true'></svg-star-hollow>
-        </button>
+        </Button_>
         <svg-play-circular class='iui-thumbnail-icon' aria-hidden='true'></svg-play-circular>
       </div>
 
@@ -746,15 +685,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -768,15 +701,15 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-thumbnail'>
         <div class='iui-tile-thumbnail-picture demo-photo'></div>
-        <button
+        <Button_
           aria-label='Favorite'
           type='button'
-          class='iui-button iui-tile-thumbnail-quick-action'
-          data-iui-variant='borderless'
-          data-iui-size='small'
+          class='iui-tile-thumbnail-quick-action'
+          variant='borderless'
+          size='small'
         >
           <svg-star-hollow class='iui-button-icon' aria-hidden='true'></svg-star-hollow>
-        </button>
+        </Button_>
         <svg-play-circular class='iui-thumbnail-icon' aria-hidden='true'></svg-play-circular>
       </div>
 
@@ -792,15 +725,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -828,15 +755,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -857,15 +778,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -886,15 +801,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -916,15 +825,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -963,15 +866,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1004,15 +901,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1046,15 +937,9 @@ import Badge from '../components/Badge.astro';
           </div>
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1076,15 +961,9 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-content'>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1115,15 +994,9 @@ import Badge from '../components/Badge.astro';
           </div>
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1152,15 +1025,9 @@ import Badge from '../components/Badge.astro';
           </div>
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1184,15 +1051,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1215,15 +1076,9 @@ import Badge from '../components/Badge.astro';
         </div>
 
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1244,15 +1099,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1274,15 +1123,9 @@ import Badge from '../components/Badge.astro';
 
       <div class='iui-tile-content'>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1303,15 +1146,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>
@@ -1330,15 +1167,9 @@ import Badge from '../components/Badge.astro';
           A collection of all Bentley Systems 2D and 3D marketing assets.
         </div>
         <div class='iui-tile-more-options'>
-          <button
-            aria-label='More options'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='More options' type='button' variant='borderless' size='small'>
             <svg-more class='iui-button-icon' aria-hidden='true'></svg-more>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>

--- a/apps/css-workshop/src/pages/toast.astro
+++ b/apps/css-workshop/src/pages/toast.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 ---
 
 <Layout title='Toast notification'>
@@ -83,15 +84,9 @@ import Layout from './_layout.astro';
             data-iui-underline='true'
             data-iui-status='positive'>View the report</a
           >
-          <button
-            aria-label='Close'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
             <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-toast iui-positive'>
@@ -99,15 +94,9 @@ import Layout from './_layout.astro';
             <svg-status-success class='iui-icon' aria-hidden='true'></svg-status-success>
           </div>
           <div class='iui-message'>Processing completed.</div>
-          <button
-            aria-label='Close'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
             <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-toast iui-positive'>
@@ -140,15 +129,9 @@ import Layout from './_layout.astro';
             data-iui-underline='true'
             data-iui-status='informational'>View</a
           >
-          <button
-            aria-label='Close'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
             <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-toast iui-informational' id='demo-informational'>
@@ -175,15 +158,9 @@ import Layout from './_layout.astro';
             data-iui-underline='true'
             data-iui-status='negative'>View the report</a
           >
-          <button
-            aria-label='Close'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
             <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-          </button>
+          </Button_>
         </div>
 
         <div class='iui-toast iui-warning' id='demo-warning'>
@@ -197,15 +174,9 @@ import Layout from './_layout.astro';
             data-iui-underline='true'
             data-iui-status='warning'>Approve</a
           >
-          <button
-            aria-label='Close'
-            type='button'
-            class='iui-button'
-            data-iui-variant='borderless'
-            data-iui-size='small'
-          >
+          <Button_ aria-label='Close' type='button' variant='borderless' size='small'>
             <svg-close-small class='iui-button-icon' aria-hidden='true'></svg-close-small>
-          </button>
+          </Button_>
         </div>
       </div>
     </div>

--- a/apps/css-workshop/src/pages/transfer-list.astro
+++ b/apps/css-workshop/src/pages/transfer-list.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Checkbox_ from '../components/Checkbox.astro';
 import Checkbox from './checkbox.astro';
 ---
@@ -63,18 +64,18 @@ import Checkbox from './checkbox.astro';
       </div>
 
       <div class='iui-transfer-list-toolbar' role='toolbar' aria-label='Actions'>
-        <button class='iui-button' data-iui-variant='borderless'>
+        <Button_ variant='borderless'>
           <svg-chevron-up class='iui-button-icon' aria-hidden='true'></svg-chevron-up>
-        </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        </Button_>
+        <Button_ variant='borderless'>
           <svg-chevron-right class='iui-button-icon' aria-hidden='true'></svg-chevron-right>
-        </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        </Button_>
+        <Button_ variant='borderless'>
           <svg-chevron-left class='iui-button-icon' aria-hidden='true'></svg-chevron-left>
-        </button>
-        <button class='iui-button' data-iui-variant='borderless'>
+        </Button_>
+        <Button_ variant='borderless'>
           <svg-chevron-down class='iui-button-icon' aria-hidden='true'></svg-chevron-down>
-        </button>
+        </Button_>
       </div>
 
       <div class='iui-transfer-list-listbox-wrapper'>

--- a/apps/css-workshop/src/pages/tree.astro
+++ b/apps/css-workshop/src/pages/tree.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Button_ from '../components/Button.astro';
 import Checkbox_ from '../components/Checkbox.astro';
 ---
 
@@ -24,16 +25,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Node 1</div>
             </span>
@@ -54,16 +50,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Node 2</div>
             </span>
@@ -73,16 +64,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
             <div class='iui-tree-node' style='--level: 1;'>
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>Node 2.1</div>
                 </span>
@@ -92,16 +78,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true'>
             <div class='iui-tree-node' style='--level: 1;'>
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>Node 2.2</div>
                 </span>
@@ -111,16 +92,11 @@ import Checkbox_ from '../components/Checkbox.astro';
               <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true'>
                 <div class='iui-tree-node' style='--level: 2;'>
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                    >
+                    <Button_ variant='borderless' size='small' type='button'>
                       <svg-chevron-right
                         class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                         aria-hidden='true'></svg-chevron-right>
-                    </button>
+                    </Button_>
                     <span class='iui-tree-node-content-label'>
                       <div class='iui-tree-node-content-title'>Node 2.2.1</div>
                     </span>
@@ -145,16 +121,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Node 3</div>
             </span>
@@ -172,16 +143,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true' id='test-node'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
             ></svg-placeholder>
             <span class='iui-tree-node-content-label'>
@@ -208,16 +174,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
             <div class='iui-tree-node' style='--level: 1;'>
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -234,16 +195,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
             <div class='iui-tree-node' style='--level: 1;'>
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -282,16 +238,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='true'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -316,16 +267,11 @@ import Checkbox_ from '../components/Checkbox.astro';
           <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
             <div class='iui-tree-node' style='--level: 1;'>
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -346,16 +292,11 @@ import Checkbox_ from '../components/Checkbox.astro';
       <li class='iui-tree-item' role='treeitem' tabindex='0' aria-expanded='false'>
         <div class='iui-tree-node'>
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -388,16 +329,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Category 1</div>
               <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -421,16 +357,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Category 2</div>
               <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -442,16 +373,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node' style='--level: 1;'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>Subcategory</div>
                 </span>
@@ -464,16 +390,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Category 3</div>
               <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -492,16 +413,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <span class='iui-tree-node-content-label'>
               <div class='iui-tree-node-content-title'>Category 1</div>
               <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -523,16 +439,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>Category 2</div>
                   <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -544,17 +455,11 @@ import Checkbox_ from '../components/Checkbox.astro';
                 <div class='iui-tree-node iui-disabled' style='--level: 1;'>
                   <Checkbox_ disabled checked variant='eyeball' basic />
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                      disabled
-                    >
+                    <Button_ variant='borderless' size='small' type='button' disabled>
                       <svg-chevron-right
                         class='iui-button-icon iui-tree-node-content-expander-icon'
                         aria-hidden='true'></svg-chevron-right>
-                    </button>
+                    </Button_>
                     <span class='iui-tree-node-content-label'>
                       <div class='iui-tree-node-content-title'>Subcategory</div>
                     </span>
@@ -567,17 +472,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node iui-disabled'>
               <Checkbox_ disabled checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                  disabled
-                >
+                <Button_ variant='borderless' size='small' type='button' disabled>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <span class='iui-tree-node-content-label'>
                   <div class='iui-tree-node-content-title'>Category 3</div>
                   <div class='iui-tree-node-content-caption'>A basic description.</div>
@@ -598,16 +497,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
             ></svg-placeholder>
             <span class='iui-tree-node-content-label'>
@@ -620,16 +514,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node' style='--level: 1;'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -670,16 +559,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right>
-            </button>
+            </Button_>
             <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
             ></svg-placeholder>
             <span class='iui-tree-node-content-label'>
@@ -693,16 +577,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node' style='--level: 1;'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -715,16 +594,11 @@ import Checkbox_ from '../components/Checkbox.astro';
                 <div class='iui-tree-node' style='--level: 2;'>
                   <Checkbox_ checked variant='eyeball' basic />
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                    >
+                    <Button_ variant='borderless' size='small' type='button'>
                       <svg-chevron-right
                         class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                         aria-hidden='true'></svg-chevron-right>
-                    </button>
+                    </Button_>
                     <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                     ></svg-placeholder>
                     <span class='iui-tree-node-content-label'>
@@ -751,16 +625,11 @@ import Checkbox_ from '../components/Checkbox.astro';
                 <div class='iui-tree-node' style='--level: 2;'>
                   <Checkbox_ checked variant='eyeball' basic />
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                    >
+                    <Button_ variant='borderless' size='small' type='button'>
                       <svg-chevron-right
                         class='iui-button-icon iui-tree-node-content-expander-icon'
                         aria-hidden='true'></svg-chevron-right>
-                    </button>
+                    </Button_>
                     <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                     ></svg-placeholder>
                     <span class='iui-tree-node-content-label'>
@@ -784,16 +653,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right-small
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right-small>
-            </button>
+            </Button_>
             <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
             ></svg-placeholder>
             <span class='iui-tree-node-content-label'>
@@ -806,16 +670,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node' style='--level: 1;'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right-small
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right-small>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -856,16 +715,11 @@ import Checkbox_ from '../components/Checkbox.astro';
         <div class='iui-tree-node'>
           <Checkbox_ variant='eyeball' basic checked />
           <div class='iui-tree-node-content'>
-            <button
-              class='iui-button'
-              data-iui-variant='borderless'
-              data-iui-size='small'
-              type='button'
-            >
+            <Button_ variant='borderless' size='small' type='button'>
               <svg-chevron-right-small
                 class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                 aria-hidden='true'></svg-chevron-right-small>
-            </button>
+            </Button_>
             <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
             ></svg-placeholder>
             <span class='iui-tree-node-content-label'>
@@ -879,16 +733,11 @@ import Checkbox_ from '../components/Checkbox.astro';
             <div class='iui-tree-node' style='--level: 1;'>
               <Checkbox_ checked variant='eyeball' basic />
               <div class='iui-tree-node-content'>
-                <button
-                  class='iui-button'
-                  data-iui-variant='borderless'
-                  data-iui-size='small'
-                  type='button'
-                >
+                <Button_ variant='borderless' size='small' type='button'>
                   <svg-chevron-right-small
                     class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                     aria-hidden='true'></svg-chevron-right-small>
-                </button>
+                </Button_>
                 <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                 ></svg-placeholder>
                 <span class='iui-tree-node-content-label'>
@@ -901,16 +750,11 @@ import Checkbox_ from '../components/Checkbox.astro';
                 <div class='iui-tree-node' style='--level: 2;'>
                   <Checkbox_ checked variant='eyeball' basic />
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                    >
+                    <Button_ variant='borderless' size='small' type='button'>
                       <svg-chevron-right-small
                         class='iui-button-icon iui-tree-node-content-expander-icon iui-tree-node-content-expander-icon-expanded'
                         aria-hidden='true'></svg-chevron-right-small>
-                    </button>
+                    </Button_>
                     <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                     ></svg-placeholder>
                     <span class='iui-tree-node-content-label'>
@@ -937,16 +781,11 @@ import Checkbox_ from '../components/Checkbox.astro';
                 <div class='iui-tree-node' style='--level: 2;'>
                   <Checkbox_ checked variant='eyeball' basic />
                   <div class='iui-tree-node-content'>
-                    <button
-                      class='iui-button'
-                      data-iui-variant='borderless'
-                      data-iui-size='small'
-                      type='button'
-                    >
+                    <Button_ variant='borderless' size='small' type='button'>
                       <svg-chevron-right-small
                         class='iui-button-icon iui-tree-node-content-expander-icon'
                         aria-hidden='true'></svg-chevron-right-small>
-                    </button>
+                    </Button_>
                     <svg-placeholder class='iui-tree-node-content-icon' aria-hidden='true'
                     ></svg-placeholder>
                     <span class='iui-tree-node-content-label'>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Adds `Button` Astro component to the `css-workshop`. Imported as `Button_` to all files in order to maintain consistency. Takes in props for all of the potential `data-iui` values.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Ran visual tests and confirmed that the component did not cause any visual changes.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

N/A
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
