### PR TITLE
add `await`s to e2e tests to reduce flakiness

### DIFF
--- a/testing/e2e/app/routes/DropdownMenu/spec.ts
+++ b/testing/e2e/app/routes/DropdownMenu/spec.ts
@@ -7,29 +7,29 @@ test.describe('DropdownMenu', () => {
     const trigger = page.getByTestId('trigger');
     await trigger.click();
 
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
 
     // Go to the deepest level using keyboard
     await page.keyboard.press('ArrowRight', keyboardPressOptions);
-    expect(page.getByTestId('Item 2_1')).toBeFocused();
+    await expect(page.getByTestId('Item 2_1')).toBeFocused();
 
     await page.keyboard.press('ArrowDown', keyboardPressOptions);
-    expect(page.getByTestId('Item 2_2')).toBeFocused();
+    await expect(page.getByTestId('Item 2_2')).toBeFocused();
 
     await page.keyboard.press('ArrowDown', keyboardPressOptions);
-    expect(page.getByTestId('Item 2_3')).toBeFocused();
+    await expect(page.getByTestId('Item 2_3')).toBeFocused();
 
     await page.keyboard.press('ArrowRight', keyboardPressOptions);
-    expect(page.getByTestId('Item 3_1')).toBeFocused();
+    await expect(page.getByTestId('Item 3_1')).toBeFocused();
 
     await page.keyboard.press('ArrowDown', keyboardPressOptions);
-    expect(page.getByTestId('Item 3_2')).toBeFocused();
+    await expect(page.getByTestId('Item 3_2')).toBeFocused();
 
     await page.keyboard.press('ArrowDown', keyboardPressOptions);
-    expect(page.getByTestId('Item 3_3')).toBeFocused();
+    await expect(page.getByTestId('Item 3_3')).toBeFocused();
 
     await page.keyboard.press('ArrowRight', keyboardPressOptions);
-    expect(page.getByTestId('Item 3_3_1')).toBeFocused();
+    await expect(page.getByTestId('Item 3_3_1')).toBeFocused();
 
     // Hovering out of a submenu should not close the entire menu tree
     await moveMouseWithRespectToComponent({
@@ -41,7 +41,7 @@ test.describe('DropdownMenu', () => {
 
     // If the last menu item of the tree is visible, the whole tree is visible.
     // So just checking for the last item is enough.
-    expect(page.getByTestId('Item 3_3_1')).toBeFocused();
+    await expect(page.getByTestId('Item 3_3_1')).toBeFocused();
 
     // Hovering an ancestor "X" that has a submenu "Y" should close all submenus of "Y"
     await moveMouseWithRespectToComponent({
@@ -51,12 +51,12 @@ test.describe('DropdownMenu', () => {
       page,
     });
 
-    expect(page.getByTestId('Item 2_1')).toBeVisible();
-    expect(page.getByTestId('Item 2_2')).toBeVisible();
-    expect(page.getByTestId('Item 2_3')).toBeVisible();
-    expect(page.getByTestId('Item 3_1')).toBeHidden();
-    expect(page.getByTestId('Item 3_2')).toBeHidden();
-    expect(page.getByTestId('Item 3_3')).toBeHidden();
+    await expect(page.getByTestId('Item 2_1')).toBeVisible();
+    await expect(page.getByTestId('Item 2_2')).toBeVisible();
+    await expect(page.getByTestId('Item 2_3')).toBeVisible();
+    await expect(page.getByTestId('Item 3_1')).toBeHidden();
+    await expect(page.getByTestId('Item 3_2')).toBeHidden();
+    await expect(page.getByTestId('Item 3_3')).toBeHidden();
 
     // Go to the deepest level using mouse.
     // Hovering an element should focus it.
@@ -66,7 +66,7 @@ test.describe('DropdownMenu', () => {
       componentTestId: 'Item 2_3',
       page,
     });
-    expect(page.getByTestId('Item 2_3')).toBeFocused();
+    await expect(page.getByTestId('Item 2_3')).toBeFocused();
 
     await moveMouseWithRespectToComponent({
       side: 'left',
@@ -74,7 +74,7 @@ test.describe('DropdownMenu', () => {
       componentTestId: 'Item 3_3',
       page,
     });
-    expect(page.getByTestId('Item 3_3')).toBeFocused();
+    await expect(page.getByTestId('Item 3_3')).toBeFocused();
 
     await moveMouseWithRespectToComponent({
       side: 'left',
@@ -82,7 +82,7 @@ test.describe('DropdownMenu', () => {
       componentTestId: 'Item 3_3_1',
       page,
     });
-    expect(page.getByTestId('Item 3_3_1')).toBeFocused();
+    await expect(page.getByTestId('Item 3_3_1')).toBeFocused();
 
     // When a node "X" is focused, should close "X"'s siblings' submenus
     // i.e. only one submenu in each menu should be open at a time
@@ -99,8 +99,8 @@ test.describe('DropdownMenu', () => {
       page,
     });
 
-    expect(page.getByTestId('Item 3_2_1')).toBeVisible();
-    expect(page.getByTestId('Item 3_3_1')).toBeHidden();
+    await expect(page.getByTestId('Item 3_2_1')).toBeVisible();
+    await expect(page.getByTestId('Item 3_3_1')).toBeHidden();
 
     await page.waitForTimeout(100);
   });
@@ -113,27 +113,27 @@ test.describe('DropdownMenu', () => {
     const trigger = page.getByTestId('trigger');
     await trigger.click();
 
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
 
     await page.getByTestId('Item 1_1').click();
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
-    expect(page.getByTestId('Item 2_1')).toBeVisible();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 2_1')).toBeVisible();
 
     await page.getByTestId('Item 1_1').click();
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
-    expect(page.getByTestId('Item 2_1')).toBeHidden();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 2_1')).toBeHidden();
 
     await page.keyboard.press('Enter', keyboardPressOptions);
-    expect(page.getByTestId('Item 2_1')).toBeFocused();
+    await expect(page.getByTestId('Item 2_1')).toBeFocused();
 
     await page.keyboard.press('ArrowLeft', keyboardPressOptions);
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
 
     await page.keyboard.press('Space', keyboardPressOptions);
-    expect(page.getByTestId('Item 2_1')).toBeFocused();
+    await expect(page.getByTestId('Item 2_1')).toBeFocused();
 
     await page.keyboard.press('ArrowLeft', keyboardPressOptions);
-    expect(page.getByTestId('Item 1_1')).toBeFocused();
+    await expect(page.getByTestId('Item 1_1')).toBeFocused();
   });
 
   test('should close entire menu on pressing escape or tab key', async ({
@@ -164,7 +164,7 @@ test.describe('DropdownMenu', () => {
     await trigger.click();
 
     await expect(page.getByTestId('Item 1_1')).toBeFocused();
-    goToTheDeepestLevel();
+    await goToTheDeepestLevel();
     await expect(page.getByTestId('Item 3_3_1')).toBeFocused();
 
     await page.keyboard.press('Tab', keyboardPressOptions);
@@ -177,13 +177,13 @@ test.describe('DropdownMenu', () => {
     const trigger = page.getByTestId('trigger');
 
     await page.keyboard.press('Tab', keyboardPressOptions);
-    expect(trigger).toBeFocused();
+    await expect(trigger).toBeFocused();
 
     await trigger.click();
-    expect(trigger).not.toBeFocused();
+    await expect(trigger).not.toBeFocused();
 
     await trigger.click();
-    expect(trigger).toBeFocused();
+    await expect(trigger).toBeFocused();
   });
 });
 

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -5,21 +5,21 @@ test.describe('Table sorting', () => {
     await page.goto('/Table');
 
     const firstColumnCells = page.locator('[role="cell"]:first-child');
-    expect(firstColumnCells).toHaveText(['1', '2', '3']);
+    await expect(firstColumnCells).toHaveText(['1', '2', '3']);
 
     await page.keyboard.press('Tab');
 
     // ascending
     await page.keyboard.press('Enter');
-    expect(firstColumnCells).toHaveText(['1', '2', '3']);
+    await expect(firstColumnCells).toHaveText(['1', '2', '3']);
 
     // descending
     await page.keyboard.press('Enter');
-    expect(firstColumnCells).toHaveText(['3', '2', '1']);
+    await expect(firstColumnCells).toHaveText(['3', '2', '1']);
 
     // ascending again
     await page.keyboard.press('Enter');
-    expect(firstColumnCells).toHaveText(['1', '2', '3']);
+    await expect(firstColumnCells).toHaveText(['1', '2', '3']);
   });
 });
 


### PR DESCRIPTION
## Changes

Self-explanatory title. The lack of `await` makes tests randomly fail in CI.

See https://playwright.dev/docs/test-assertions

## Testing

All tests continue to pass, hopefully more predictably now.

## Docs

N/A