### PR TITLE
export `meta` object containing version and module

### DIFF
--- a/.changeset/itchy-insects-wink.md
+++ b/.changeset/itchy-insects-wink.md
@@ -1,0 +1,11 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+A new `meta` object is exported, containing meta information about the package.
+
+```ts
+import { meta } from "@itwin/itwinui-react";
+
+console.log(meta.version, meta.module); // 3.12.0, ESM
+```

--- a/packages/itwinui-react/scripts/build.mjs
+++ b/packages/itwinui-react/scripts/build.mjs
@@ -29,7 +29,7 @@ const swcOptions = {
       this.shared,
       this.compilerOptions,
       '-C module.type=es6',
-      `-C jsc.transform.optimizer.globals.vars.__module=\\'ESM\\'`,
+      `-C jsc.transform.optimizer.globals.vars.__module="\'ESM\'"`,
     ].join(' ');
   },
 
@@ -38,7 +38,7 @@ const swcOptions = {
       this.shared,
       this.compilerOptions,
       '-C module.type=commonjs',
-      `-C jsc.transform.optimizer.globals.vars.__module=\\'CJS\\'`,
+      `-C jsc.transform.optimizer.globals.vars.__module="\'CJS\'"`,
     ].join(' ');
   },
 };

--- a/packages/itwinui-react/scripts/build.mjs
+++ b/packages/itwinui-react/scripts/build.mjs
@@ -25,13 +25,21 @@ const swcOptions = {
   ].join(' -C '),
 
   get esm() {
-    return [this.shared, this.compilerOptions, '-C module.type=es6'].join(' ');
+    return [
+      this.shared,
+      this.compilerOptions,
+      '-C module.type=es6',
+      `-C jsc.transform.optimizer.globals.vars.__module=\\'ESM\\'`,
+    ].join(' ');
   },
 
   get cjs() {
-    return [this.shared, this.compilerOptions, '-C module.type=commonjs'].join(
-      ' ',
-    );
+    return [
+      this.shared,
+      this.compilerOptions,
+      '-C module.type=commonjs',
+      `-C jsc.transform.optimizer.globals.vars.__module=\\'CJS\\'`,
+    ].join(' ');
   },
 };
 

--- a/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
+++ b/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
@@ -13,7 +13,7 @@ import type {
   TableKeyedProps,
   TableState,
 } from '../../../react-table/react-table.js';
-import styles from '../../../styles.js';
+import { styles } from '../../../styles.js';
 
 const REORDER_ACTIONS = {
   columnDragStart: 'columnDragStart',

--- a/packages/itwinui-react/src/index.ts
+++ b/packages/itwinui-react/src/index.ts
@@ -213,3 +213,5 @@ export { Flex } from './core/Flex/Flex.js';
 export { Popover } from './core/Popover/Popover.js';
 
 export { Divider } from './core/Divider/Divider.js';
+
+export { meta } from './utils/meta.js';

--- a/packages/itwinui-react/src/styles.d.ts
+++ b/packages/itwinui-react/src/styles.d.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export default styles as Record<string, string>;
+export declare const styles: Record<string, string>;
+export declare const version: string;

--- a/packages/itwinui-react/src/styles.js/index.mjs
+++ b/packages/itwinui-react/src/styles.js/index.mjs
@@ -2,13 +2,14 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { version } from '../../package.json';
 
 // Side-effect import to ensure CSS file is generated even though the classes are not used.
 import './styles.module.css';
 
 // This proxy converts `iui-` to `_iui3-` in class names with very little code.
 // This is more efficient than exporting the entire mapping of original-to-transformed classes.
-export default new Proxy(
+const styles = new Proxy(
   {},
   {
     get(_, prop) {
@@ -21,3 +22,5 @@ export default new Proxy(
     },
   },
 );
+
+export { styles, version };

--- a/packages/itwinui-react/src/styles.js/vite.config.mjs
+++ b/packages/itwinui-react/src/styles.js/vite.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
     minify: true,
     cssMinify: false,
     lib: {
-      entry: path.resolve(__dirname, './classes.mjs'),
+      entry: path.resolve(__dirname, './index.mjs'),
       fileName: (format) => `${format}/styles.js`,
       formats: ['esm', 'cjs'],
     },

--- a/packages/itwinui-react/src/utils/components/WithCSSTransition.tsx
+++ b/packages/itwinui-react/src/utils/components/WithCSSTransition.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { CSSTransition } from 'react-transition-group';
-import styles from '../../styles.js';
+import { styles } from '../../styles.js';
 
 export const WithCSSTransition = (
   props: Partial<React.ComponentPropsWithoutRef<typeof CSSTransition>> & {

--- a/packages/itwinui-react/src/utils/functions/polymorphic.tsx
+++ b/packages/itwinui-react/src/utils/functions/polymorphic.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import cx from 'classnames';
 import type { PolymorphicForwardRefComponent } from '../props.js';
 import { useGlobals } from '../hooks/useGlobals.js';
-import styles from '../../styles.js';
+import { styles } from '../../styles.js';
 
 const _base = <As extends keyof JSX.IntrinsicElements = 'div'>(
   defaultElement: As,

--- a/packages/itwinui-react/src/utils/meta.ts
+++ b/packages/itwinui-react/src/utils/meta.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { version } from '../styles.js';
 
-// @ts-expect-error: __module gets injected by SWC
-const module = (__module || 'DEV') as 'ESM' | 'CJS';
+const module: 'ESM' | 'CJS' =
+  // @ts-expect-error: __module gets injected by SWC
+  typeof __module !== 'undefined' ? __module : 'DEV';
 
 /** Meta information about the package. */
 export const meta = {

--- a/packages/itwinui-react/src/utils/meta.ts
+++ b/packages/itwinui-react/src/utils/meta.ts
@@ -2,17 +2,16 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-export const styles = new Proxy(
-  {},
-  {
-    get: (target, prop) => {
-      // instead of returning scoped css modules, we will preserve the original classes
-      if (typeof prop === 'string' && prop.startsWith('iui')) {
-        return prop;
-      }
-      return Reflect.get(target, prop);
-    },
-  },
-);
 
-export const version = 'DEV';
+import { version } from '../styles.js';
+
+// @ts-expect-error: __module gets injected by SWC
+const module = (__module || 'DEV') as 'ESM' | 'CJS';
+
+/** Meta information about the package. */
+export const meta = {
+  /** The exact version of @itwin/itwinui-react. */
+  version,
+  /** The current module format (e.g. esm vs cjs). */
+  module,
+};

--- a/packages/itwinui-react/src/utils/meta.ts
+++ b/packages/itwinui-react/src/utils/meta.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import { version } from '../styles.js';
 
 // @ts-expect-error: __module gets injected by SWC
@@ -12,6 +11,6 @@ const module = (__module || 'DEV') as 'ESM' | 'CJS';
 export const meta = {
   /** The exact version of @itwin/itwinui-react. */
   version,
-  /** The current module format (e.g. esm vs cjs). */
+  /** The current module format (i.e. "ESM" vs "CJS"). */
   module,
 };

--- a/packages/itwinui-react/src/utils/meta.ts
+++ b/packages/itwinui-react/src/utils/meta.ts
@@ -9,7 +9,7 @@ const module = (__module || 'DEV') as 'ESM' | 'CJS';
 
 /** Meta information about the package. */
 export const meta = {
-  /** The exact version of @itwin/itwinui-react. */
+  /** The exact version of `@itwin/itwinui-react`. */
   version,
   /** The current module format (i.e. "ESM" vs "CJS"). */
   module,

--- a/testing/e2e/app/routes/_index.spec.ts
+++ b/testing/e2e/app/routes/_index.spec.ts
@@ -1,8 +1,26 @@
 import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 test('should greet the world', async ({ page }) => {
   await page.goto('/');
 
   const h1 = page.getByRole('heading', { level: 1 });
   await expect(h1).toHaveText('Hello world');
+});
+
+test('should have correct meta information', async ({ page }) => {
+  await page.goto('/');
+
+  const { version } = JSON.parse(
+    await fs.promises.readFile(
+      require.resolve('@itwin/itwinui-react/package.json'),
+      'utf8',
+    ),
+  );
+
+  await expect(page.getByTestId('version')).toHaveText(version);
+  await expect(page.getByTestId('module')).toHaveText('ESM');
 });

--- a/testing/e2e/app/routes/_index.tsx
+++ b/testing/e2e/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@itwin/itwinui-react';
+import { Text, meta } from '@itwin/itwinui-react';
 
 export default function Index() {
   return (
@@ -6,6 +6,8 @@ export default function Index() {
       <Text as='h1' variant='headline'>
         Hello world
       </Text>
+      <Text data-testid='version'>{meta.version}</Text>
+      <Text data-testid='module'>{meta.module}</Text>
     </>
   );
 }


### PR DESCRIPTION
## Changes

This PR creates a `meta` object containing two fields:
- `module`: This comes from a global `__module` var which gets [substituted by SWC](https://swc.rs/docs/configuration/compilation#jsctransformoptimizerglobals) into `"ESM"` or `"CJS"`.
- `version`: This is simply re-exported from the `styles.js` generated by Vite (see #2106).
  - As a result of this, I had to change `styles` from a default export to a named export. This avoids issues in CommonJS where a default export would otherwise need to be accessed using `.default`.

This object is publicly exported to make it easier for consumers to debug version conflicts. In a future PR, I also plan to use this information for some basic runtime checks.

## Testing

Verified that the `meta` object is created correctly.

Added e2e test to verify that the `meta` object contains the correct information.

## Docs

Added changeset documenting the `meta` export.