### PR TITLE
remove `Tooltip` from DOM when ARIA is not used

### DIFF
--- a/.changeset/gentle-seas-protect.md
+++ b/.changeset/gentle-seas-protect.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Improved `IconButton` so that its tooltip is removed from the DOM when not visible.

--- a/.changeset/lovely-pigs-chew.md
+++ b/.changeset/lovely-pigs-chew.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a performance issue in `Tooltip` where expensive calculations were being run even when the tooltip was not visible.

--- a/packages/itwinui-react/src/core/Buttons/IconButton.test.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton.test.tsx
@@ -2,11 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { SvgMore } from '../../utils/index.js';
 
 import { IconButton } from './IconButton.js';
+import { userEvent } from '@testing-library/user-event';
 
 it('renders icon button correctly', () => {
   const onClickMock = vi.fn();
@@ -91,7 +92,7 @@ it('should pass props to IconButton parts', () => {
   const { container } = render(
     <IconButton
       label='hello'
-      labelProps={{ className: 'the-label' }}
+      labelProps={{ className: 'the-label', visible: true }}
       iconProps={{ className: 'custom-icon-class', style: { width: 80 } }}
     >
       <SvgMore />
@@ -107,4 +108,22 @@ it('should pass props to IconButton parts', () => {
   const label = document.querySelector('.iui-tooltip') as HTMLElement;
   expect(label).toHaveTextContent('hello');
   expect(label).toHaveClass('the-label');
+});
+
+it('should not leave behind tooltip in DOM when not visible', async () => {
+  render(
+    <IconButton label='hello'>
+      <svg />
+    </IconButton>,
+  );
+
+  expect(screen.queryAllByText('hello')).toHaveLength(1);
+
+  // focus the button
+  await userEvent.tab();
+  expect(screen.queryAllByText('hello')).toHaveLength(2);
+
+  // unfocus the button
+  await userEvent.tab();
+  expect(screen.queryAllByText('hello')).toHaveLength(1);
 });

--- a/packages/itwinui-react/src/core/Slider/Slider.test.tsx
+++ b/packages/itwinui-react/src/core/Slider/Slider.test.tsx
@@ -202,7 +202,7 @@ it('should not show tooltip if visibility is overridden', async () => {
   expect(document.activeElement).toEqual(
     container.querySelector('.iui-slider-thumb'),
   );
-  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
+  expect(document.querySelector('.iui-tooltip')).toBeNull();
 });
 
 it('should show custom tooltip when focused', async () => {
@@ -502,7 +502,7 @@ it('should show tooltip on thumb hover', async () => {
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
+  expect(document.querySelector('.iui-tooltip')).toBeNull();
 
   vi.useFakeTimers();
   fireEvent.mouseEnter(thumb);
@@ -519,7 +519,7 @@ it('should show tooltip on thumb focus', async () => {
   assertBaseElement(container);
   const thumb = container.querySelector('.iui-slider-thumb') as HTMLDivElement;
   expect(thumb.classList).not.toContain('iui-active');
-  expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
+  expect(document.querySelector('.iui-tooltip')).toBeNull();
 
   await userEvent.tab();
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -279,6 +279,7 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
   const { content, children, portal = true, className, style, ...rest } = props;
 
   const tooltip = useTooltip(rest);
+  const refs = useMergedRefs(tooltip.refs.setFloating, forwardedRef);
 
   return (
     <>
@@ -287,16 +288,21 @@ export const Tooltip = React.forwardRef((props, forwardedRef) => {
         ref: tooltip.refs.setReference,
       }))}
 
-      <Portal portal={portal}>
-        <Box
-          className={cx('iui-tooltip', className)}
-          ref={useMergedRefs(tooltip.refs.setFloating, forwardedRef)}
-          style={{ ...tooltip.floatingStyles, ...style }}
-          {...tooltip.floatingProps}
-        >
-          {content}
-        </Box>
-      </Portal>
+      {
+        // Tooltip must always be present in the DOM (even when closed) for ARIA to work
+        props.ariaStrategy !== 'none' || tooltip.context.open ? (
+          <Portal portal={portal}>
+            <Box
+              className={cx('iui-tooltip', className)}
+              ref={refs}
+              style={{ ...tooltip.floatingStyles, ...style }}
+              {...tooltip.floatingProps}
+            >
+              {content}
+            </Box>
+          </Portal>
+        ) : null
+      }
     </>
   );
 }) as PolymorphicForwardRefComponent<'div', TooltipOwnProps & TooltipOptions>;


### PR DESCRIPTION
## Changes

This addresses a user complaint about `Tooltip` staying in DOM even when not visible. This is normally necessary for ARIA to work, but since `IconButton` uses `ariaStrategy='none'`, we can remove the DOM element for this one specific scenario.

## Testing

Manually verified in dev tools that the tooltip element is removed from DOM when it's not visible. Added a unit test for it too.

## Docs

Added changeset.