### PR TITLE
Fix `Button.size` docs website example

### DIFF
--- a/examples/Button.size.css
+++ b/examples/Button.size.css
@@ -1,4 +1,5 @@
 .demo-container {
   display: flex;
   gap: var(--iui-size-xs);
+  align-items: center;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@mayank99 noticed a small issue with the [`Button.size`](https://itwinui.bentley.com/docs/button#size) example. This PR fixes that issue.

|Old|New|
|-|-|
|<img width="284" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/dc37da03-39b0-4db7-9ede-9b9c6d2cd4d0">|<img width="286" alt="image" src="https://github.com/iTwin/iTwinUI/assets/45748283/cfbf49da-9459-4889-bd83-b5619ce11e16">|

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the `Button.size` is now correct.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A