### PR TITLE
use `popover` API in `Tooltip` if supported

### DIFF
--- a/.changeset/quick-ligers-serve.md
+++ b/.changeset/quick-ligers-serve.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': minor
+---
+
+Added support for `popover` attribute in `iui-tooltip`.

--- a/.changeset/tender-forks-visit.md
+++ b/.changeset/tender-forks-visit.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`Tooltip` will now automatically use the [`popover` API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) in supported browsers. This ensures that tooltips appear in the top layer, avoiding stacking context issues.

--- a/apps/website/src/content/docs/tooltip.mdx
+++ b/apps/website/src/content/docs/tooltip.mdx
@@ -37,7 +37,7 @@ There are some advanced props available for more granular control over positioni
 
 ### Portals
 
-It is important to know that before calculating the position, the tooltip gets [portaled](https://react.dev/reference/react-dom/createPortal) into the nearest [`ThemeProvider`](themeprovider) to avoid [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) issues. This behavior can be controlled using the Tooltip's `portal` prop or the ThemeProvider's [`portalContainer`](themeprovider#portals) prop.
+It is important to know that before calculating the position, the tooltip gets [portaled](https://react.dev/reference/react-dom/createPortal) into the nearest [`ThemeProvider`](themeprovider). This is done to avoid [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) issues in browsers where the [`popover` API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) is not supported. This portaling behavior can be controlled using the Tooltip's `portal` prop or the ThemeProvider's [`portalContainer`](themeprovider#portals) prop.
 
 ## Accessibility
 

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -23,7 +23,7 @@
 
   @include mixins.iui-blur($hsl: 0 0% 0%, $opacity: 3);
 
-  &[hidden] {
+  &:where([hidden], [popover]:not(:popover-open)) {
     display: none !important;
   }
 }

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -20,7 +20,7 @@ it('should toggle the visibility of tooltip on hover', () => {
 
   const tooltip = getByText('some text');
   expect(tooltip).not.toBeVisible();
-  expect(tooltip).toHaveAttribute('popover');
+  expect(tooltip).toHaveAttribute('popover', 'manual');
 
   fireEvent.mouseEnter(trigger);
   expect(tooltip).toBeVisible();
@@ -46,7 +46,7 @@ it('should toggle the visibility of tooltip on focus', async () => {
 
   const tooltip = getByText('some text');
   expect(tooltip).not.toBeVisible();
-  expect(tooltip).toHaveAttribute('popover');
+  expect(tooltip).toHaveAttribute('popover', 'manual');
 
   fireEvent.focus(trigger);
   act(() => void vi.advanceTimersByTime(50));

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -20,6 +20,7 @@ it('should toggle the visibility of tooltip on hover', () => {
 
   const tooltip = getByText('some text');
   expect(tooltip).not.toBeVisible();
+  expect(tooltip).toHaveAttribute('popover');
 
   fireEvent.mouseEnter(trigger);
   expect(tooltip).toBeVisible();
@@ -45,6 +46,7 @@ it('should toggle the visibility of tooltip on focus', async () => {
 
   const tooltip = getByText('some text');
   expect(tooltip).not.toBeVisible();
+  expect(tooltip).toHaveAttribute('popover');
 
   fireEvent.focus(trigger);
   act(() => void vi.advanceTimersByTime(50));

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -120,6 +120,11 @@ type TooltipOwnProps = {
   children?: React.ReactNode;
 } & PortalProps;
 
+// TODO: Remove this when types are available
+type HTMLElementWithPopover = HTMLElement & {
+  togglePopover: (force?: boolean) => void;
+};
+
 // ----------------------------------------------------------------------------
 
 const useTooltip = (options: TooltipOptions = {}) => {
@@ -136,13 +141,12 @@ const useTooltip = (options: TooltipOptions = {}) => {
     ...props
   } = options;
 
-  const tooltipRef = React.useRef<HTMLElement | null>(null);
+  const tooltipRef = React.useRef<HTMLElementWithPopover | null>(null);
   const latestOnVisibleChange = useLatestRef(onVisibleChangeProp);
 
   const syncWithControlledState = React.useCallback(
-    (element: HTMLElement | null) => {
+    (element: HTMLElementWithPopover | null) => {
       if (element && visibleProp !== undefined) {
-        // @ts-expect-error -- types not available yet
         element?.togglePopover?.(visibleProp);
       }
     },
@@ -151,7 +155,6 @@ const useTooltip = (options: TooltipOptions = {}) => {
 
   const onVisibleChange = React.useCallback(
     (visible: boolean) => {
-      // @ts-expect-error -- types not available yet
       tooltipRef.current?.togglePopover?.(visible);
       latestOnVisibleChange.current?.(visible);
     },
@@ -289,8 +292,8 @@ const useTooltip = (options: TooltipOptions = {}) => {
       refs: {
         ...floating.refs,
         setFloating: (element: HTMLElement | null) => {
-          tooltipRef.current = element;
-          syncWithControlledState(element);
+          tooltipRef.current = element as HTMLElementWithPopover;
+          syncWithControlledState(element as HTMLElementWithPopover);
           floating.refs.setFloating(element);
         },
       },

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -155,8 +155,7 @@ const useTooltip = (options: TooltipOptions = {}) => {
     try {
       tooltipRef.current?.togglePopover?.(open);
     } catch {
-      // This try-catch is a way to fail silently, because popover will otherwise
-      // throw if it fails for any reason (e.g. the element is not currently mounted)
+      // Fail silently, to avoid crashing the page
     }
   }, [open]);
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -147,7 +147,14 @@ const useTooltip = (options: TooltipOptions = {}) => {
   );
 
   const syncWithControlledState = React.useCallback(
-    (element: HTMLElementWithPopover | null) => element?.togglePopover?.(open),
+    (element: HTMLElementWithPopover | null) => {
+      try {
+        queueMicrotask(() => element?.togglePopover?.(open));
+      } catch {
+        // This try-catch is a way to fail silently, because popover will otherwise
+        // throw if it fails for any reason (e.g. the element is not currently mounted)
+      }
+    },
     [open],
   );
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -29,7 +29,6 @@ import {
   cloneElementWithRef,
   useControlledState,
   useId,
-  useLayoutEffect,
   useMergedRefs,
 } from '../../utils/index.js';
 import type {
@@ -151,12 +150,15 @@ const useTooltip = (options: TooltipOptions = {}) => {
   );
 
   // Synchronize popover visibility (DOM) with open state (React)
-  useLayoutEffect(() => {
-    try {
-      tooltipRef.current?.togglePopover?.(open);
-    } catch {
-      // Fail silently, to avoid crashing the page
-    }
+  React.useEffect(() => {
+    // Using a microtask ensures that the popover is mounted before calling togglePopover
+    queueMicrotask(() => {
+      try {
+        tooltipRef.current?.togglePopover?.(open);
+      } catch {
+        // Fail silently, to avoid crashing the page
+      }
+    });
   }, [open]);
 
   const floating = useFloating({

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -141,25 +141,25 @@ const useTooltip = (options: TooltipOptions = {}) => {
     ...props
   } = options;
 
-  const tooltipRef = React.useRef<HTMLElementWithPopover>();
-
   const [open, onOpenChange] = useControlledState(
     false,
     visible,
     onVisibleChange,
   );
 
-  // Synchronize popover visibility (DOM) with open state (React)
-  React.useEffect(() => {
-    // Using a microtask ensures that the popover is mounted before calling togglePopover
-    queueMicrotask(() => {
-      try {
-        tooltipRef.current?.togglePopover?.(open);
-      } catch {
-        // Fail silently, to avoid crashing the page
-      }
-    });
-  }, [open]);
+  const syncWithControlledState = React.useCallback(
+    (element: HTMLElementWithPopover | null) => {
+      // Using a microtask ensures that the popover is mounted before calling togglePopover
+      queueMicrotask(() => {
+        try {
+          element?.togglePopover?.(open);
+        } catch {
+          // Fail silently, to avoid crashing the page
+        }
+      });
+    },
+    [open],
+  );
 
   const floating = useFloating({
     placement,
@@ -287,13 +287,13 @@ const useTooltip = (options: TooltipOptions = {}) => {
         ...floating.refs,
         setFloating: (element: HTMLElement | null) => {
           floating.refs.setFloating(element);
-          tooltipRef.current = element as HTMLElementWithPopover;
+          syncWithControlledState(element);
         },
       },
       // styles are not relevant when tooltip is not open
       floatingStyles: floating.context.open ? floating.floatingStyles : {},
     }),
-    [getReferenceProps, floatingProps, floating],
+    [getReferenceProps, floatingProps, floating, syncWithControlledState],
   );
 };
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -39,11 +39,6 @@ import type {
 
 // ----------------------------------------------------------------------------
 
-const isPopoverSupported = () =>
-  typeof HTMLElement !== 'undefined' && 'popover' in HTMLElement.prototype;
-
-// ----------------------------------------------------------------------------
-
 type TooltipOptions = {
   /**
    * Placement of the Tooltip
@@ -143,28 +138,24 @@ const useTooltip = (options: TooltipOptions = {}) => {
 
   const tooltipRef = React.useRef<HTMLElement | null>(null);
   const latestOnVisibleChange = useLatestRef(onVisibleChangeProp);
-  const supportsPopover = React.useMemo(() => isPopoverSupported(), []);
 
   const syncWithControlledState = React.useCallback(
     (element: HTMLElement | null) => {
-      // Toggle popover visibility when visibleProp changes
-      if (element && visibleProp !== undefined && supportsPopover) {
+      if (element && visibleProp !== undefined) {
         // @ts-expect-error -- types not available yet
         element?.togglePopover?.(visibleProp);
       }
     },
-    [visibleProp, supportsPopover],
+    [visibleProp],
   );
 
   const onVisibleChange = React.useCallback(
     (visible: boolean) => {
-      if (supportsPopover) {
-        // @ts-expect-error -- types not available yet
-        tooltipRef.current?.togglePopover?.(visible);
-      }
+      // @ts-expect-error -- types not available yet
+      tooltipRef.current?.togglePopover?.(visible);
       latestOnVisibleChange.current?.(visible);
     },
-    [latestOnVisibleChange, supportsPopover],
+    [latestOnVisibleChange],
   );
 
   const [open, onOpenChange] = useControlledState(
@@ -285,9 +276,9 @@ const useTooltip = (options: TooltipOptions = {}) => {
         ...props,
         id,
       }),
-      popover: supportsPopover ? 'manual' : undefined,
+      popover: 'manual',
     }),
-    [interactions, props, id, open, supportsPopover],
+    [interactions, props, id, open],
   );
 
   return React.useMemo(


### PR DESCRIPTION
## Changes

When supported, [`popover=manual`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#using_manual_popover_state) will be used to show the tooltip in the [top-layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer). In non-supported browsers, the attribute is ignored.

In addition to the `popover` attribute itself, there are only two changes:
- **JS**: Calling [`togglePopover`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover) whenever the React state changes.
  - This is guarded using `?.` for supporting older browsers.
  - This also required adding a custom TS type, which can be removed in the future.
- **CSS**: Hiding the tooltip when [`:popover-open`](https://developer.mozilla.org/en-US/docs/Web/CSS/:popover-open) doesn't match.

I kept the existing mechanism (`Portal` component, `z-index` property, `hidden` attribute), so `Tooltip` will continue to work in browsers that don't support popover.

## Testing

All existing tests pass 🚀

Tested manually that hover/focus behaviors are intact and that the tooltip does indeed show in the top layer (This can be verified in Chrome dev tools, for example). Also emulated older browsers by commenting out `popover` and testing that it works fine.

<img src="https://github.com/iTwin/iTwinUI/assets/9084735/639f84b8-c921-4fc0-b64c-ed40c0c71e12" width="300">

Updated unit tests to simply check for the presence of the `popover` attribute. I spent some time looking into adding tests for `togglePopover` without success, since [JSDOM doesn't support it](https://redirect.github.com/jsdom/jsdom/issues/3721). This is not a big deal imo; the visual tests already serve as a way to ensure that the tooltip is working.

## Docs

Added changesets for both CSS and React.

Updated Tooltip documentation to mention that portaling is useful only in browsers that don't support `popover`.