### PR TITLE
fix `styleType` being passed to DOM

### DIFF
--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -290,6 +290,8 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
     triggerProps,
     status,
     popoverProps,
+    // @ts-expect-error -- this prop is disallowed by types but should still be handled at runtime
+    styleType,
     ...rest
   } = props;
 
@@ -423,6 +425,7 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
           aria-expanded={isOpen}
           aria-haspopup='listbox'
           aria-controls={`${uid}-menu`}
+          styleType={styleType}
           {...triggerProps}
           ref={useMergedRefs(
             selectRef,


### PR DESCRIPTION
## Changes

`LabeledSelect` forces a `styleType` even when it's disallowed for non-native Select. This PR ensures that it's handled correctly by `SelectButton`, rather than being passed to the `InputWithIcon` DOM element along with `...rest` props.

## Testing

Tested that the prop doesn't appear in DOM

## Docs

N/A. Too small of a change for changeset