### PR TITLE
`EditableCell` properly merges user's `className`/`style` with inner props

### DIFF
--- a/.changeset/light-jeans-cheer.md
+++ b/.changeset/light-jeans-cheer.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`EditableCell`'s styling does not break anymore when passing a custom `className` or `style` prop.

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import type { CellRendererProps } from '@itwin/itwinui-react/react-table';
+import { DefaultCell } from './DefaultCell.js';
+
+const renderComponent = (
+  props?: Partial<React.ComponentProps<typeof DefaultCell>>,
+) => {
+  const dummyTableCellRenderedProps = {
+    cellElementProps: {
+      className: 'iui-table-cell',
+      style: {
+        boxSizing: 'border-box',
+        flex: '1 1 145px',
+        minWidth: '72px',
+        width: '0px',
+      },
+    },
+    cellProps: {
+      column: {
+        id: 'id',
+      },
+      value: 'cell value',
+    },
+  } as CellRendererProps<any>;
+
+  return render(<DefaultCell {...dummyTableCellRenderedProps} {...props} />);
+};
+
+it('should merge className/style with cellElementProps', () => {
+  const { container } = renderComponent({
+    className: 'test-class',
+    style: { color: 'red' },
+  });
+
+  const cellElement = container.querySelector('.iui-table-cell') as HTMLElement;
+  expect(cellElement).toBeTruthy();
+  expect(cellElement.classList.contains('test-class')).toBe(true);
+  expect(cellElement.style.color).toBe('red');
+});

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
@@ -4,41 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import type { CellRendererProps } from '@itwin/itwinui-react/react-table';
 import { DefaultCell } from './DefaultCell.js';
 
-const renderComponent = (
-  props?: Partial<React.ComponentProps<typeof DefaultCell>>,
-) => {
-  const dummyTableCellRenderedProps = {
-    cellElementProps: {
-      className: 'iui-table-cell',
-      style: {
-        boxSizing: 'border-box',
-        flex: '1 1 145px',
-        minWidth: '72px',
-        width: '0px',
-      },
-    },
-    cellProps: {
-      column: {
-        id: 'id',
-      },
-      value: 'cell value',
-    },
-  } as CellRendererProps<any>;
-
-  return render(<DefaultCell {...dummyTableCellRenderedProps} {...props} />);
-};
-
 it('should merge className/style with cellElementProps', () => {
-  const { container } = renderComponent({
-    className: 'test-class',
-    style: { color: 'red' },
-  });
+  const { container } = render(
+    <DefaultCell
+      cellElementProps={{
+        key: 'key',
+        className: 'original-class',
+        style: { width: 100 },
+      }}
+      className='test-class'
+      style={{ color: 'red' }}
+      cellProps={{ column: { id: 'id' } } as any}
+    >
+      {null}
+    </DefaultCell>,
+  );
 
-  const cellElement = container.querySelector('.iui-table-cell') as HTMLElement;
-  expect(cellElement).toBeTruthy();
-  expect(cellElement.classList.contains('test-class')).toBe(true);
+  const cellElement = container.querySelector('.original-class') as HTMLElement;
+  expect(cellElement).toHaveClass('test-class');
+  expect(cellElement.style.width).toBe('100px');
   expect(cellElement.style.color).toBe('red');
 });

--- a/packages/itwinui-react/src/core/Table/cells/EditableCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/EditableCell.test.tsx
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { EditableCell } from './EditableCell.js';
+import type { CellRendererProps } from '@itwin/itwinui-react/react-table';
+
+const renderComponent = (
+  props?: Partial<React.ComponentProps<typeof EditableCell>>,
+) => {
+  const dummyTableCellRenderedProps = {
+    cellElementProps: {
+      className: 'iui-table-cell',
+      style: {
+        boxSizing: 'border-box',
+        flex: '1 1 145px',
+        minWidth: '72px',
+        width: '0px',
+      },
+    },
+    cellProps: {
+      column: {
+        id: 'id',
+      },
+      value: 'cell value',
+    },
+  } as CellRendererProps<any>;
+
+  const onCellEdit = vi.fn();
+
+  return render(
+    <EditableCell
+      onCellEdit={onCellEdit}
+      {...dummyTableCellRenderedProps}
+      {...props}
+    />,
+  );
+};
+
+it('should merge className/style with cellElementProps', () => {
+  const { container } = renderComponent({
+    className: 'test-class',
+    style: { color: 'red' },
+  });
+
+  const cellElement = container.querySelector('.iui-table-cell') as HTMLElement;
+  expect(cellElement).toBeTruthy();
+  expect(cellElement.classList.contains('test-class')).toBe(true);
+  expect(cellElement.style.color).toBe('red');
+});

--- a/packages/itwinui-react/src/core/Table/cells/EditableCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/EditableCell.test.tsx
@@ -5,48 +5,26 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import { EditableCell } from './EditableCell.js';
-import type { CellRendererProps } from '@itwin/itwinui-react/react-table';
-
-const renderComponent = (
-  props?: Partial<React.ComponentProps<typeof EditableCell>>,
-) => {
-  const dummyTableCellRenderedProps = {
-    cellElementProps: {
-      className: 'iui-table-cell',
-      style: {
-        boxSizing: 'border-box',
-        flex: '1 1 145px',
-        minWidth: '72px',
-        width: '0px',
-      },
-    },
-    cellProps: {
-      column: {
-        id: 'id',
-      },
-      value: 'cell value',
-    },
-  } as CellRendererProps<any>;
-
-  const onCellEdit = vi.fn();
-
-  return render(
-    <EditableCell
-      onCellEdit={onCellEdit}
-      {...dummyTableCellRenderedProps}
-      {...props}
-    />,
-  );
-};
 
 it('should merge className/style with cellElementProps', () => {
-  const { container } = renderComponent({
-    className: 'test-class',
-    style: { color: 'red' },
-  });
+  const { container } = render(
+    <EditableCell
+      cellElementProps={{
+        key: 'key',
+        className: 'original-class',
+        style: { width: 100 },
+      }}
+      className='test-class'
+      style={{ color: 'red' }}
+      cellProps={{ value: 'value' } as any}
+      onCellEdit={() => {}}
+    >
+      {null}
+    </EditableCell>,
+  );
 
-  const cellElement = container.querySelector('.iui-table-cell') as HTMLElement;
-  expect(cellElement).toBeTruthy();
-  expect(cellElement.classList.contains('test-class')).toBe(true);
+  const cellElement = container.querySelector('.original-class') as HTMLElement;
+  expect(cellElement).toHaveClass('test-class');
+  expect(cellElement.style.width).toBe('100px');
   expect(cellElement.style.color).toBe('red');
 });

--- a/packages/itwinui-react/src/core/Table/cells/EditableCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/EditableCell.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import type { CellRendererProps } from '../../../react-table/react-table.js';
 import { Box, getRandomValue } from '../../../utils/index.js';
+import cx from 'classnames';
 
 export type EditableCellProps<T extends Record<string, unknown>> =
   CellRendererProps<T> & {
@@ -42,11 +43,17 @@ export const EditableCell = <T extends Record<string, unknown>>(
   props: EditableCellProps<T>,
 ) => {
   const {
-    cellElementProps,
+    cellElementProps: {
+      className: cellElementClassName,
+      style: cellElementStyle,
+      ...cellElementProps
+    },
     cellProps,
     onCellEdit,
     children,
     isDisabled,
+    className,
+    style,
     ...rest
   } = props;
   isDisabled; // To omit and prevent eslint error.
@@ -73,6 +80,8 @@ export const EditableCell = <T extends Record<string, unknown>>(
       suppressContentEditableWarning
       key={key}
       {...rest}
+      className={cx(cellElementClassName, className)}
+      style={{ ...cellElementStyle, ...style }}
       onInput={(e) => {
         setValue(sanitizeString((e.target as HTMLElement).innerText));
         setIsDirty(true);


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I noticed that `EditableCell` was not merging the user's `className` and `style` properly with `cellElementProps`. As a result, when users would pass a `className` or `style`, it would override (instead of merging with) the `className` and `style` from `cellElementProps` and thus break the layout.

This PR fixes it by merging the user's `className` and `style` with `cellElementProps`, similar to [DefaultCell](https://github.com/iTwin/iTwinUI/blob/75a7a5ff70927059a14182021015822fcf5c6acf/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx#L79-L82).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Added unit tests for `DefaultCell` and `EditableCell` to confirm that the `className` and `style` are properly merged with `cellElementProps`.

Tested in the vite playground:
* [Current version (3.11.0)](https://stackblitz.com/edit/github-p3k8jw?file=package.json)
* [This PR](https://gist.github.com/rohan-kadkol/3103eac1cde30b822f7d63a88829da99)

<details>
<summary>custom className and style</summary>

```jsx
className='my-custom-cell'
style={{
  backgroundColor: 'black',
}}
```

</details>

|Current version (3.11.0)|This PR|
|-|-|
|<img width="504" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/1a1e355e-7f37-481c-91ea-5525f576faf5">|<img width="510" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/768ad2fe-745a-460c-8c19-274f26ba7130">|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changeset