### PR TITLE
Use `useLatestRef` internally

### DIFF
--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -9,6 +9,7 @@ import {
   useMergedRefs,
   useContainerWidth,
   mergeEventHandlers,
+  useLatestRef,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { ComboBoxMultipleContainer } from './ComboBoxMultipleContainer.js';
@@ -41,10 +42,7 @@ export const ComboBoxInput = React.forwardRef((props, forwardedRef) => {
     useSafeContext(ComboBoxRefsContext);
   const refs = useMergedRefs(inputRef, popover.refs.setReference, forwardedRef);
 
-  const focusedIndexRef = React.useRef(focusedIndex ?? -1);
-  React.useEffect(() => {
-    focusedIndexRef.current = focusedIndex ?? -1;
-  }, [focusedIndex]);
+  const focusedIndexRef = useLatestRef(focusedIndex ?? -1);
 
   const getIdFromIndex = (index: number) => {
     return (
@@ -177,6 +175,7 @@ export const ComboBoxInput = React.forwardRef((props, forwardedRef) => {
     [
       dispatch,
       enableVirtualization,
+      focusedIndexRef,
       isOpen,
       menuRef,
       onClickHandler,

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -38,6 +38,7 @@ import {
   ShadowRoot,
   LineClamp,
   useMergedRefs,
+  useLatestRef,
 } from '../../utils/index.js';
 import type { CommonProps } from '../../utils/index.js';
 import {
@@ -440,13 +441,8 @@ export const Table = <
     [],
   );
 
-  // useRef prevents from rerendering when one of these callbacks changes
-  const onBottomReachedRef = React.useRef(onBottomReached);
-  const onRowInViewportRef = React.useRef(onRowInViewport);
-  React.useEffect(() => {
-    onBottomReachedRef.current = onBottomReached;
-    onRowInViewportRef.current = onRowInViewport;
-  }, [onBottomReached, onRowInViewport]);
+  const onBottomReachedRef = useLatestRef(onBottomReached);
+  const onRowInViewportRef = useLatestRef(onRowInViewport);
 
   const hasManualSelectionColumn = React.useMemo(() => {
     const flatColumns = flattenColumns(columns);
@@ -861,6 +857,8 @@ export const Table = <
       enableVirtualization,
       tableRowRef,
       density,
+      onBottomReachedRef,
+      onRowInViewportRef,
     ],
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I stumbled upon some code in `Table.tsx` that seemed to be doing the same thing as our util function, `useLatestRef`. So, this PR replaces that code with `useLatestRef`. I also did a quick global search to make it in all other places I could find.

In `Tree.tsx`, after changing `flatNodesListRef` to use `useLatestRef`, I got a warning that `flatNodesListRef` should be added to the dep list of the adjacent `useEffect`. But I believe doing that will break the logic of the `useEffect`. Thus, I left that unchanged.

<details>
<summary>Relevant code from Tree.tsx</summary>

https://github.com/iTwin/iTwinUI/blob/f699eb774e74b1ee08a0edb7729f1e5446c2f8aa/packages/itwinui-react/src/core/Tree/Tree.tsx#L294-L313

</details>

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

All tests passing.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A