### PR TITLE
change `Dialog` to `setFocus` by default

### DIFF
--- a/.changeset/eighty-cups-taste.md
+++ b/.changeset/eighty-cups-taste.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": minor
+---
+
+`Dialog` will now default `setFocus` to `true`, so that focus moves into the dialog when opened.

--- a/packages/itwinui-react/src/core/Dialog/Dialog.tsx
+++ b/packages/itwinui-react/src/core/Dialog/Dialog.tsx
@@ -25,7 +25,7 @@ type DialogProps = {
 const DialogComponent = React.forwardRef((props, ref) => {
   const {
     trapFocus = false,
-    setFocus = false,
+    setFocus = true,
     preventDocumentScroll = false,
     isOpen = false,
     isDismissible = true,

--- a/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
@@ -41,7 +41,7 @@ export type DialogContextProps = {
   trapFocus?: boolean;
   /**
    * If true, focuses the dialog.
-   * @default false
+   * @default true
    */
   setFocus?: boolean;
   /**


### PR DESCRIPTION
## Changes

WIP

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
