### PR TITLE
bump floating-ui

### DIFF
--- a/.changeset/brave-bobcats-smoke.md
+++ b/.changeset/brave-bobcats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Bumped the minimum required version of `@floating-ui/react` to `0.26.18`.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -84,7 +84,7 @@
     "dev:styles": "pnpm build:styles --watch"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.26.10",
+    "@floating-ui/react": "^0.26.18",
     "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@swc/helpers": "^0.5.11",
     "classnames": "^2.3.2",

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -132,7 +132,11 @@ export const ButtonGroup = React.forwardRef((props, forwardedRef) => {
     <FloatingDelayGroup delay={{ open: 50, close: 250 }}>
       <ButtonGroupContext.Provider value={orientation}>
         {props.role === 'toolbar' ? (
-          <Composite orientation={orientation} render={node} />
+          <Composite
+            orientation={orientation}
+            render={node}
+            disabledIndices={[]}
+          />
         ) : (
           node
         )}

--- a/packages/itwinui-react/src/core/Menu/Menu.tsx
+++ b/packages/itwinui-react/src/core/Menu/Menu.tsx
@@ -25,7 +25,6 @@ import {
   useFloatingNodeId,
   useFloatingParentNodeId,
   useFloatingTree,
-  type ReferenceType,
   type UseHoverProps,
 } from '@floating-ui/react';
 
@@ -182,7 +181,7 @@ export const Menu = React.forwardRef((props, ref) => {
           : {
               // If in a FloatingTree, the hover interaction is automatically disabled if a submenu has focus.
               enabled: !!hoverProp && !hasFocusedNodeInSubmenu,
-              ...(hoverProp as UseHoverProps<ReferenceType>),
+              ...(hoverProp as UseHoverProps),
             },
       listNavigation: {
         listRef: focusableElementsRef,

--- a/packages/itwinui-react/src/core/Popover/Popover.tsx
+++ b/packages/itwinui-react/src/core/Popover/Popover.tsx
@@ -31,7 +31,6 @@ import type {
   SizeOptions,
   Placement,
   UseListNavigationProps,
-  ReferenceType,
   UseFloatingOptions,
   UseHoverProps,
   UseClickProps,
@@ -136,7 +135,7 @@ type PopoverInternalProps = {
   interactions?: {
     click?: boolean | Omit<UseClickProps, 'enabled'>;
     dismiss?: boolean | Omit<UseDismissProps, 'enabled'>;
-    hover?: boolean | Omit<UseHoverProps<ReferenceType>, 'enabled'>;
+    hover?: boolean | Omit<UseHoverProps, 'enabled'>;
     focus?: boolean | Omit<UseFocusProps, 'enabled'>;
 
     // All UseListNavigationProps are optional, except listRef

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,8 +335,8 @@ importers:
   packages/itwinui-react:
     dependencies:
       '@floating-ui/react':
-        specifier: ^0.26.10
-        version: 0.26.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^0.26.18
+        version: 0.26.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2172,28 +2172,28 @@ packages:
         integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==,
       }
 
-  '@floating-ui/react-dom@2.0.8':
+  '@floating-ui/react-dom@2.1.1':
     resolution:
       {
-        integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==,
+        integrity: sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==,
       }
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.10':
+  '@floating-ui/react@0.26.18':
     resolution:
       {
-        integrity: sha512-sh6f9gVvWQdEzLObrWbJ97c0clJObiALsFe0LiR/kb3tDRKwEhObASEH2QyfdoO/ZBPzwxa9j+nYFo+sqgbioA==,
+        integrity: sha512-enDDX09Jpi3kmhcXXpvs+fvRXOfBj1jUV2KF6uDMf5HjS+SOZJzNTFUW71lKbFcxz0BkmQqwbvqdmHIxMq/fyQ==,
       }
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.1':
+  '@floating-ui/utils@0.2.3':
     resolution:
       {
-        integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==,
+        integrity: sha512-XGndio0l5/Gvd6CLIABvsav9HHezgDFFhDfHk1bvLfr9ni8dojqLSvBbotJEjmIwNHL7vK4QzBJTdBRoB+c1ww==,
       }
 
   '@fontsource/noto-sans-mono@5.0.18':
@@ -15040,28 +15040,28 @@ snapshots:
 
   '@floating-ui/core@1.6.0':
     dependencies:
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.3
 
   '@floating-ui/dom@1.6.3':
     dependencies:
       '@floating-ui/core': 1.6.0
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.3
 
-  '@floating-ui/react-dom@2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react-dom@2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 1.6.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react@0.26.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react@0.26.18(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/utils': 0.2.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.2.0
 
-  '@floating-ui/utils@0.2.1': {}
+  '@floating-ui/utils@0.2.3': {}
 
   '@fontsource/noto-sans-mono@5.0.18': {}
 


### PR DESCRIPTION
## Changes

Bumped `@floating-ui/react` to latest ([0.26.18](https://github.com/floating-ui/floating-ui/releases/tag/%40floating-ui%2Freact%400.26.18)).

This required three changes:
1. Removing generic type from `UseHoverProps` (see [error](https://github.com/iTwin/iTwinUI/actions/runs/9663994236/job/26657627217?pr=2116#step:8:76))
2. Overriding `disabledIndicies` for `Composite` used in `ButtonGroup` (see [failing test](https://github.com/iTwin/iTwinUI/actions/runs/9664274264/job/26658565890?pr=2117#step:7:136))
3. Not calling `useListNavigation` without required props even when using `enabled: false` (see #2117; fixes #2115)

## Testing

CI passing after #2117 was merged into this branch 🥳

Manually re-verified the stories of some affected components (`ButtonGroup`, `SplitButton`, `Select`, `DropdownMenu`, `ComboBox`, `Tooltip`).

## Docs

Added changeset to list out version bump.
