### PR TITLE
Fix alignment in the `Input.separatelabel.jsx` docs site example

### DIFF
--- a/examples/Input.separatelabel.css
+++ b/examples/Input.separatelabel.css
@@ -1,18 +1,7 @@
 .demo-container {
-  display: flex;
+  display: grid;
   gap: var(--iui-size-xs);
-}
-
-.demo-labels-container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: var(--iui-size-m);
-}
-
-.demo-inputs-container {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--iui-size-xs);
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  justify-items: end;
 }

--- a/examples/Input.separatelabel.jsx
+++ b/examples/Input.separatelabel.jsx
@@ -8,16 +8,12 @@ import { Input, Label } from '@itwin/itwinui-react';
 export default () => {
   return (
     <div className='demo-container'>
-      <div className='demo-labels-container'>
-        <Label htmlFor='first-name'>First name</Label>
-        <Label htmlFor='middle-initial'>Middle initial</Label>
-        <Label htmlFor='last-name'>Last name</Label>
-      </div>
-      <div className='demo-inputs-container'>
-        <Input id='first-name' />
-        <Input id='middle-initial' maxlength='1' />
-        <Input id='last-name' />
-      </div>
+      <Label htmlFor='first-name'>First name</Label>
+      <Input id='first-name' />
+      <Label htmlFor='middle-initial'>Middle initial</Label>
+      <Input id='middle-initial' maxlength='1' />
+      <Label htmlFor='last-name'>Last name</Label>
+      <Input id='last-name' />
     </div>
   );
 };

--- a/internal/helpers/index.js
+++ b/internal/helpers/index.js
@@ -7,6 +7,9 @@ import * as path from 'node:path';
 export const itwinuiReactAliases =
   process.env.NODE_ENV === 'development'
     ? {
+        '@itwin/itwinui-react/styles.css?url': path.resolve(
+          '../../packages/itwinui-react/styles.css?url',
+        ),
         '@itwin/itwinui-react/styles.css': path.resolve(
           '../../packages/itwinui-react/styles.css',
         ),


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@FlyersPh9 pointed out that the alignment of the labels and the inputs in `Input.separatelabel.jsx` seemed incorrect ([link](https://itwinui.bentley.com/docs/input#standalone)):

<img width="316" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/736ea4a3-4fb3-4fb1-abfa-c89eab311978">

This PR fixes that alignment by having one div with `display: grid` instead of two disjoint divs with `display: flex`:

<img width="320" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/f2fca309-c21a-4a15-a9ff-6b39fe2f8487">

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the alignment of the labels and the inputs in `Input.separatelabel.jsx` now looks correct.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A