### PR TITLE
warn when multiple instances of the package are found

### DIFF
--- a/.changeset/cool-beds-hunt.md
+++ b/.changeset/cool-beds-hunt.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Development-only warnings will now be displayed when multople versions of iTwinUI are detected.
+Development-only warnings will now be displayed when multiple versions of iTwinUI are detected.

--- a/.changeset/cool-beds-hunt.md
+++ b/.changeset/cool-beds-hunt.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Development-only warnings will now be displayed when multople versions of iTwinUI are detected.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -427,40 +427,41 @@ const FallbackStyles = ({ root }: { root: HTMLElement }) => {
  * and displays development-only warnings when multiple versions are detected.
  */
 const useIuiDebugRef = () => {
-  (globalThis as any).__iui ||= { versions: new Set() };
+  const _globalThis = globalThis as any;
+  _globalThis.__iui ||= { versions: new Set() };
 
   if (process.env.NODE_ENV === 'development' && !isUnitTest) {
     // Override the `add` method to automatically detect multiple versions as they're added
-    (globalThis as any).__iui.versions.add = (version: string) => {
-      Set.prototype.add.call((globalThis as any).__iui.versions, version);
+    _globalThis.__iui.versions.add = (version: string) => {
+      Set.prototype.add.call(_globalThis.__iui.versions, version);
 
-      if ((globalThis as any).__iui.versions.size > 1) {
-        (globalThis as any).__iui._shouldWarn = true;
+      if (_globalThis.__iui.versions.size > 1) {
+        _globalThis.__iui._shouldWarn = true;
 
-        if ((globalThis as any).__iui._warnTimeout) {
-          clearTimeout((globalThis as any).__iui._warnTimeout);
+        if (_globalThis.__iui._warnTimeout) {
+          clearTimeout(_globalThis.__iui._warnTimeout);
         }
 
         // Warn after 3 seconds, but only once
-        (globalThis as any).__iui._warnTimeout = setTimeout(() => {
-          if ((globalThis as any).__iui._shouldWarn) {
+        _globalThis.__iui._warnTimeout = setTimeout(() => {
+          if (_globalThis.__iui._shouldWarn) {
             console.warn(
               `Multiple versions of iTwinUI were detected on this page. This can lead to unexpected behavior and duplicated code in the bundle. ` +
                 `Make sure you're using a single iTwinUI instance across your app. https://github.com/iTwin/iTwinUI/wiki/Version-conflicts`,
             );
             console.groupCollapsed('iTwinUI versions detected:');
             const versionsTable: any[] = [];
-            (globalThis as any).__iui.versions.forEach((version: string) => {
+            _globalThis.__iui.versions.forEach((version: string) => {
               versionsTable.push(JSON.parse(version));
             });
             console.table(versionsTable);
             console.groupEnd();
-            (globalThis as any).__iui._shouldWarn = false;
+            _globalThis.__iui._shouldWarn = false;
           }
         }, 3000);
       }
     };
   }
 
-  (globalThis as any).__iui.versions.add(JSON.stringify(meta));
+  _globalThis.__iui.versions.add(JSON.stringify(meta));
 };

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -445,7 +445,7 @@ const useIuiDebugRef = () => {
         (globalThis as any).__iui._warnTimeout = setTimeout(() => {
           if ((globalThis as any).__iui._shouldWarn) {
             console.warn(
-              `Found multiple versions of iTwinUI in the same app. This can lead to unexpected behavior and duplicated code in the bundle. ` +
+              `Multiple versions of iTwinUI were detected on this page. This can lead to unexpected behavior and duplicated code in the bundle. ` +
                 `Make sure you're using a single iTwinUI instance across your app. https://github.com/iTwin/iTwinUI/wiki/Version-conflicts`,
             );
             console.groupCollapsed('iTwinUI versions detected:');


### PR DESCRIPTION
## Changes

This PR stores the package meta information in a `__iui` key under the global `window` object. It uses a JS `Set` to avoid re-adding the same version twice.

During development only, it detects multiple instances of the package (either multiple versions or different modules of the same version) and displays a warning along with a table listing out all the versions. This is done by patching the set's `add` method to run some extra code every time it's called.

## Testing

Verified that warnings appear during development when simulating multiple versions (i.e. simply calling `add` multiple times with different args).

<details><summary>Code</summary>

```diff
  (globalThis as any).__iui.versions.add(JSON.stringify(meta));

+ (globalThis as any).__iui.versions.add(JSON.stringify({ version: '3.14.0', module: 'ESM' }));

+ (globalThis as any).__iui.versions.add(JSON.stringify({ version: '3.14.0', module: 'CJS' }));
```

</details> 

![](https://github.com/iTwin/iTwinUI/assets/9084735/d1c97be0-45e0-4e80-9f32-5dcf5ef90119)

Also verified that dev-only code is eliminated from the prod build.

## Docs

Added patch changeset.