### PR TITLE
allow minor drift in `pnpm` versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ node-linker=hoisted
 shell-emulator=true
 shamefully-hoist=true
 link-workspace-packages=true
+package-manager-strict=false

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
   "engines": {
     "node": ">=18.14.1"
   },
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@9.1.0",
   "prettier": "configs/prettier-config"
 }


### PR DESCRIPTION
## Changes

This updates `pnpm` to latest (9.1.0) and prevents CI from failing when there is a new version of `pnpm` in the future.

## Testing

N/A

## Docs

N/A