### PR TITLE
Adds `Blockquote` Astro component.

### DIFF
--- a/apps/css-workshop/src/components/Blockquote.astro
+++ b/apps/css-workshop/src/components/Blockquote.astro
@@ -1,0 +1,7 @@
+---
+type Props = astroHTML.JSX.BlockquoteHTMLAttributes;
+
+const { class: className, ...props } = Astro.props;
+---
+
+<blockquote class:list={['iui-blockquote', className]} {...props}><slot /></blockquote>

--- a/apps/css-workshop/src/pages/blockquote.astro
+++ b/apps/css-workshop/src/pages/blockquote.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from './_layout.astro';
+import Blockquote_ from '../components/Blockquote.astro';
 ---
 
 <Layout title='Blockquote'>
@@ -12,7 +13,7 @@ import Layout from './_layout.astro';
   <hr />
 
   <section id='demo-default'>
-    <blockquote class='iui-blockquote' cite='https://www.bentley.com/en'>
+    <Blockquote_ cite='https://www.bentley.com/en'>
       <p>
         For 36 years we have served engineers with our software, passionately believing that better
         performing and more resilient infrastructure is essential to improve the quality of life for
@@ -22,6 +23,6 @@ import Layout from './_layout.astro';
         —Greg Bentley,
         <cite>NasdaqListed</cite>
       </footer>
-    </blockquote>
+    </Blockquote_>
   </section>
 </Layout>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Adds `Blockquote` Astro component to `css-workshop`. Imported as `Blockquote_` in the `blockquote.astro` file.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Ran visual test to insure that adding this component caused no visual changes.

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

N/A

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
