### PR TITLE
remove `label` attribute from `ComboBox` options in DOM

### DIFF
--- a/.changeset/happy-penguins-pump.md
+++ b/.changeset/happy-penguins-pump.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a minor issue in `ComboBox` where a `label` attribute was accidentally being added to options in the DOM.

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -448,7 +448,12 @@ export const ComboBox = React.forwardRef(
       (option: SelectOption<T>, filteredIndex?: number) => {
         const optionId = getOptionId(option, id);
         const { __originalIndex } = optionsExtraInfoRef.current[optionId];
-        const { icon, startIcon: startIconProp, ...restOptions } = option;
+        const {
+          icon,
+          startIcon: startIconProp,
+          label,
+          ...restOptions
+        } = option;
 
         const startIcon = startIconProp ?? icon;
 
@@ -491,7 +496,7 @@ export const ComboBox = React.forwardRef(
             index={__originalIndex}
             data-iui-filtered-index={filteredIndex}
           >
-            {option.label}
+            {label}
           </ComboBoxMenuItem>
         );
       },


### PR DESCRIPTION
## Changes

Very minor thing I noticed: `label` was showing up in DOM because we spread `...rest` props and weren't destructuring `label`.

## Testing

| Before | After |
| --- | --- |
| <img src="https://github.com/iTwin/iTwinUI/assets/9084735/eb5c0cc3-d913-4474-a825-2866d7fd35e3" width="350"> | <img src="https://github.com/iTwin/iTwinUI/assets/9084735/8a545300-5279-4c7f-b570-46a1435d8d01" width="350"> |

## Docs

N/A