### PR TITLE
pin cypress binary version in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,8 @@ jobs:
 
       - name: Install Cypress binary if not found
         run: pnpx cypress install
+        env:
+          CYPRESS_INSTALL_BINARY: 13.8.1
 
       - name: Run a11y tests
         run: pnpm run test --filter=a11y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,6 +333,7 @@ jobs:
         run: pnpx cypress install
         env:
           CYPRESS_INSTALL_BINARY: 13.8.1
+          CYPRESS_CACHE_FOLDER: '~/.cache/Cypress/13.8.1'
 
       - name: Run a11y tests
         run: pnpm run test --filter=a11y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,8 +331,6 @@ jobs:
 
       - name: Install Cypress binary if not found
         run: pnpx cypress@13.8.1 install
-        env:
-          CYPRESS_INSTALL_BINARY: 13.8.1
 
       - name: Run a11y tests
         run: pnpm run test --filter=a11y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,10 +330,9 @@ jobs:
       - run: pnpm install
 
       - name: Install Cypress binary if not found
-        run: pnpx cypress install
+        run: pnpx cypress@13.8.1 install
         env:
           CYPRESS_INSTALL_BINARY: 13.8.1
-          CYPRESS_CACHE_FOLDER: '~/.cache/Cypress/13.8.1'
 
       - name: Run a11y tests
         run: pnpm run test --filter=a11y

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "typescript": "~5.1.6",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.18",
-    "astro": "~4.5.6"
+    "astro": "~4.5.6",
+    "cypress": "13.8.1"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   '@types/react': 18.2.14
   '@types/react-dom': 18.2.18
   astro: ~4.5.6
+  cypress: 13.8.1
 
 importers:
   .:
@@ -5235,7 +5236,7 @@ packages:
     engines: { node: '>=10' }
     peerDependencies:
       axe-core: ^3 || ^4
-      cypress: ^10 || ^11 || ^12 || ^13
+      cypress: 13.8.1
 
   cypress-image-diff-js@1.30.1:
     resolution:
@@ -5244,7 +5245,7 @@ packages:
       }
     hasBin: true
     peerDependencies:
-      cypress: '>=9.6.1'
+      cypress: 13.8.1
 
   cypress-recurse@1.20.0:
     resolution:


### PR DESCRIPTION
## Changes

This is a follow-up to #2025 to fix failing CI (again) caused by a new version of `cypress` being available.

`13.8.1` is now pinned in main `package.json` resolutions and in `pnpx cypress install` step in CI.

## Testing

CI passing. See [latest run](https://github.com/iTwin/iTwinUI/actions/runs/9003106576/job/24733030272?pr=2033).

## Docs

N/A