### PR TITLE
Added explicit import paths for 'react-table'

### DIFF
--- a/.changeset/shiny-trainers-heal.md
+++ b/.changeset/shiny-trainers-heal.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed CommonJS types exports for the `/react-table` entrypoint.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -20,12 +20,10 @@
     },
     "./react-table": {
       "import": {
-        "types": "./esm/react-table/react-table.d.ts",
-        "default": "./esm/react-table/react-table.js"
+        "types": "./esm/react-table/react-table.d.ts"
       },
       "require": {
-        "types": "./cjs/react-table/react-table.d.ts",
-        "default": "./cjs/react-table/react-table.js"
+        "types": "./cjs/react-table/react-table.d.ts"
       }
     },
     "./styles.css": "./styles.css",

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -19,7 +19,14 @@
       }
     },
     "./react-table": {
-      "types": "./react-table.d.ts"
+      "import": {
+        "types": "./esm/react-table/react-table.d.ts",
+        "default": "./esm/react-table/react-table.js"
+      },
+      "require": {
+        "types": "./cjs/react-table/react-table.d.ts",
+        "default": "./cjs/react-table/react-table.js"
+      }
     },
     "./styles.css": "./styles.css",
     "./cjs": "./cjs/index.js",

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -24,7 +24,8 @@
       },
       "require": {
         "types": "./cjs/react-table/react-table.d.ts"
-      }
+      },
+      "types": "./react-table.d.ts"
     },
     "./styles.css": "./styles.css",
     "./cjs": "./cjs/index.js",


### PR DESCRIPTION
## Changes

Added explicit paths to support `"moduleResolution": "node16"` for `react-table`.
The change fixes #2072 

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Can be tested with a consuming application using the specified module resolution. No tests should be required otherwise.

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

- None

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
