### PR TITLE
replace live region in `Select` with `aria-multiselectable`

### DIFF
--- a/.changeset/unlucky-mayflies-rush.md
+++ b/.changeset/unlucky-mayflies-rush.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Improved the screen-reader user experience of `<Select multiple>` by using the standard `aria-multiselectable` attribute instead of a live region.

--- a/packages/itwinui-react/src/core/Select/Select.test.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.test.tsx
@@ -30,10 +30,19 @@ function assertSelect(
 
 function assertMenu(
   menu: HTMLElement,
-  { hasIcon = false, selectedIndex = -1, disabledIndex = -1 } = {},
+  {
+    hasIcon = false,
+    selectedIndex = -1,
+    disabledIndex = -1,
+    multiple = false,
+  } = {},
 ) {
   expect(menu).toBeTruthy();
   expect(menu.getAttribute('role')).toEqual('listbox');
+  if (multiple) {
+    expect(menu).toHaveAttribute('aria-multiselectable', 'true');
+  }
+
   const menuItems = menu.querySelectorAll('.iui-list-item');
   expect(menuItems.length).toBe(3);
   menuItems.forEach((item, index) => {
@@ -539,44 +548,6 @@ it('should use custom render for selected item (multiple)', async () => {
   expect(selectedValues.length).toBe(2);
   expect((selectedValues[0] as HTMLElement).style.color).toEqual('green');
   expect((selectedValues[1] as HTMLElement).style.color).toEqual('red');
-});
-
-it('should update live region when selection changes', async () => {
-  const MultiSelectTest = () => {
-    const [selected, setSelected] = React.useState([0]);
-    return (
-      <Select
-        options={[0, 1, 2].map((value) => ({
-          value,
-          label: `Item ${value}`,
-        }))}
-        popoverProps={{ visible: true }}
-        multiple
-        value={selected}
-        onChange={(value, type) =>
-          setSelected((prev) =>
-            type === 'added'
-              ? [...prev, value]
-              : prev.filter((v) => v !== value),
-          )
-        }
-      />
-    );
-  };
-  const { container } = render(<MultiSelectTest />);
-
-  const liveRegion = container.querySelector('[aria-live="polite"]');
-  expect(liveRegion).toHaveTextContent('');
-  const options = document.querySelectorAll('[role="option"]');
-
-  await userEvent.click(options[1]);
-  expect(liveRegion).toHaveTextContent('Item 0, Item 1');
-
-  await userEvent.click(options[2]);
-  expect(liveRegion).toHaveTextContent('Item 0, Item 1, Item 2');
-
-  await userEvent.click(options[0]);
-  expect(liveRegion).toHaveTextContent('Item 1, Item 2');
 });
 
 it.each([true, false] as const)(

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -9,7 +9,6 @@ import type { MenuItemProps } from '../Menu/MenuItem.js';
 import {
   SvgCaretDownSmall,
   useId,
-  AutoclearingHiddenLiveRegion,
   Box,
   Portal,
   useMergedRefs,
@@ -297,7 +296,6 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
   } = props;
 
   const [isOpen, setIsOpen] = React.useState(false);
-  const [liveRegionSelection, setLiveRegionSelection] = React.useState('');
 
   const [uncontrolledValue, setUncontrolledValue] = React.useState<unknown>();
   const value = valueProp !== undefined ? valueProp : uncontrolledValue;
@@ -358,21 +356,6 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
             onChangeRef.current?.(
               option.value,
               isSelected ? 'removed' : 'added',
-            );
-          }
-
-          // update live region
-          if (isMultipleEnabled(value, multiple)) {
-            const prevSelectedValue = value || [];
-            const newSelectedValue = isSelected
-              ? prevSelectedValue.filter((i) => option.value !== i)
-              : [...prevSelectedValue, option.value];
-            setLiveRegionSelection(
-              options
-                .filter((i) => newSelectedValue.includes(i.value))
-                .map((item) => item.label)
-                .filter(Boolean)
-                .join(', '),
             );
           }
         },
@@ -479,10 +462,6 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
           )}
         </SelectButton>
         <SelectEndIcon disabled={disabled} isOpen={isOpen} />
-
-        {multiple ? (
-          <AutoclearingHiddenLiveRegion text={liveRegionSelection} />
-        ) : null}
       </InputWithIcon>
 
       {popover.open && (
@@ -492,6 +471,7 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
             className={menuClassName}
             id={`${uid}-menu`}
             key={`${uid}-menu`}
+            aria-multiselectable={multiple ? 'true' : undefined}
             {...popover.getFloatingProps({
               style: menuStyle,
               onKeyDown: ({ key }) => {


### PR DESCRIPTION
## Changes

Replaced the custom live region implementation with [`aria-multiselectable`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) after noticing that it works fine in latest VoiceOver.

## Testing

Testing in NVDA, however, revealed that this pattern does not work. It seems that NVDA doesn't even correctly support `role=listbox`, let alone `aria-multiselectable`. See [related issue](https://redirect.github.com/nvaccess/nvda/issues/10624).

## Docs

N/A