### PR TITLE
work around incorrectly minified CSS in vertical slider

### DIFF
--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -117,15 +117,12 @@ $iui-slider-tick-thickness: 1px;
 
       &::before {
         block-size: 100%;
+        inline-size: var(--_iui-slider-track-thickness);
       }
     }
 
-    .iui-slider::before,
     .iui-slider-track {
       inline-size: var(--_iui-slider-track-thickness);
-    }
-
-    .iui-slider-track {
       inset-block: var(--iui-slider-track-position, #{$slider-position-vertical});
     }
 


### PR DESCRIPTION
## Changes

This is the same change as https://github.com/iTwin/iTwinUI/pull/1963#discussion_r1546746144 but for vertical slider. I haven't inspected the minified CSS, but it's likely caused by improper minification in `esbuild`.

The simple work around is to split `::before` and `-track` into two separate rules.

## Testing

| Before | After |
| --- | --- |
| ![image](https://github.com/iTwin/iTwinUI/assets/9084735/feb1364e-170c-4460-b5fd-dc11032a9d2e) | ![image](https://github.com/iTwin/iTwinUI/assets/9084735/4c051879-2ae3-4d9d-bec4-f9b7b2955ba4) |

✅ [All (react-workshop) tests pass now](https://github.com/iTwin/iTwinUI/actions/runs/8634454402/job/23669968809?pr=1992#step:6:3750)

## Docs

N/A. Users shouldn't encounter this change; it's mainly for react-workshop.