### PR TITLE
Don't pass `eslint` ignored files to `eslint` during precommit

### DIFF
--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -140,9 +140,7 @@
       "prettier --write",
       "node ../../scripts/copyrightLinter.js --fix"
     ],
-    "*.{tsx,ts}": [
-      "eslint --max-warnings=0 --fix"
-    ]
+    "!(*.test){.tsx,.ts}": "eslint --max-warnings=0 --fix"
   },
   "prettier": "configs/prettier-config",
   "sideEffects": [


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@Ben-Pusey-Bentley pointed out an eslint error in the pre-commit hook when trying to commit changes to `.test.tsx`/`.test.ts` unit test files. Example:

<img width="712" alt="image" src="https://github.com/user-attachments/assets/70cf728a-313a-491e-958c-984822abb973">

@mayank99 hinted at the problem being that unit test files are being passed to eslint in the package.json's `lint-staged`.

This PR updates `lint-staged` to no longer pass `.test.tsx`/`.test.ts` unit test files to eslint.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that committing changes in unit test files no longer gives eslint warnings in the pre-commit hook.

Since [`lint-staged`](https://github.com/lint-staged/lint-staged#filtering-files) uses [`micromatch`](https://github.com/micromatch/micromatch) for glob matching, I confirmed that `micromatch` correctly avoids unit test files with the new glob pattern.

<details>
<summary>Code</summary>

```js
import micromatch from 'micromatch';

console.log(
  micromatch(
    ['Abc.test.tsx', 'Abc.tsx', 'Abc.test.ts', 'Abc.ts', 'random.md'],
    ['!(*.test){.tsx,.ts}'],
  ),
); 
// Output: [ 'Abc.tsx', 'Abc.ts' ]

```

</details>

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A