### PR TITLE
rename `stretch` to `stretched`

### DIFF
--- a/.changeset/thin-eagles-sparkle.md
+++ b/.changeset/thin-eagles-sparkle.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": minor
 ---
 
-Added a new `stretch` prop to `Button` to allow it to span the full width of its container.
+Added a new `stretched` prop to `Button` to allow it to span the full width of its container.

--- a/apps/react-workshop/src/Button.stories.tsx
+++ b/apps/react-workshop/src/Button.stories.tsx
@@ -115,7 +115,7 @@ export const AsLink = () => {
 };
 
 export const Stretch = () => {
-  return <Button stretch>Sign in</Button>;
+  return <Button stretched>Sign in</Button>;
 };
 Stretch.decorators = [
   (Story: () => React.ReactNode) => (

--- a/apps/website/src/content/docs/button.mdx
+++ b/apps/website/src/content/docs/button.mdx
@@ -63,12 +63,12 @@ There are 3 different sizes available, which can be applied to any button. The m
   <AllExamples.ButtonSizeExample client:load />
 </LiveExample>
 
-### Stretch
+### Stretched
 
-To make a button stretch to the full width of its parent, use the `stretch` prop.
+To make a button stretch to the full width of its parent, use the `stretched` prop.
 
 ```jsx
-<Button stretch>Sign in</Button>
+<Button stretched>Sign in</Button>
 ```
 
 This is useful in narrow containers and mobile views. Don't overuse this!

--- a/packages/itwinui-react/src/core/Buttons/Button.test.tsx
+++ b/packages/itwinui-react/src/core/Buttons/Button.test.tsx
@@ -216,7 +216,7 @@ it('should render [x]Props correctly', () => {
   expect(labelElement.style.width).toBe('80px');
 });
 
-it('should respect `stretch` prop', () => {
-  const { container } = render(<Button stretch>Do not click</Button>);
+it('should respect `stretched` prop', () => {
+  const { container } = render(<Button stretched>Do not click</Button>);
   expect(container.querySelector('button')).toHaveStyle('--_iui-width: 100%');
 });

--- a/packages/itwinui-react/src/core/Buttons/Button.tsx
+++ b/packages/itwinui-react/src/core/Buttons/Button.tsx
@@ -44,7 +44,7 @@ export type ButtonProps = {
    *
    * This is useful on narrow containers and mobile views.
    */
-  stretch?: boolean;
+  stretched?: boolean;
 } & Pick<React.ComponentProps<typeof ButtonBase>, 'htmlDisabled'>;
 
 /**
@@ -67,7 +67,7 @@ export const Button = React.forwardRef((props, ref) => {
     labelProps,
     startIconProps,
     endIconProps,
-    stretch,
+    stretched,
     ...rest
   } = props;
 
@@ -80,7 +80,7 @@ export const Button = React.forwardRef((props, ref) => {
       {...rest}
       style={
         {
-          '--_iui-width': stretch ? '100%' : undefined,
+          '--_iui-width': stretched ? '100%' : undefined,
           ...props.style,
         } as React.CSSProperties
       }


### PR DESCRIPTION
## Changes

Simple rename of the (unreleased) `stretch` prop from #1971. `<Button stretched>` feels more appropriate as a declarative prop API.

Other options considered (which I think are worse):
- `isStretched`
- `fullWidth`
- `fullSpan`
- `fillContainer`

## Testing

N/A

## Docs

N/A