### PR TITLE
use `List` instead of `Menu` in `Select`

### DIFF
--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -78,6 +78,7 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
     popover.open && (
       <Portal portal>
         <List
+          as='div'
           className={cx('iui-menu', className)}
           id={`${id}-list`}
           role='listbox'

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import cx from 'classnames';
 import { Menu } from '../Menu/Menu.js';
 import {
   useSafeContext,
@@ -13,6 +14,7 @@ import {
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { ComboBoxStateContext, ComboBoxRefsContext } from './helpers.js';
+import { List } from '../List/List.js';
 
 type ComboBoxMenuProps = Omit<
   React.ComponentPropsWithoutRef<typeof Menu>,
@@ -65,7 +67,7 @@ const VirtualizedComboBoxMenu = (props: React.ComponentProps<'div'>) => {
 };
 
 export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
-  const { children, style, ...rest } = props;
+  const { className, children, style, ...rest } = props;
   const { id, enableVirtualization, popover } =
     useSafeContext(ComboBoxStateContext);
   const { menuRef } = useSafeContext(ComboBoxRefsContext);
@@ -75,9 +77,9 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
   return (
     popover.open && (
       <Portal portal>
-        <Menu
+        <List
+          className={cx('iui-menu', className)}
           id={`${id}-list`}
-          setFocus={false}
           role='listbox'
           ref={refs}
           {...popover.getFloatingProps({
@@ -97,7 +99,7 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
           ) : (
             <VirtualizedComboBoxMenu>{children}</VirtualizedComboBoxMenu>
           )}
-        </Menu>
+        </List>
       </Portal>
     )
   );

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -158,6 +158,7 @@ it('should set focus on select and call onBlur', () => {
   expect(onBlur).not.toHaveBeenCalled();
 
   fireEvent.click(selectButton);
+  vi.runAllTimers();
   expect(selectButton).not.toHaveFocus();
   expect(onBlur).toHaveBeenCalled();
 });
@@ -308,7 +309,7 @@ it('should show selected item in menu', () => {
   fireEvent.click(select.querySelector('.iui-select-button') as HTMLElement);
   const menu = document.querySelector('.iui-menu') as HTMLElement;
   assertMenu(menu, { selectedIndex: 1 });
-  expect(scrollSpy).toHaveBeenCalledTimes(1);
+  expect(scrollSpy).toHaveBeenCalled();
 });
 
 it('should call onChange on item click', () => {

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { Menu } from '../Menu/Menu.js';
 import { MenuItem } from '../Menu/MenuItem.js';
 import type { MenuItemProps } from '../Menu/MenuItem.js';
 import {
@@ -27,6 +26,8 @@ import { SelectTag } from './SelectTag.js';
 import { SelectTagContainer } from './SelectTagContainer.js';
 import { Icon } from '../Icon/Icon.js';
 import { usePopover } from '../Popover/Popover.js';
+import { List } from '../List/List.js';
+import { Composite, CompositeItem } from '@floating-ui/react';
 
 // ----------------------------------------------------------------------------
 
@@ -396,6 +397,16 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
       : options.find((option) => option.value === value);
   }, [multiple, options, value]);
 
+  const defaultFocusedIndex = React.useMemo(() => {
+    let index = 0;
+    if (Array.isArray(value) && value.length > 0) {
+      index = options.findIndex((option) => option.value === value[0]);
+    } else if (value) {
+      index = options.findIndex((option) => option.value === value);
+    }
+    return index >= 0 ? index : 0;
+  }, [options, value]);
+
   const tagRenderer = React.useCallback((item: SelectOption<unknown>) => {
     return <SelectTag key={item.label} label={item.label} />;
   }, []);
@@ -476,8 +487,8 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
 
       {popover.open && (
         <Portal>
-          <Menu
-            role='listbox'
+          <SelectListbox
+            defaultFocusedIndex={defaultFocusedIndex}
             className={menuClassName}
             id={`${uid}-menu`}
             key={`${uid}-menu`}
@@ -492,7 +503,7 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
             ref={popover.refs.setFloating}
           >
             {menuItems}
-          </Menu>
+          </SelectListbox>
         </Portal>
       )}
     </>
@@ -763,3 +774,55 @@ type MultipleSelectButtonProps<T> = {
   selectedItemsRenderer?: (options: SelectOption<T>[]) => JSX.Element;
   tagRenderer: (item: SelectOption<T>) => JSX.Element;
 };
+
+// ----------------------------------------------------------------------------
+
+const SelectListbox = React.forwardRef((props, forwardedRef) => {
+  const {
+    defaultFocusedIndex = 0,
+    autoFocus = true,
+    children: childrenProp,
+    className,
+    ...rest
+  } = props;
+
+  const [focusedIndex, setFocusedIndex] = React.useState(defaultFocusedIndex);
+
+  const autoFocusRef = React.useCallback((element: HTMLElement | null) => {
+    queueMicrotask(() => {
+      const firstFocusable = element?.querySelector(
+        '[tabindex="0"]',
+      ) as HTMLElement | null;
+      firstFocusable?.focus();
+    });
+  }, []);
+
+  const children = React.useMemo(() => {
+    return React.Children.map(childrenProp, (child, index) =>
+      React.isValidElement(child) ? (
+        <CompositeItem
+          key={index}
+          render={child}
+          ref={child.props.ref || (child as any).ref}
+        />
+      ) : (
+        child
+      ),
+    );
+  }, [childrenProp]);
+
+  return (
+    <Composite
+      render={<List as='div' className={cx('iui-menu', className)} />}
+      orientation='vertical'
+      role='listbox'
+      aria-orientation={undefined}
+      activeIndex={focusedIndex}
+      onNavigate={setFocusedIndex}
+      ref={useMergedRefs(forwardedRef, autoFocus ? autoFocusRef : undefined)}
+      {...rest}
+    >
+      {children}
+    </Composite>
+  );
+}) as PolymorphicForwardRefComponent<'div', { defaultFocusedIndex?: number }>;

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -816,7 +816,6 @@ const SelectListbox = React.forwardRef((props, forwardedRef) => {
       render={<List as='div' className={cx('iui-menu', className)} />}
       orientation='vertical'
       role='listbox'
-      aria-orientation={undefined}
       activeIndex={focusedIndex}
       onNavigate={setFocusedIndex}
       ref={useMergedRefs(forwardedRef, autoFocus ? autoFocusRef : undefined)}


### PR DESCRIPTION
## Changes

Similar to #2034, this replaces the `Menu` component which does not belong in `Select`.

Unlike `ComboBox`, this one was relying on the focus management and keyboard navigation from `Menu`, so I replaced those parts with [`Composite`](https://floating-ui.com/docs/composite) from floating-ui. I had to add a little bit of code to tell `Composite` which indexes are active and that it should automatically move focus when the Select is opened.

## Testing

Manually tested all stories to make sure they're working as intended.

Had to slightly tweak a couple unit tests to make them pass.

## Docs

N/A