### PR TITLE
fix dialog title overflow

### DIFF
--- a/.changeset/dry-jars-type.md
+++ b/.changeset/dry-jars-type.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Dialog`, where long titles were not wrapping properly.

--- a/.changeset/dry-jars-type.md
+++ b/.changeset/dry-jars-type.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed an issue in `Dialog`, where long titles were not wrapping properly.
+Fixed an issue in `Dialog` and `Modal`, where long titles were not wrapping properly.

--- a/.changeset/twelve-deers-laugh.md
+++ b/.changeset/twelve-deers-laugh.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue in `iui-dialog`, where long titles were not wrapping properly.

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -140,6 +140,8 @@ $iui-dialog-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins
 
 .iui-dialog-title {
   margin-inline-end: auto;
+  overflow: hidden;
+  overflow-wrap: break-word;
 }
 
 .iui-dialog-title-bar {


### PR DESCRIPTION
## Changes

Added `overflow-wrap: break-word` to the dialog title. This also requires `overflow: hidden` to work because the title doesn't have a fixed width to be constrained by. Fixes #2126

## Testing

| Before | After |
| --- | --- |
| ![](https://github.com/iTwin/iTwinUI/assets/9084735/2f26bf43-8001-4f6e-8cd0-cb24ab3a10f5) | ![](https://github.com/iTwin/iTwinUI/assets/9084735/074044b9-c12c-4cd5-b033-a8d8a46a0eac) |

## Docs

N/A. Added patch changesets for 3.12.2 release
