### PR TITLE
Added missing comma in Header JSDocs example

### DIFF
--- a/packages/itwinui-react/src/core/Header/Header.tsx
+++ b/packages/itwinui-react/src/core/Header/Header.tsx
@@ -87,7 +87,7 @@ const defaultTranslations: HeaderTranslations = {
  *  appLogo={<HeaderLogo logo={<SvgImodelHollow />}>iTwin Application</HeaderLogo>}
  *  breadcrumbs={
  *   <HeaderBreadcrumbs items={[
- *    <HeaderButton key='project' name='Project A' />
+ *    <HeaderButton key='project' name='Project A' />,
  *    <HeaderButton key='imodel' name='IModel X' />
  *   ]} />
  *  }
@@ -98,9 +98,9 @@ const defaultTranslations: HeaderTranslations = {
  *     <SvgHelpCircularHollow />
  *    </IconButton>
  *   </DropdownMenu>,
- *   <DropdownMenu menuItems={...}>
+ *   <DropdownMenu menuItems={…}>
  *    <IconButton styleType='borderless'>
- *     <Avatar ... />
+ *     <Avatar … />
  *    </IconButton>
  *   </DropdownMenu>
  *  ]}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

When copy-pasting the `Header`'s JSDocs example in the vite playground, I noticed a missing comma that was causing errors even after replacing the `…` placeholders.

This small PR adds that missing comma to make it easier for users who copy-paste JSDocs examples.

Unrelated: Replaced `...` with `…`

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that:
* the rendered JSDocs example still appears correctly
* after copy-pasting the example JSDocs and replacing the `…` placeholders, no more errors show up.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A