### PR TITLE
skip unnecessary calculations when `Tooltip` is not visible

### DIFF
--- a/.changeset/lovely-pigs-chew.md
+++ b/.changeset/lovely-pigs-chew.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a performance issue in `Tooltip` where expensive calculations were being run even when the tooltip was not visible.


### PR DESCRIPTION
## Changes

Fixes #2002, mainly by removing the `autoUpdate` function which was being executed even when the tooltip is closed. I also removed `floatingStyles` when the tooltip is closed, and memoized the `middleware` object to avoid recreating it on each re-render.

## Testing

Manually tested that the performance issue is fixed, with 6x CPU slowdown in Chrome devtools.

<details><summary>Before</summary>

https://github.com/iTwin/iTwinUI/assets/9084735/34c602bd-4197-467a-939f-d8a62b918b83

</details> 

<details><summary>After</summary>

https://github.com/iTwin/iTwinUI/assets/9084735/77b9f38e-b179-4094-830e-57486e30c3b1

</details> 

## Docs

Added changeset.