### PR TITLE
underline `Anchor` inside `Text` by default

### DIFF
--- a/.changeset/new-clocks-grin.md
+++ b/.changeset/new-clocks-grin.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": minor
+---
+
+`Anchor` elements inside `Text` will now be underlined by default.

--- a/apps/website/src/content/docs/anchor.mdx
+++ b/apps/website/src/content/docs/anchor.mdx
@@ -59,9 +59,12 @@ If you do ultimately decide based on your research that it is beneficial to open
 
 ### Underlines
 
-By default, the anchor is only underlined when hovered, except when using a high-contrast theme.
+By default, an anchor is only underlined when hovered, with a few exceptions:
 
-For [better accessibility](https://adrianroselli.com/2016/06/on-link-underlines.html#recommendation), it is recommended to explicitly make the anchor underlined in all themes, using the `underline` prop.
+1. Anchors inside a [`Text`](https://itwinui.bentley.com/docs/typography#text) component are underlined by default.
+2. All anchors are underlined by default using a high-contrast theme.
+
+For [better accessibility](https://adrianroselli.com/2016/06/on-link-underlines.html#recommendation), it is recommended to explicitly make the anchor underlined in all themes, even when used outside `Text`. This can be achieved using the `underline` prop.
 
 <LiveExample src='Anchor.underline.jsx' truncate={false}>
   <AllExamples.AnchorUnderlineExample client:idle />

--- a/apps/website/src/content/docs/anchor.mdx
+++ b/apps/website/src/content/docs/anchor.mdx
@@ -62,7 +62,7 @@ If you do ultimately decide based on your research that it is beneficial to open
 By default, an anchor is only underlined when hovered, with a few exceptions:
 
 1. Anchors inside a [`Text`](https://itwinui.bentley.com/docs/typography#text) component are underlined by default.
-2. All anchors are underlined by default using a high-contrast theme.
+2. All anchors are underlined by default when using a high-contrast theme.
 
 For [better accessibility](https://adrianroselli.com/2016/06/on-link-underlines.html#recommendation), it is recommended to explicitly make the anchor underlined in all themes, even when used outside `Text`. This can be achieved using the `underline` prop.
 

--- a/packages/itwinui-react/src/core/Typography/Anchor.test.tsx
+++ b/packages/itwinui-react/src/core/Typography/Anchor.test.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 
 import { Anchor } from './Anchor.js';
+import { Text } from './Text.js';
 
 it('should render in its most basic state', () => {
   const { container } = render(<Anchor>link</Anchor>);
@@ -84,6 +85,16 @@ it('should support underline prop', () => {
       link
     </Anchor>,
   );
+  expect(container.querySelector('a')).toHaveAttribute(
+    'data-iui-underline',
+    'true',
+  );
+});
+
+it('should underline by default when inside Text component', () => {
+  const { container } = render(<Anchor href='#'>link</Anchor>, {
+    wrapper: ({ children }) => <Text>{children}</Text>,
+  });
   expect(container.querySelector('a')).toHaveAttribute(
     'data-iui-underline',
     'true',

--- a/packages/itwinui-react/src/core/Typography/Anchor.tsx
+++ b/packages/itwinui-react/src/core/Typography/Anchor.tsx
@@ -8,6 +8,7 @@ import cx from 'classnames';
 import { Box } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden.js';
+import { TextContext } from './Text.js';
 
 type AnchorProps = {
   /**
@@ -43,7 +44,8 @@ type AnchorProps = {
  * <Anchor as='button' onClick={() => {}}>click me</Anchor>
  */
 export const Anchor = React.forwardRef((props, forwardedRef) => {
-  const { isExternal, underline, children, ...rest } = props;
+  const isInsideText = React.useContext(TextContext);
+  const { isExternal, underline = isInsideText, children, ...rest } = props;
 
   return (
     <Box

--- a/packages/itwinui-react/src/core/Typography/Text.tsx
+++ b/packages/itwinui-react/src/core/Typography/Text.tsx
@@ -33,6 +33,8 @@ type TextProps = {
   isSkeleton?: boolean;
 };
 
+// ----------------------------------------------------------------------------
+
 /**
  * Polymorphic typography component to render any kind of text as any kind of element.
  * Users should decide which element to render based on the context of their app. Link to heading levels docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#accessibility_concerns
@@ -55,18 +57,24 @@ export const Text = React.forwardRef((props, ref) => {
   } = props;
 
   return (
-    <Box
-      className={cx(
-        {
-          [`iui-text-${variant}`]: variant !== 'body',
-          'iui-text-block': variant === 'body',
-          'iui-text-muted': isMuted,
-          'iui-skeleton': isSkeleton,
-        },
-        className,
-      )}
-      ref={ref}
-      {...rest}
-    />
+    <TextContext.Provider value={true}>
+      <Box
+        className={cx(
+          {
+            [`iui-text-${variant}`]: variant !== 'body',
+            'iui-text-block': variant === 'body',
+            'iui-text-muted': isMuted,
+            'iui-skeleton': isSkeleton,
+          },
+          className,
+        )}
+        ref={ref}
+        {...rest}
+      />
+    </TextContext.Provider>
   );
 }) as PolymorphicForwardRefComponent<'div', TextProps>;
+
+// ----------------------------------------------------------------------------
+
+export const TextContext = React.createContext(false);


### PR DESCRIPTION
## Changes

This is a follow-up to #1864. `Anchor`'s `underline` prop will default to `true` when used inside a `Text`. The implementation is done using a simple React context.

This change improves the accessibility, by adding an additional cue to differentiate links from surrounding text. See [Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color). 

## Testing

Added unit test + tested manually.

![image](https://github.com/iTwin/iTwinUI/assets/9084735/a0a8d5e0-67c1-4177-b40f-5c604c46ce35)


## Docs

Added changeset + updated existing docs on `underline` to mention new behavior.