### PR TITLE
bump `lightningcss` to `1.25.0`

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -28,7 +28,7 @@
     "astro-expressive-code": "^0.33.5",
     "examples": "workspace:*",
     "htm": "^3",
-    "lightningcss": "^1.22.1",
+    "lightningcss": "^1.25.0",
     "nanoid": "*",
     "nanostores": "^0.9.0",
     "outdent": "^0.8.0",

--- a/packages/itwinui-css/package.json
+++ b/packages/itwinui-css/package.json
@@ -39,7 +39,7 @@
   "dependencies": {},
   "devDependencies": {
     "chokidar": "^3.5.3",
-    "lightningcss": "^1.21.5",
+    "lightningcss": "^1.25.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.31",
     "sass": "^1.63.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,10 +90,10 @@ importers:
         version: 0.20.0
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       astro-relative-links:
         specifier: ^0.3.7
-        version: 0.3.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+        version: 0.3.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       backstopjs:
         specifier: ~6.2.1
         version: 6.2.2(typescript@5.1.6)
@@ -105,7 +105,7 @@ importers:
     dependencies:
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
 
   apps/react-workshop:
     devDependencies:
@@ -126,7 +126,7 @@ importers:
         version: link:../../packages/itwinui-variables
       '@ladle/react':
         specifier: ^4.0.2
-        version: 4.0.2(@swc/helpers@0.5.5)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.24.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.1.6)
+        version: 4.0.2(@swc/helpers@0.5.5)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.1.6)
       '@types/node':
         specifier: '*'
         version: 18.17.19
@@ -159,16 +159,16 @@ importers:
         version: 5.1.6
       vite:
         specifier: '*'
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
 
   apps/website:
     dependencies:
       '@astrojs/mdx':
         specifier: '2'
-        version: 2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6))
+        version: 2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6))
       '@astrojs/react':
         specifier: '3'
-        version: 3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       '@astrojs/sitemap':
         specifier: '3'
         version: 3.1.1
@@ -201,13 +201,13 @@ importers:
         version: 18.2.14
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       astro-auto-import:
         specifier: ^0.4.2
-        version: 0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6))
+        version: 0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6))
       astro-expressive-code:
         specifier: ^0.33.5
-        version: 0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6))
+        version: 0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6))
       examples:
         specifier: workspace:*
         version: link:../../examples
@@ -215,8 +215,8 @@ importers:
         specifier: ^3
         version: 3.1.1
       lightningcss:
-        specifier: ^1.22.1
-        version: 1.24.1
+        specifier: ^1.25.0
+        version: 1.25.0
       nanoid:
         specifier: '*'
         version: 5.0.6
@@ -316,8 +316,8 @@ importers:
         specifier: ^3.5.3
         version: 3.5.3
       lightningcss:
-        specifier: ^1.21.5
-        version: 1.24.1
+        specifier: ^1.25.0
+        version: 1.25.0
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -363,7 +363,7 @@ importers:
         version: 1.3.101(@swc/helpers@0.5.5)
       '@testing-library/jest-dom':
         specifier: ^6.3.0
-        version: 6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))
       '@testing-library/react':
         specifier: ^13.2.0
         version: 13.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -384,7 +384,7 @@ importers:
         version: 4.4.10
       '@vitest/coverage-v8':
         specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))
       eslint:
         specifier: ^8
         version: 8.56.0
@@ -408,10 +408,10 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^5.1.7
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
       vitest:
         specifier: ^1.2.1
-        version: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
 
   packages/itwinui-variables:
     devDependencies:
@@ -423,13 +423,13 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: '3'
-        version: 3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       '@itwin/itwinui-react':
         specifier: '*'
         version: link:../../packages/itwinui-react
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -490,7 +490,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       '@types/react':
         specifier: 18.2.14
         version: 18.2.14
@@ -502,10 +502,10 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
 
   playgrounds/vite:
     dependencies:
@@ -530,13 +530,13 @@ importers:
         version: 18.2.18
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       typescript:
         specifier: ~5.1.6
         version: 5.1.6
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
 
   testing/a11y:
     dependencies:
@@ -585,7 +585,7 @@ importers:
         version: 1.42.1
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
       '@types/node':
         specifier: '*'
         version: 18.17.19
@@ -603,10 +603,10 @@ importers:
         version: 5.1.6
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))
+        version: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
 
 packages:
   '@aashutoshrathi/word-wrap@1.2.6':
@@ -8273,91 +8273,91 @@ packages:
       }
     engines: { node: '>= 0.8.0' }
 
-  lightningcss-darwin-arm64@1.24.1:
+  lightningcss-darwin-arm64@1.25.0:
     resolution:
       {
-        integrity: sha512-1jQ12jBy+AE/73uGQWGSafK5GoWgmSiIQOGhSEXiFJSZxzV+OXIx+a9h2EYHxdJfX864M+2TAxWPWb0Vv+8y4w==,
+        integrity: sha512-neCU5PrQUAec/b2mpXv13rrBWObQVaG/y0yhGKzAqN9cj7lOv13Wegnpiro0M66XAxx/cIkZfmJstRfriOR2SQ==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.24.1:
+  lightningcss-darwin-x64@1.25.0:
     resolution:
       {
-        integrity: sha512-R4R1d7VVdq2mG4igMU+Di8GPf0b64ZLnYVkubYnGG0Qxq1KaXQtAzcLI43EkpnoWvB/kUg8JKCWH4S13NfiLcQ==,
+        integrity: sha512-h1XBxDHdED7TY4/1V30UNjiqXceGbcL8ARhUfbf8CWAEhD7wMKK/4UqMHi94RDl31ko4LTmt9fS2u1uyeWYE6g==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.24.1:
+  lightningcss-freebsd-x64@1.25.0:
     resolution:
       {
-        integrity: sha512-z6NberUUw5ALES6Ixn2shmjRRrM1cmEn1ZQPiM5IrZ6xHHL5a1lPin9pRv+w6eWfcrEo+qGG6R9XfJrpuY3e4g==,
+        integrity: sha512-f7v6QwrqCFtQOG1Y7iZ4P1/EAmMsyUyRBrYbSmDxihMzdsL7xyTM753H2138/oCpam+maw2RZrXe/NA1r/I5cQ==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.24.1:
+  lightningcss-linux-arm-gnueabihf@1.25.0:
     resolution:
       {
-        integrity: sha512-NLQLnBQW/0sSg74qLNI8F8QKQXkNg4/ukSTa+XhtkO7v3BnK19TS1MfCbDHt+TTdSgNEBv0tubRuapcKho2EWw==,
+        integrity: sha512-7KSVcjci9apHxUKNjiLKXn8hVQJqCtwFg5YNvTeKi/BM91A9lQTuO57RpmpPbRIb20Qm8vR7fZtL1iL5Yo3j9A==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.24.1:
+  lightningcss-linux-arm64-gnu@1.25.0:
     resolution:
       {
-        integrity: sha512-AQxWU8c9E9JAjAi4Qw9CvX2tDIPjgzCTrZCSXKELfs4mCwzxRkHh2RCxX8sFK19RyJoJAjA/Kw8+LMNRHS5qEg==,
+        integrity: sha512-1+6tuAsUyMVG5N2rzgwaOOf84yEU+Gjl71b+wLcz26lyM/ohgFgeqPWeB/Dor0wyUnq7vg184l8goGT26cRxoQ==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.24.1:
+  lightningcss-linux-arm64-musl@1.25.0:
     resolution:
       {
-        integrity: sha512-JCgH/SrNrhqsguUA0uJUM1PvN5+dVuzPIlXcoWDHSv2OU/BWlj2dUYr3XNzEw748SmNZPfl2NjQrAdzaPOn1lA==,
+        integrity: sha512-4kw3ZnGQzxD8KkaB4doqfi32hP5h3o04OlrdfZ7T9VLTbUxeh3YZUKcJmhINV2rdMOOmVODqaRw1kuvvF16Q+Q==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.24.1:
+  lightningcss-linux-x64-gnu@1.25.0:
     resolution:
       {
-        integrity: sha512-TYdEsC63bHV0h47aNRGN3RiK7aIeco3/keN4NkoSQ5T8xk09KHuBdySltWAvKLgT8JvR+ayzq8ZHnL1wKWY0rw==,
+        integrity: sha512-oVEP5rBrFQB5V7fRIPYkDxKLmd2fAbz9VagKWIRu1TlYDUFWXK4F3KztAtAKuD7tLMBSGGi1LMUueFzVe+cZbw==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.24.1:
+  lightningcss-linux-x64-musl@1.25.0:
     resolution:
       {
-        integrity: sha512-HLfzVik3RToot6pQ2Rgc3JhfZkGi01hFetHt40HrUMoeKitLoqUUT5owM6yTZPTytTUW9ukLBJ1pc3XNMSvlLw==,
+        integrity: sha512-7ssY6HwCvmPDohqtXuZG2Mh9q32LbVBhiF/SS/VMj2jUcXcsBilUEviq/zFDzhZMxl5f1lXi5/+mCuSGrMir1A==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-x64-msvc@1.24.1:
+  lightningcss-win32-x64-msvc@1.25.0:
     resolution:
       {
-        integrity: sha512-joEupPjYJ7PjZtDsS5lzALtlAudAbgIBMGJPNeFe5HfdmJXFd13ECmEM+5rXNxYVMRHua2w8132R6ab5Z6K9Ow==,
+        integrity: sha512-DUVxj1S6dCQkixQ5qiHcYojamxE02bgmSpc4p6lejPwW7WRd/pvDPDAr+BvZWAkX5MRphxB7ei6+93+42ZtvmQ==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.24.1:
+  lightningcss@1.25.0:
     resolution:
       {
-        integrity: sha512-kUpHOLiH5GB0ERSv4pxqlL0RYKnOXtgGtVe7shDGfhS0AZ4D1ouKFYAcLcZhql8aMspDNzaUCumGHZ78tb2fTg==,
+        integrity: sha512-B08o6QQikGaY4rPuQohtFVE+X2++mm/QemwAJ/1sgnMgTwwUnafJbTmSSBWC8Tv4JPfhelXZB6sWA0Y/6eYJmQ==,
       }
     engines: { node: '>= 12.0.0' }
 
@@ -14115,12 +14115,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6))':
+  '@astrojs/mdx@2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6))':
     dependencies:
       '@astrojs/markdown-remark': 4.3.0
       '@mdx-js/mdx': 3.0.1
       acorn: 8.11.3
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       es-module-lexer: 1.4.2
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -14140,11 +14140,11 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/react@3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@astrojs/react@3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@types/react': 18.2.14
       '@types/react-dom': 18.2.18
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       ultrahtml: 1.5.2
@@ -14152,11 +14152,11 @@ snapshots:
       - supports-color
       - vite
 
-  '@astrojs/react@3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@astrojs/react@3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@types/react': 18.2.14
       '@types/react-dom': 18.2.18
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       ultrahtml: 1.5.3
@@ -15140,7 +15140,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@ladle/react@4.0.2(@swc/helpers@0.5.5)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.24.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.1.6)':
+  '@ladle/react@4.0.2(@swc/helpers@0.5.5)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.1.6)':
     dependencies:
       '@babel/code-frame': 7.23.5
       '@babel/core': 7.23.6
@@ -15152,8 +15152,8 @@ snapshots:
       '@ladle/react-context': 1.0.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mdx-js/mdx': 3.0.0
       '@mdx-js/react': 3.0.0(@types/react@18.2.14)(react@18.2.0)
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))
-      '@vitejs/plugin-react-swc': 3.5.0(@swc/helpers@0.5.5)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
+      '@vitejs/plugin-react-swc': 3.5.0(@swc/helpers@0.5.5)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
       axe-core: 4.8.2
       boxen: 7.1.1
       chokidar: 3.5.3
@@ -15181,8 +15181,8 @@ snapshots:
       remark-gfm: 4.0.0
       source-map: 0.7.4
       vfile: 6.0.1
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
-      vite-tsconfig-paths: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite-tsconfig-paths: 4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -15568,7 +15568,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/generator': 7.24.1
@@ -15584,7 +15584,7 @@ snapshots:
       '@remix-run/router': 1.15.3-pre.0
       '@remix-run/server-runtime': 2.8.1(typescript@5.1.6)
       '@types/mdx': 2.0.11
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -15626,7 +15626,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.8.1(typescript@5.1.6)
       typescript: 5.1.6
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - bluebird
@@ -15641,7 +15641,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.1.6))(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/generator': 7.24.1
@@ -15657,7 +15657,7 @@ snapshots:
       '@remix-run/router': 1.15.3-pre.0
       '@remix-run/server-runtime': 2.8.1(typescript@5.1.6)
       '@types/mdx': 2.0.11
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -15699,7 +15699,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.8.1(typescript@5.1.6)
       typescript: 5.1.6
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - bluebird
@@ -15934,7 +15934,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@testing-library/jest-dom@6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.23.9
@@ -15945,7 +15945,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0)
+      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
 
   '@testing-library/react@13.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -16238,7 +16238,7 @@ snapshots:
       modern-ahocorasick: 1.0.1
       outdent: 0.8.0
 
-  '@vanilla-extract/integration@6.5.0(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.1)
@@ -16251,8 +16251,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.5.0
       outdent: 0.8.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16263,7 +16263,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/integration@6.5.0(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.1)
@@ -16276,8 +16276,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.5.0
       outdent: 0.8.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16290,36 +16290,36 @@ snapshots:
 
   '@vanilla-extract/private@1.0.3': {}
 
-  '@vitejs/plugin-react-swc@3.5.0(@swc/helpers@0.5.5)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@vitejs/plugin-react-swc@3.5.0(@swc/helpers@0.5.5)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@swc/core': 1.3.101(@swc/helpers@0.5.5)
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.23.6)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.23.6)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.23.6)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.23.6)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0))':
+  '@vitest/coverage-v8@1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -16334,7 +16334,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0)
+      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16565,21 +16565,21 @@ snapshots:
 
   astring@1.8.4: {}
 
-  astro-auto-import@0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)):
+  astro-auto-import@0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)):
     dependencies:
       '@types/node': 18.19.26
       acorn: 8.11.3
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
 
-  astro-expressive-code@0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)):
+  astro-expressive-code@0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)):
     dependencies:
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       hast-util-to-html: 8.0.4
       remark-expressive-code: 0.33.5
 
-  astro-relative-links@0.3.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6):
+  astro-relative-links@0.3.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6):
     dependencies:
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6)
       glob: 10.3.10
     transitivePeerDependencies:
       - '@types/node'
@@ -16592,7 +16592,7 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.5.6(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)(typescript@5.1.6):
+  astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.1.6):
     dependencies:
       '@astrojs/compiler': 2.7.0
       '@astrojs/internal-helpers': 0.3.0
@@ -16650,8 +16650,8 @@ snapshots:
       tsconfck: 3.0.3(typescript@5.1.6)
       unist-util-visit: 5.0.0
       vfile: 6.0.1
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
-      vitefu: 0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0))
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vitefu: 0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
       which-pm: 2.1.1
       yargs-parser: 21.1.1
       zod: 3.22.4
@@ -19555,46 +19555,46 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-darwin-arm64@1.24.1:
+  lightningcss-darwin-arm64@1.25.0:
     optional: true
 
-  lightningcss-darwin-x64@1.24.1:
+  lightningcss-darwin-x64@1.25.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.24.1:
+  lightningcss-freebsd-x64@1.25.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.24.1:
+  lightningcss-linux-arm-gnueabihf@1.25.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.24.1:
+  lightningcss-linux-arm64-gnu@1.25.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.24.1:
+  lightningcss-linux-arm64-musl@1.25.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.24.1:
+  lightningcss-linux-x64-gnu@1.25.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.24.1:
+  lightningcss-linux-x64-musl@1.25.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.24.1:
+  lightningcss-win32-x64-msvc@1.25.0:
     optional: true
 
-  lightningcss@1.24.1:
+  lightningcss@1.25.0:
     dependencies:
       detect-libc: 1.0.3
     optionalDependencies:
-      lightningcss-darwin-arm64: 1.24.1
-      lightningcss-darwin-x64: 1.24.1
-      lightningcss-freebsd-x64: 1.24.1
-      lightningcss-linux-arm-gnueabihf: 1.24.1
-      lightningcss-linux-arm64-gnu: 1.24.1
-      lightningcss-linux-arm64-musl: 1.24.1
-      lightningcss-linux-x64-gnu: 1.24.1
-      lightningcss-linux-x64-musl: 1.24.1
-      lightningcss-win32-x64-msvc: 1.24.1
+      lightningcss-darwin-arm64: 1.25.0
+      lightningcss-darwin-x64: 1.25.0
+      lightningcss-freebsd-x64: 1.25.0
+      lightningcss-linux-arm-gnueabihf: 1.25.0
+      lightningcss-linux-arm64-gnu: 1.25.0
+      lightningcss-linux-arm64-musl: 1.25.0
+      lightningcss-linux-x64-gnu: 1.25.0
+      lightningcss-linux-x64-musl: 1.25.0
+      lightningcss-win32-x64-msvc: 1.25.0
 
   lilconfig@3.0.0: {}
 
@@ -23334,13 +23334,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.2.1(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0):
+  vite-node@1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23351,13 +23351,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.2.1(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0):
+  vite-node@1.2.1(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23368,29 +23368,29 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)):
+  vite-tsconfig-paths@4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.1.6)
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)):
+  vite-tsconfig-paths@4.2.1(typescript@5.1.6)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.1.6)
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0):
+  vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.37
@@ -23398,10 +23398,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.17.19
       fsevents: 2.3.3
-      lightningcss: 1.24.1
+      lightningcss: 1.25.0
       sass: 1.72.0
 
-  vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0):
+  vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.37
@@ -23409,14 +23409,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.26
       fsevents: 2.3.3
-      lightningcss: 1.24.1
+      lightningcss: 1.25.0
       sass: 1.72.0
 
-  vitefu@0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)):
+  vitefu@0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)):
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
 
-  vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.24.1)(sass@1.72.0):
+  vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0):
     dependencies:
       '@vitest/expect': 1.2.1
       '@vitest/runner': 1.2.1
@@ -23436,8 +23436,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.1
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.24.1)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 18.17.19


### PR DESCRIPTION
## Changes

1.24.1 → 1.25.0. See [release notes](https://github.com/parcel-bundler/lightningcss/releases).

This shouldn't change anything but we should try to be on the latest, since there are often bug fixes.

## Testing

N/A

## Docs

N/A