### PR TITLE
use `List` instead of `Menu` in `ComboBox`

### DIFF
--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -78,6 +78,7 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
     popover.open && (
       <Portal portal>
         <List
+          as='div'
           className={cx('iui-menu', className)}
           id={`${id}-list`}
           role='listbox'

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import cx from 'classnames';
 import { Menu } from '../Menu/Menu.js';
 import {
   useSafeContext,
@@ -13,6 +14,7 @@ import {
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { ComboBoxStateContext, ComboBoxRefsContext } from './helpers.js';
+import { List } from '../List/List.js';
 
 type ComboBoxMenuProps = Omit<
   React.ComponentPropsWithoutRef<typeof Menu>,
@@ -65,7 +67,7 @@ const VirtualizedComboBoxMenu = (props: React.ComponentProps<'div'>) => {
 };
 
 export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
-  const { children, style, ...rest } = props;
+  const { className, children, style, ...rest } = props;
   const { id, enableVirtualization, popover } =
     useSafeContext(ComboBoxStateContext);
   const { menuRef } = useSafeContext(ComboBoxRefsContext);
@@ -75,9 +77,9 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
   return (
     popover.open && (
       <Portal portal>
-        <Menu
+        <List
+          className={cx('iui-menu', className)}
           id={`${id}-list`}
-          setFocus={false}
           role='listbox'
           ref={refs}
           {...popover.getFloatingProps({
@@ -97,7 +99,7 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
           ) : (
             <VirtualizedComboBoxMenu>{children}</VirtualizedComboBoxMenu>
           )}
-        </Menu>
+        </List>
       </Portal>
     )
   );


### PR DESCRIPTION
## Changes

This is a very small change in `ComboBox`, simply replacing `Menu` with `List` while keeping the `iui-menu` styling (necessary for surface, max-height, and overflow).

The reason this works is: `ComboBox` and `Menu` have very little in common. `ComboBox` even manages its own focus and keyboard navigation, so the extra logic from `Menu` is not necessary.

**Note**: This PR is not the end state; it is simply a small step towards our [larger plan](https://github.com/iTwin/iTwinUI/pull/1942#discussion_r1581201279). Hopefully it helps ease the implementation in #2021. One thing worth pointing out is that we still recommend using `MenuItem` with the [custom renderer](https://itwinui.bentley.com/docs/combobox#custom-renderer). This is because [`ListItem`](https://itwinui.bentley.com/docs/list#interactive-states) is too low level and requires the user to manage ARIA manually (which is error prone). A proper solution for this would be to expose a more convenient `ComboBox.Option` in the future.

## Testing

Everything works the same! All tests unchanged and passing.

## Docs

N/A