### PR TITLE
use `undefined` instead of `''` in inline style

### DIFF
--- a/.changeset/soft-peas-notice.md
+++ b/.changeset/soft-peas-notice.md
@@ -1,0 +1,5 @@
+---
+"@itwin/itwinui-react": patch
+---
+
+Fixed a rare hydration error in `Surface` caused by using an empty string inside the `style` attribute.

--- a/packages/itwinui-react/src/core/Surface/Surface.tsx
+++ b/packages/itwinui-react/src/core/Surface/Surface.tsx
@@ -25,7 +25,7 @@ const getSurfaceElevationValue = (elevation: SurfaceProps['elevation']) => {
     case 5:
       return 'var(--iui-shadow-5)';
     default:
-      return '';
+      return undefined;
   }
 };
 
@@ -39,7 +39,7 @@ const getBorderValue = (border: boolean | string | undefined) => {
     return 'none';
   }
 
-  return '';
+  return undefined;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

This fixes a small hydration error when using `Surface` with SSR environments like `next`/`remix`/`astro`.

## Testing

**Before**:
```console
Warning: Prop `style` did not match.
Server: "null"
Client: "--iui-surface-elevation:;--iui-surface-border:"
```

**After**:
No more hydration error!

## Docs

Added changeset.