### PR TITLE
Fix docs site import error when running the `dev` script

### DIFF
--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -6,15 +6,28 @@ import * as path from 'node:path';
 
 export const itwinuiReactAliases =
   process.env.NODE_ENV === 'development'
-    ? {
-        '@itwin/itwinui-react/styles.css?url': path.resolve(
-          '../../packages/itwinui-react/styles.css?url',
-        ),
-        '@itwin/itwinui-react/styles.css': path.resolve(
-          '../../packages/itwinui-react/styles.css',
-        ),
-        '@itwin/itwinui-react': path.resolve(
-          '../../packages/itwinui-react/src',
-        ),
-      }
-    : {};
+    ? [
+        {
+          find: /^@itwin\/itwinui-react$/,
+          replacement: path.resolve(
+            '../../packages/itwinui-react/src/index.ts',
+          ),
+        },
+        {
+          find: /^@itwin\/itwinui-react\/styles.css(.*)$/,
+          replacement: path.resolve(
+            '../../packages/itwinui-react/styles.css$1',
+          ),
+        },
+        {
+          find: /^@itwin\/itwinui-react\/react-table$/,
+          replacement: path.resolve(
+            '../../packages/itwinui-react/react-table.d.ts',
+          ),
+        },
+        {
+          find: /^@itwin\/itwinui-react\/(.*)$/,
+          replacement: path.resolve('../../packages/itwinui-react/src/$1'),
+        },
+      ]
+    : [];

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -8,21 +8,13 @@ export const itwinuiReactAliases =
   process.env.NODE_ENV === 'development'
     ? [
         {
-          find: /^@itwin\/itwinui-react$/,
+          find: /^@itwin\/itwinui-react\/(.*)/,
+          replacement: path.resolve('../../packages/itwinui-react/$1'),
+        },
+        {
+          find: '@itwin/itwinui-react',
           replacement: path.resolve(
             '../../packages/itwinui-react/src/index.ts',
-          ),
-        },
-        {
-          find: /^@itwin\/itwinui-react\/styles.css(.*)$/,
-          replacement: path.resolve(
-            '../../packages/itwinui-react/styles.css$1',
-          ),
-        },
-        {
-          find: /^@itwin\/itwinui-react\/react-table$/,
-          replacement: path.resolve(
-            '../../packages/itwinui-react/react-table.d.ts',
           ),
         },
       ]

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -7,6 +7,9 @@ import * as path from 'node:path';
 export const itwinuiReactAliases =
   process.env.NODE_ENV === 'development'
     ? {
+        '@itwin/itwinui-react/styles.css?url': path.resolve(
+          '../../packages/itwinui-react/styles.css?url',
+        ),
         '@itwin/itwinui-react/styles.css': path.resolve(
           '../../packages/itwinui-react/styles.css',
         ),

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -20,6 +20,12 @@ export const itwinuiReactAliases =
           ),
         },
         {
+          find: /^@itwin\/itwinui-react\/react-table$/,
+          replacement: path.resolve(
+            '../../packages/itwinui-react/react-table.d.ts',
+          ),
+        },
+        {
           find: /^@itwin\/itwinui-react\/(.*)$/,
           replacement: path.resolve('../../packages/itwinui-react/src/$1'),
         },

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -20,12 +20,6 @@ export const itwinuiReactAliases =
           ),
         },
         {
-          find: /^@itwin\/itwinui-react\/react-table$/,
-          replacement: path.resolve(
-            '../../packages/itwinui-react/react-table.d.ts',
-          ),
-        },
-        {
           find: /^@itwin\/itwinui-react\/(.*)$/,
           replacement: path.resolve('../../packages/itwinui-react/src/$1'),
         },

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -25,9 +25,5 @@ export const itwinuiReactAliases =
             '../../packages/itwinui-react/react-table.d.ts',
           ),
         },
-        {
-          find: /^@itwin\/itwinui-react\/(.*)$/,
-          replacement: path.resolve('../../packages/itwinui-react/src/$1'),
-        },
       ]
     : [];


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

After #2024, @FlyersPh9 and I started noticing the below error when opening any docs site's pages with the path `/docs/…`

<img width="1238" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/abe764e2-b76d-4a13-9506-1f2d094416f7">

Seems like the `?url` in the import in LiveExample is causing some issue.

https://github.com/iTwin/iTwinUI/blob/f699eb774e74b1ee08a0edb7729f1e5446c2f8aa/apps/website/src/components/LiveExample.astro#L6

~This PR adds a [`resolve.alias`](https://vitejs.dev/config/shared-options.html#resolve-alias) for this import too.~ Instead changed the `resolve.alias` to be find and replacement rules (https://github.com/iTwin/iTwinUI/pull/2038#discussion_r1596099089).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the docs site's `/docs/…` pages open without any errors. Also confirmed that other workspaces continue working.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A