### PR TITLE
Small improvements to `ColorPicker` examples and stories

### DIFF
--- a/apps/react-workshop/src/ColorPicker.stories.tsx
+++ b/apps/react-workshop/src/ColorPicker.stories.tsx
@@ -86,7 +86,7 @@ export const Basic = () => {
       >
         <IconButton>
           <ColorSwatch
-            style={{ pointerEvents: 'none', margin: 0 }}
+            style={{ pointerEvents: 'none' }}
             color={activeColor.color}
           />
         </IconButton>
@@ -153,7 +153,7 @@ export const Advanced = () => {
         >
           <IconButton>
             <ColorSwatch
-              style={{ pointerEvents: 'none', margin: 0 }}
+              style={{ pointerEvents: 'none' }}
               color={selectedColor}
             />
           </IconButton>
@@ -230,7 +230,7 @@ export const WithAlpha = () => {
         >
           <IconButton>
             <ColorSwatch
-              style={{ pointerEvents: 'none', margin: 0 }}
+              style={{ pointerEvents: 'none' }}
               color={selectedColor}
             />
           </IconButton>

--- a/examples/ColorPicker.advancedPopover.jsx
+++ b/examples/ColorPicker.advancedPopover.jsx
@@ -65,12 +65,10 @@ export default () => {
           }
           portal={{ to: () => document.body }}
           visible={isOpen}
+          onVisibleChange={setIsOpen}
           placement='bottom-start'
         >
-          <IconButton
-            onClick={() => setIsOpen((open) => !open)}
-            label='Show color picker'
-          >
+          <IconButton label='Show color picker'>
             <ColorSwatch color={selectedColor} className='demo-color-swatch' />
           </IconButton>
         </Popover>

--- a/examples/ColorPicker.main.jsx
+++ b/examples/ColorPicker.main.jsx
@@ -8,6 +8,9 @@ import {
   ColorInputPanel,
   ColorPicker,
   ColorValue,
+  IconButton,
+  ColorSwatch,
+  Popover,
 } from '@itwin/itwinui-react';
 
 export default () => {
@@ -20,9 +23,20 @@ export default () => {
   };
 
   return (
-    <ColorPicker selectedColor={activeColor} onChangeComplete={onColorChanged}>
-      <ColorBuilder />
-      <ColorInputPanel defaultColorFormat={'hsl'} />
-    </ColorPicker>
+    <Popover
+      content={
+        <ColorPicker
+          selectedColor={activeColor}
+          onChangeComplete={onColorChanged}
+        >
+          <ColorBuilder />
+          <ColorInputPanel defaultColorFormat={'hsl'} />
+        </ColorPicker>
+      }
+    >
+      <IconButton>
+        <ColorSwatch style={{ pointerEvents: 'none' }} color={activeColor} />
+      </IconButton>
+    </Popover>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Based on https://github.com/iTwin/iTwinUI/pull/2009#discussion_r1580160704, this PR:
* Adds a `Popover` in the `ColorPicker.main` example.
  * Didn't do the same in the `ColorPicker.advanced` example since not having a Popover seemed intentional in this case (there is a `ColorPicker.advancedPopover` example that shows mostly the same example, but with a `Popover`).
* Uses the `Popover`'s `onVisibleChange` instead of toggling the open state using the `IconButton`'s `onClick` in the `ColorPicker.main` example.
* Removes the unnecessary `margin: 0` on the `ColorSwatch` in some of the stories.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the result of the changes in the examples and stories look and work correctly.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A