### PR TITLE
create `FieldsetBase` component

### DIFF
--- a/.changeset/mean-hornets-attend.md
+++ b/.changeset/mean-hornets-attend.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': minor
+---
+
+Added a new `iui-fieldset-base` class that removes default `<fieldset>` styles.

--- a/.changeset/mean-hornets-attend.md
+++ b/.changeset/mean-hornets-attend.md
@@ -1,5 +1,10 @@
 ---
-'@itwin/itwinui-css': minor
+'@itwin/itwinui-css': major
 ---
 
-Added a new `iui-fieldset-base` class that removes default `<fieldset>` styles.
+Added a new `iui-fieldset-base` class that removes default `<fieldset>` styles. This class is now required when using `iui-fieldset`.
+
+```diff
+- <fieldset class="iui-fieldset">
++ <fieldset class="iui-fieldset-base iui-fieldset">
+```

--- a/apps/css-workshop/src/pages/fieldset.astro
+++ b/apps/css-workshop/src/pages/fieldset.astro
@@ -21,7 +21,7 @@ import Icon_ from '../components/Icon.astro';
   <hr />
 
   <section id='demo-default'>
-    <fieldset class='iui-fieldset'>
+    <fieldset class='iui-fieldset-base iui-fieldset'>
       <legend>General settings</legend>
 
       <div class='iui-input-grid' data-iui-label-placement='inline'>
@@ -76,7 +76,7 @@ import Icon_ from '../components/Icon.astro';
 
     <br />
 
-    <fieldset class='iui-fieldset' disabled>
+    <fieldset class='iui-fieldset-base iui-fieldset' disabled>
       <legend>Advanced settings</legend>
 
       <label class='iui-input-grid' data-iui-label-placement='inline'>

--- a/packages/itwinui-css/src/fieldset/fieldset.scss
+++ b/packages/itwinui-css/src/fieldset/fieldset.scss
@@ -1,9 +1,13 @@
 // Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 // See LICENSE.md in the project root for license terms and full copyright notice.
-@use '../mixins';
+
+:where(.iui-fieldset-base) {
+  padding: 0;
+  margin: 0;
+  border: none;
+}
 
 .iui-fieldset {
-  @include mixins.iui-reset;
   padding: var(--iui-size-s);
   border-radius: var(--iui-border-radius-1);
   border: 1px solid var(--iui-color-border);

--- a/packages/itwinui-react/src/core/Fieldset/Fieldset.tsx
+++ b/packages/itwinui-react/src/core/Fieldset/Fieldset.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Box } from '../../utils/index.js';
+import { FieldsetBase } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
 import cx from 'classnames';
@@ -30,8 +30,7 @@ export const Fieldset = React.forwardRef((props, ref) => {
   const { children, className, disabled, legend, ...rest } = props;
 
   return (
-    <Box
-      as='fieldset'
+    <FieldsetBase
       className={cx('iui-fieldset', className)}
       disabled={disabled}
       ref={ref}
@@ -46,6 +45,6 @@ export const Fieldset = React.forwardRef((props, ref) => {
               : child,
           )
         : children}
-    </Box>
+    </FieldsetBase>
   );
 }) as PolymorphicForwardRefComponent<'fieldset', FieldsetProps>;

--- a/packages/itwinui-react/src/utils/components/FieldsetBase.tsx
+++ b/packages/itwinui-react/src/utils/components/FieldsetBase.tsx
@@ -4,4 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { polymorphic } from '../functions/polymorphic.js';
 
+/**
+ * Thin wrapper over the `<fieldset>` element that removes its default styles.
+ *
+ * @private
+ */
 export const FieldsetBase = polymorphic.fieldset('iui-fieldset-base');

--- a/packages/itwinui-react/src/utils/components/FieldsetBase.tsx
+++ b/packages/itwinui-react/src/utils/components/FieldsetBase.tsx
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { polymorphic } from '../functions/polymorphic.js';
+
+export const FieldsetBase = polymorphic.fieldset('iui-fieldset-base');

--- a/packages/itwinui-react/src/utils/components/index.ts
+++ b/packages/itwinui-react/src/utils/components/index.ts
@@ -16,3 +16,4 @@ export * from './ButtonBase.js';
 export * from './Portal.js';
 export * from './ShadowRoot.js';
 export * from './LineClamp.js';
+export * from './FieldsetBase.js';


### PR DESCRIPTION
## Changes

1. Added a new base class that only resets default `<fieldset>` styles.
2. Created a private `FieldsetBase` component that uses this new class.
3. Updated `Fieldset` component to use this new component as a base.

The `FieldsetBase` component will be useful in other places (e.g. #2135) where we should use `<fieldset>` but feel limited by its default styles. In the future, we could potentially even expose this as a public component with some docs and improvements.

## Testing

N/A. This is just moving things around so everything works the same.

## Docs

Added CSS changeset since the new class is part of the public API and requires a breaking change.

Added light jsdocs. No React changeset needed, as this shouldn't affect anyone.