### PR TITLE
Floating UI `safePolygon` for non-last `MenuItem`s

### DIFF
--- a/.changeset/smart-flies-reflect.md
+++ b/.changeset/smart-flies-reflect.md
@@ -2,4 +2,4 @@
 "@itwin/itwinui-react": patch
 ---
 
-Previously added leniency in mouse precision when hovering from one `MenuItem` to its submenu now even works for `MenuItem`s that are not at the end of the menu.
+Submenus within a `DropdownMenu` will now consistently require less precision when moving the mouse between the parent item and the submenu.

--- a/.changeset/smart-flies-reflect.md
+++ b/.changeset/smart-flies-reflect.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Previously added leniency in mouse precision when hovering from one `MenuItem` to its submenu now even works for `MenuItem`s that are not at the end of the menu.

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -179,7 +179,13 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
   const popover = usePopover({
     nodeId,
     visible: isSubmenuVisible,
-    onVisibleChange: setIsSubmenuVisible,
+    onVisibleChange: (v) => {
+      if (!v) {
+        setHasFocusedNodeInSubmenu(false);
+      }
+
+      setIsSubmenuVisible(v);
+    },
     placement: 'right-start',
     interactions: !disabled
       ? {

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -235,7 +235,11 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
   };
 
   const onFocus = () => {
-    parent.setHasFocusedNodeInSubmenu?.(true);
+    // Set hasFocusedNodeInSubmenu in a microtask to ensure the submenu stays open reliably.
+    // E.g. Even when hovering into it rapidly.
+    queueMicrotask(() => {
+      parent.setHasFocusedNodeInSubmenu?.(true);
+    });
 
     tree?.events.emit('onNodeFocused', {
       nodeId,

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -179,13 +179,12 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
   const popover = usePopover({
     nodeId,
     visible: isSubmenuVisible,
-    onVisibleChange: (v) => {
-      if (!v) {
+    onVisibleChange: React.useCallback((visible: boolean) => {
+      if (!visible) {
         setHasFocusedNodeInSubmenu(false);
       }
-
-      setIsSubmenuVisible(v);
-    },
+      setIsSubmenuVisible(visible);
+    }, []),
     placement: 'right-start',
     interactions: !disabled
       ? {

--- a/packages/itwinui-react/src/core/Popover/Popover.tsx
+++ b/packages/itwinui-react/src/core/Popover/Popover.tsx
@@ -231,7 +231,6 @@ export const usePopover = (options: PopoverOptions & PopoverInternalProps) => {
       delay: 100,
       handleClose: safePolygon({
         buffer: 1,
-        requireIntent: false,
         blockPointerEvents: true,
       }),
       move: false,

--- a/packages/itwinui-react/src/core/Popover/Popover.tsx
+++ b/packages/itwinui-react/src/core/Popover/Popover.tsx
@@ -229,7 +229,11 @@ export const usePopover = (options: PopoverOptions & PopoverInternalProps) => {
     useHover(floating.context, {
       enabled: !!mergedInteractions.hover,
       delay: 100,
-      handleClose: safePolygon({ buffer: 1, requireIntent: false }),
+      handleClose: safePolygon({
+        buffer: 1,
+        requireIntent: false,
+        blockPointerEvents: true,
+      }),
       move: false,
       ...(mergedInteractions.hover as object),
     }),


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

After PR TODO from #1942 (https://github.com/iTwin/iTwinUI/pull/1942#discussion_r1578323366).

To make the `safePolygon` work for even the non-last `MenuItem`s, looks like we needed to set [`blockPointerEvents: true`](https://floating-ui.com/docs/useHover#blockpointerevents). This PR makes that change.

This change is done in `usePopover` instead of `MenuItem` because `MenuItem` is the only component that has been using the hover trigger so far. So, making this change in `usePopover` is alright since it will not affect any other user component or our own internal component.

Additionally, to make it easier for users to hover over adjacent items instead of keeping the submenu open, [`requireIntent: false`](https://floating-ui.com/docs/usehover#requireintent) is removed (https://github.com/iTwin/iTwinUI/pull/2026#discussion_r1591009663).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

`safePolygon` works for non-last `MenuItem`s too.

<details>
<summary>Screen-recordings</summary>

Before:

https://github.com/iTwin/iTwinUI/assets/45748283/2dc9de71-81e1-498f-9a5c-9c8e5990229c

After:

https://github.com/iTwin/iTwinUI/assets/45748283/35d29f96-cb46-41d7-8bf4-f8c866682cbe

</details>

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changesets.