### PR TITLE
fix `module` variable in CJS

### DIFF
--- a/.changeset/fast-windows-attend.md
+++ b/.changeset/fast-windows-attend.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a CommonJS-related error where an internal variable was accidentally trying to override the [`module`](https://nodejs.org/api/modules.html#the-module-object) object.

--- a/packages/itwinui-react/src/utils/meta.ts
+++ b/packages/itwinui-react/src/utils/meta.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { version } from '../styles.js';
 
-const module: 'ESM' | 'CJS' =
+const _moduleType: 'ESM' | 'CJS' =
   // @ts-expect-error: __module gets injected by SWC
   typeof __module !== 'undefined' ? __module : 'DEV';
 
@@ -13,5 +13,5 @@ export const meta = {
   /** The exact version of `@itwin/itwinui-react`. */
   version,
   /** The current module format (i.e. "ESM" vs "CJS"). */
-  module,
+  module: _moduleType,
 };


### PR DESCRIPTION
## Changes

Simply renames the module variable, because [`module`](https://nodejs.org/api/modules.html#the-module-object) is a built-in thing in CJS.

This fixes #2123. The same issue was also reported privately by another user ("SyntaxError: Identifier 'module' has already been declared").

## Testing

N/A

## Docs

N/A