### PR TITLE
allow `TreeNode` to accept arbitrary props

### DIFF
--- a/.changeset/heavy-adults-sit.md
+++ b/.changeset/heavy-adults-sit.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added the ability pass arbitrary DOM props to `TreeNode`.

--- a/.changeset/heavy-adults-sit.md
+++ b/.changeset/heavy-adults-sit.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Added the ability pass arbitrary DOM props to `TreeNode`.
+Added the ability to pass arbitrary DOM props to `TreeNode`.

--- a/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { fireEvent, getByTestId, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 import { TreeNode } from './TreeNode.js';
 import { type TreeContextProps, TreeContext } from './TreeContext.js';
@@ -221,9 +221,15 @@ it('should render selected node', () => {
   expect(onSelected).toHaveBeenCalledWith('testId', false);
 });
 
-it('should render treeNode with  [x]Props correctly', () => {
+it('should render treeNode with [x]Props correctly', () => {
+  const onClick = vi.fn();
+  const onKeyDown = vi.fn();
+
   const { container } = renderComponent({
     props: {
+      className: 'testClass',
+      onClick,
+      onKeyDown,
       checkbox: <Checkbox variant='eyeball' className='testClass' />,
       checkboxProps: {
         style: { color: 'green' },
@@ -263,6 +269,16 @@ it('should render treeNode with  [x]Props correctly', () => {
       },
     },
   });
+
+  const treeItem = container.querySelector('li') as HTMLElement;
+  expect(treeItem).toBeTruthy();
+  expect(treeItem).toHaveClass('testClass');
+
+  fireEvent.click(treeItem);
+  expect(onClick).toHaveBeenCalled();
+
+  fireEvent.keyDown(treeItem, { key: 'Enter' });
+  expect(onKeyDown).toHaveBeenCalled();
 
   const treeNode = container.querySelector('.iui-tree-node') as HTMLElement;
 
@@ -319,33 +335,4 @@ it('should render treeNode with  [x]Props correctly', () => {
   expect(expanderIcon).toBeTruthy();
   expect(expanderIcon).toHaveClass('iui-tree-node-content-expander-icon');
   expect(expanderIcon?.style.color).toBe('white');
-});
-
-it('should allow passing event handlers', () => {
-  const onClick = vi.fn();
-  const onKeyDown = vi.fn();
-
-  const { container } = renderComponent(
-    <TreeContext.Provider
-      value={{ nodeDepth: 0, groupSize: 1, indexInGroup: 0 }}
-    >
-      <TreeNode
-        data-testid='test-node'
-        nodeId='testId'
-        label='label'
-        onExpanded={vi.fn()}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-      />
-    </TreeContext.Provider>,
-  );
-
-  const treeNode = getByTestId(container, 'test-node');
-  expect(treeNode).toBeTruthy();
-
-  fireEvent.click(treeNode);
-  expect(onClick).toHaveBeenCalled();
-
-  fireEvent.keyDown(treeNode, { key: 'Enter' });
-  expect(onKeyDown).toHaveBeenCalled();
 });

--- a/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
@@ -227,10 +227,10 @@ it('should render treeNode with [x]Props correctly', () => {
 
   const { container } = renderComponent({
     props: {
-      className: 'testClass',
+      className: 'custom-class',
       onClick,
       onKeyDown,
-      checkbox: <Checkbox variant='eyeball' className='testClass' />,
+      checkbox: <Checkbox variant='eyeball' />,
       checkboxProps: {
         style: { color: 'green' },
         className: 'custom-checkbox-class',
@@ -270,9 +270,9 @@ it('should render treeNode with [x]Props correctly', () => {
     },
   });
 
-  const treeItem = container.querySelector('li') as HTMLElement;
+  const treeItem = container.querySelector('.iui-tree-item') as HTMLElement;
   expect(treeItem).toBeTruthy();
-  expect(treeItem).toHaveClass('testClass');
+  expect(treeItem).toHaveClass('custom-class');
 
   fireEvent.click(treeItem);
   expect(onClick).toHaveBeenCalled();

--- a/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.test.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, getByTestId, render } from '@testing-library/react';
 
 import { TreeNode } from './TreeNode.js';
 import { type TreeContextProps, TreeContext } from './TreeContext.js';
@@ -319,4 +319,33 @@ it('should render treeNode with  [x]Props correctly', () => {
   expect(expanderIcon).toBeTruthy();
   expect(expanderIcon).toHaveClass('iui-tree-node-content-expander-icon');
   expect(expanderIcon?.style.color).toBe('white');
+});
+
+it('should allow passing event handlers', () => {
+  const onClick = vi.fn();
+  const onKeyDown = vi.fn();
+
+  const { container } = renderComponent(
+    <TreeContext.Provider
+      value={{ nodeDepth: 0, groupSize: 1, indexInGroup: 0 }}
+    >
+      <TreeNode
+        data-testid='test-node'
+        nodeId='testId'
+        label='label'
+        onExpanded={vi.fn()}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+      />
+    </TreeContext.Provider>,
+  );
+
+  const treeNode = getByTestId(container, 'test-node');
+  expect(treeNode).toBeTruthy();
+
+  fireEvent.click(treeNode);
+  expect(onClick).toHaveBeenCalled();
+
+  fireEvent.keyDown(treeNode, { key: 'Enter' });
+  expect(onKeyDown).toHaveBeenCalled();
 });

--- a/packages/itwinui-react/src/core/Tree/TreeNode.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.tsx
@@ -21,7 +21,10 @@ type TreeNodeProps = {
    */
   nodeId: string;
   /**
-   * Props for treeNode
+   * Props for main node inside the treeitem (excluding the sub-tree).
+   *
+   * If you need to customize the root node instead, pass top-level props
+   * directly to the `TreeNode` component.
    */
   nodeProps?: React.ComponentProps<'div'>;
   /**


### PR DESCRIPTION
## Changes

Fixes #2109

Pretty simple change to `TreeNode` to accept props (and ref) in a standard way. Review with [whitespace diff turned off](https://github.com/iTwin/iTwinUI/pull/2111/files?w=1).

One interesting note: we use `nodeId` over `id` for some reason. Since it is difficult to accept arbitrary props and exclude `id` at the same time, I marked `id` as deprecated.

## Testing

Added a simple unit test to verify that event handlers can be passed.

## Docs

Added changeset.