### PR TITLE
add development checks for `displayName`

### DIFF
--- a/.changeset/proud-hornets-itch.md
+++ b/.changeset/proud-hornets-itch.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Component `displayName`s have been eliminiated from the prod build.

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -75,7 +75,9 @@ const AlertComponent = React.forwardRef((props, forwardedRef) => {
     </Alert.Wrapper>
   );
 }) as PolymorphicForwardRefComponent<'div', AlertOwnProps & AlertLegacyProps>;
-AlertComponent.displayName = 'Alert';
+if (process.env.NODE_ENV === 'development') {
+  AlertComponent.displayName = 'Alert';
+}
 
 // ----------------------------------------------------------------------------
 // Alert.Wrapper component
@@ -101,7 +103,9 @@ const AlertWrapper = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', AlertOwnProps>;
-AlertWrapper.displayName = 'Alert.Wrapper';
+if (process.env.NODE_ENV === 'development') {
+  AlertWrapper.displayName = 'Alert.Wrapper';
+}
 
 // ----------------------------------------------------------------------------
 // Alert.Icon component
@@ -119,7 +123,9 @@ const AlertIcon = React.forwardRef((props, ref) => {
     </Icon>
   );
 }) as PolymorphicForwardRefComponent<'span', React.ComponentProps<typeof Icon>>;
-AlertIcon.displayName = 'Alert.Icon';
+if (process.env.NODE_ENV === 'development') {
+  AlertIcon.displayName = 'Alert.Icon';
+}
 
 // ----------------------------------------------------------------------------
 // Alert.Message component
@@ -147,7 +153,9 @@ const AlertAction = React.forwardRef((props, ref) => {
     </Anchor>
   );
 }) as PolymorphicForwardRefComponent<'a'>;
-AlertAction.displayName = 'Alert.Action';
+if (process.env.NODE_ENV === 'development') {
+  AlertAction.displayName = 'Alert.Action';
+}
 
 // ----------------------------------------------------------------------------
 // Alert.CloseButton component
@@ -167,7 +175,9 @@ const AlertCloseButton = React.forwardRef((props, ref) => {
     </IconButton>
   );
 }) as PolymorphicForwardRefComponent<'button'>;
-AlertCloseButton.displayName = 'Alert.CloseButton';
+if (process.env.NODE_ENV === 'development') {
+  AlertCloseButton.displayName = 'Alert.CloseButton';
+}
 
 /**
  * A small box to quickly grab user attention and communicate a brief message

--- a/packages/itwinui-react/src/core/Alert/Alert.tsx
+++ b/packages/itwinui-react/src/core/Alert/Alert.tsx
@@ -131,7 +131,9 @@ if (process.env.NODE_ENV === 'development') {
 // Alert.Message component
 
 const AlertMessage = polymorphic.span('iui-alert-message');
-AlertMessage.displayName = 'Alert.Message';
+if (process.env.NODE_ENV === 'development') {
+  AlertMessage.displayName = 'Alert.Message';
+}
 
 // ----------------------------------------------------------------------------
 // Alert.Action component

--- a/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
@@ -257,7 +257,9 @@ const BreadcrumbsItem = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'a'>;
-BreadcrumbsItem.displayName = 'Breadcrumbs.Item';
+if (process.env.NODE_ENV === 'development') {
+  BreadcrumbsItem.displayName = 'Breadcrumbs.Item';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
+++ b/packages/itwinui-react/src/core/ButtonGroup/ButtonGroup.tsx
@@ -21,7 +21,9 @@ import {
 export const ButtonGroupContext = React.createContext<string | undefined>(
   undefined,
 );
-ButtonGroupContext.displayName = 'ButtonGroupContext';
+if (process.env.NODE_ENV === 'development') {
+  ButtonGroupContext.displayName = 'ButtonGroupContext';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxEndIcon.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxEndIcon.tsx
@@ -34,4 +34,6 @@ export const ComboBoxEndIcon = React.forwardRef((props, forwardedRef) => {
     </Icon>
   );
 }) as PolymorphicForwardRefComponent<'span', ComboBoxEndIconProps>;
-ComboBoxEndIcon.displayName = 'ComboBoxEndIcon';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxEndIcon.displayName = 'ComboBoxEndIcon';
+}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInput.tsx
@@ -241,4 +241,6 @@ export const ComboBoxInput = React.forwardRef((props, forwardedRef) => {
     </>
   );
 }) as PolymorphicForwardRefComponent<'input', ComboBoxInputProps>;
-ComboBoxInput.displayName = 'ComboBoxInput';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxInput.displayName = 'ComboBoxInput';
+}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxInputContainer.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxInputContainer.tsx
@@ -47,4 +47,6 @@ export const ComboBoxInputContainer = React.forwardRef(
     );
   },
 ) as PolymorphicForwardRefComponent<'div', ComboBoxInputContainerProps>;
-ComboBoxInputContainer.displayName = 'ComboBoxInputContainer';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxInputContainer.displayName = 'ComboBoxInputContainer';
+}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -156,4 +156,6 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
     )
   );
 }) as PolymorphicForwardRefComponent<'div', ComboBoxMenuProps>;
-ComboBoxMenu.displayName = 'ComboBoxMenu';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxMenu.displayName = 'ComboBoxMenu';
+}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
@@ -79,4 +79,6 @@ export const ComboBoxMenuItem = React.memo(
     );
   }) as PolymorphicForwardRefComponent<'div', ComboBoxMenuItemProps>,
 );
-ComboBoxMenuItem.displayName = 'ComboBoxMenuItem';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxMenuItem.displayName = 'ComboBoxMenuItem';
+}

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMultipleContainer.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMultipleContainer.tsx
@@ -15,4 +15,6 @@ export const ComboBoxMultipleContainer = React.forwardRef((props, ref) => {
   return <SelectTagContainer ref={ref} tags={selectedItems} {...rest} />;
 }) as PolymorphicForwardRefComponent<'div', ComboBoxMultipleContainerProps>;
 
-ComboBoxMultipleContainer.displayName = 'ComboBoxMultipleContainer';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxMultipleContainer.displayName = 'ComboBoxMultipleContainer';
+}

--- a/packages/itwinui-react/src/core/ComboBox/helpers.ts
+++ b/packages/itwinui-react/src/core/ComboBox/helpers.ts
@@ -14,7 +14,9 @@ export const ComboBoxRefsContext = React.createContext<
     }
   | undefined
 >(undefined);
-ComboBoxRefsContext.displayName = 'ComboBoxRefsContext';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxRefsContext.displayName = 'ComboBoxRefsContext';
+}
 
 type ComboBoxStateContextProps<T = unknown> = {
   isOpen: boolean;
@@ -34,4 +36,6 @@ type ComboBoxStateContextProps<T = unknown> = {
 export const ComboBoxStateContext = React.createContext<
   ComboBoxStateContextProps | undefined
 >(undefined);
-ComboBoxStateContext.displayName = 'ComboBoxStateContext';
+if (process.env.NODE_ENV === 'development') {
+  ComboBoxStateContext.displayName = 'ComboBoxStateContext';
+}

--- a/packages/itwinui-react/src/core/ExpandableBlock/ExpandableBlock.tsx
+++ b/packages/itwinui-react/src/core/ExpandableBlock/ExpandableBlock.tsx
@@ -28,7 +28,9 @@ const ExpandableBlockContext = React.createContext<
     } & ExpandableBlockOwnProps)
   | undefined
 >(undefined);
-ExpandableBlockContext.displayName = 'ExpandableBlockContext';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockContext.displayName = 'ExpandableBlockContext';
+}
 
 // ----------------------------------------------------------------------------
 // Main ExpandableBlock component
@@ -90,7 +92,9 @@ const ExpandableBlockComponent = React.forwardRef((props, forwardedRef) => {
   'div',
   ExpandableBlockOwnProps & ExpandableBlockLegacyProps
 >;
-ExpandableBlockComponent.displayName = 'ExpandableBlock';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockComponent.displayName = 'ExpandableBlock';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -144,7 +148,9 @@ const ExpandableBlockWrapper = React.forwardRef((props, forwardedRef) => {
     </ExpandableBlockContext.Provider>
   );
 }) as PolymorphicForwardRefComponent<'div', ExpandableBlockOwnProps>;
-ExpandableBlockWrapper.displayName = 'ExpandableBlock.Wrapper';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockWrapper.displayName = 'ExpandableBlock.Wrapper';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.Trigger component
@@ -184,7 +190,9 @@ const ExpandableBlockTrigger = React.forwardRef((props, forwardedRef) => {
     </LinkBox>
   );
 }) as PolymorphicForwardRefComponent<'div', ExpandableBlockTriggerOwnProps>;
-ExpandableBlockTrigger.displayName = 'ExpandableBlock.Trigger';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockTrigger.displayName = 'ExpandableBlock.Trigger';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.ExpandIcon component
@@ -201,13 +209,17 @@ const ExpandableBlockExpandIcon = React.forwardRef((props, forwardedRef) => {
     </Icon>
   );
 }) as PolymorphicForwardRefComponent<'span'>;
-ExpandableBlockExpandIcon.displayName = 'ExpandableBlock.ExpandIcon';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockExpandIcon.displayName = 'ExpandableBlock.ExpandIcon';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.LabelArea component
 
 const ExpandableBlockLabelArea = polymorphic.span('iui-expandable-block-label');
-ExpandableBlockLabelArea.displayName = 'ExpandableBlock.LabelArea';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockLabelArea.displayName = 'ExpandableBlock.LabelArea';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.Title component
@@ -238,7 +250,9 @@ const ExpandableBlockTitle = React.forwardRef((props, forwardedRef) => {
     </ButtonBase>
   );
 }) as PolymorphicForwardRefComponent<'button'>;
-ExpandableBlockTitle.displayName = 'ExpandableBlock.Title';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockTitle.displayName = 'ExpandableBlock.Title';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.Caption component
@@ -262,7 +276,9 @@ const ExpandableBlockCaption = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'div'>;
-ExpandableBlockCaption.displayName = 'ExpandableBlock.Caption';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockCaption.displayName = 'ExpandableBlock.Caption';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.EndIcon component
@@ -281,7 +297,9 @@ const ExpandableBlockEndIcon = React.forwardRef((props, forwardedRef) => {
   'span',
   React.ComponentPropsWithoutRef<typeof Icon>
 >;
-ExpandableBlockEndIcon.displayName = 'ExpandableBlock.EndIcon';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockEndIcon.displayName = 'ExpandableBlock.EndIcon';
+}
 
 // ----------------------------------------------------------------------------
 // ExpandableBlock.Content component
@@ -302,7 +320,9 @@ const ExpandableBlockContent = React.forwardRef((props, forwardedRef) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', ExpandableBlockContentOwnProps>;
-ExpandableBlockContent.displayName = 'ExpandableBlock.Content';
+if (process.env.NODE_ENV === 'development') {
+  ExpandableBlockContent.displayName = 'ExpandableBlock.Content';
+}
 
 /**
  * Expandable block with customizable Title, Caption, Content and EndIcon subcomponents.

--- a/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
+++ b/packages/itwinui-react/src/core/FileUpload/FileUploadCard.tsx
@@ -41,13 +41,17 @@ const toDate = (dateNumber: number) => {
 const FileUploadCardIcon = polymorphic.span('iui-file-card-icon', {
   children: <SvgDocument />,
 });
-FileUploadCardIcon.displayName = 'FileUploadCard.Icon';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardIcon.displayName = 'FileUploadCard.Icon';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.Info component
 
 const FileUploadCardInfo = polymorphic.span('iui-file-card-text');
-FileUploadCardInfo.displayName = 'FileUploadCard.Info';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardInfo.displayName = 'FileUploadCard.Info';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.Title component
@@ -68,7 +72,9 @@ const FileUploadCardTitle = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'span'>;
-FileUploadCardTitle.displayName = 'FileUploadCard.Title';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardTitle.displayName = 'FileUploadCard.Title';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.Description component
@@ -97,13 +103,17 @@ const FileUploadCardDescription = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'span'>;
-FileUploadCardDescription.displayName = 'FileUploadCard.Description';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardDescription.displayName = 'FileUploadCard.Description';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.Action component
 
 const FileUploadCardAction = polymorphic.div('iui-file-card-action');
-FileUploadCardAction.displayName = 'FileUploadCard.Action';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardAction.displayName = 'FileUploadCard.Action';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.InputLabel component
@@ -117,7 +127,9 @@ const FileUploadCardInputLabel = React.forwardRef((props, ref) => {
     </Anchor>
   );
 }) as PolymorphicForwardRefComponent<'label'>;
-FileUploadCardInputLabel.displayName = 'FileUploadCard.InputLabel';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardInputLabel.displayName = 'FileUploadCard.InputLabel';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard.Input component
@@ -168,7 +180,9 @@ const FileUploadCardInput = React.forwardRef((props, ref) => {
     </>
   );
 }) as PolymorphicForwardRefComponent<'input'>;
-FileUploadCardInput.displayName = 'FileUploadCard.Input';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCardInput.displayName = 'FileUploadCard.Input';
+}
 
 // ----------------------------------------------------------------------------
 // FileUploadCard component
@@ -277,7 +291,9 @@ export const FileUploadCard = Object.assign(FileUploadCardComponent, {
   InputLabel: FileUploadCardInputLabel,
   Input: FileUploadCardInput,
 });
-FileUploadCard.displayName = 'FileUploadCard';
+if (process.env.NODE_ENV === 'development') {
+  FileUploadCard.displayName = 'FileUploadCard';
+}
 
 export const FileUploadCardContext = React.createContext<
   | {

--- a/packages/itwinui-react/src/core/Flex/Flex.tsx
+++ b/packages/itwinui-react/src/core/Flex/Flex.tsx
@@ -67,7 +67,9 @@ const FlexComponent = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'div', FlexOwnProps>;
-FlexComponent.displayName = 'Flex';
+if (process.env.NODE_ENV === 'development') {
+  FlexComponent.displayName = 'Flex';
+}
 
 type FlexOwnProps = {
   /**
@@ -125,7 +127,9 @@ const FlexSpacer = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'div', FlexSpacerOwnProps>;
-FlexSpacer.displayName = 'Flex.Spacer';
+if (process.env.NODE_ENV === 'development') {
+  FlexSpacer.displayName = 'Flex.Spacer';
+}
 
 type FlexSpacerOwnProps = {
   /**
@@ -169,7 +173,9 @@ const FlexItem = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'div', FlexItemOwnProps>;
-FlexItem.displayName = 'Flex.Item';
+if (process.env.NODE_ENV === 'development') {
+  FlexItem.displayName = 'Flex.Item';
+}
 
 type FlexItemOwnProps = {
   /**

--- a/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
+++ b/packages/itwinui-react/src/core/InputWithDecorations/InputWithDecorations.tsx
@@ -55,7 +55,9 @@ const InputWithDecorationsInput = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'input', InputProps>;
-InputWithDecorationsInput.displayName = 'InputWithDecorations.Input';
+if (process.env.NODE_ENV === 'development') {
+  InputWithDecorationsInput.displayName = 'InputWithDecorations.Input';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -79,12 +81,16 @@ const InputWithDecorationsButton = React.forwardRef((props, ref) => {
   'button',
   React.ComponentProps<typeof InputFlexContainerButton>
 >;
-InputWithDecorationsButton.displayName = 'InputWithDecorations.Button';
+if (process.env.NODE_ENV === 'development') {
+  InputWithDecorationsButton.displayName = 'InputWithDecorations.Button';
+}
 
 // ----------------------------------------------------------------------------
 
 const InputWithDecorationsIcon = InputFlexContainerIcon;
-InputWithDecorationsIcon.displayName = 'InputWithDecorations.Icon';
+if (process.env.NODE_ENV === 'development') {
+  InputWithDecorationsIcon.displayName = 'InputWithDecorations.Icon';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
+++ b/packages/itwinui-react/src/core/LinkAction/LinkAction.tsx
@@ -29,7 +29,9 @@ export const LinkAction = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'a'>;
-LinkAction.displayName = 'LinkAction';
+if (process.env.NODE_ENV === 'development') {
+  LinkAction.displayName = 'LinkAction';
+}
 
 /**
  * Polymorphic link box component.
@@ -43,4 +45,6 @@ LinkAction.displayName = 'LinkAction';
  * </LinkBox>
  */
 export const LinkBox = polymorphic.div('iui-link-box');
-LinkBox.displayName = 'LinkBox';
+if (process.env.NODE_ENV === 'development') {
+  LinkBox.displayName = 'LinkBox';
+}

--- a/packages/itwinui-react/src/core/List/List.tsx
+++ b/packages/itwinui-react/src/core/List/List.tsx
@@ -5,4 +5,6 @@
 import { polymorphic } from '../../utils/index.js';
 
 export const List = polymorphic.ul('iui-list', { role: 'list' });
-List.displayName = 'List';
+if (process.env.NODE_ENV === 'development') {
+  List.displayName = 'List';
+}

--- a/packages/itwinui-react/src/core/List/ListItem.tsx
+++ b/packages/itwinui-react/src/core/List/ListItem.tsx
@@ -33,7 +33,9 @@ const ListItemComponent = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'li', ListItemOwnProps>;
-ListItemComponent.displayName = 'ListItem';
+if (process.env.NODE_ENV === 'development') {
+  ListItemComponent.displayName = 'ListItem';
+}
 
 export type ListItemOwnProps = {
   /**
@@ -67,7 +69,9 @@ export type ListItemOwnProps = {
 // ----------------------------------------------------------------------------
 
 const ListItemIcon = polymorphic('iui-list-item-icon');
-ListItemIcon.displayName = 'ListItem.Icon';
+if (process.env.NODE_ENV === 'development') {
+  ListItemIcon.displayName = 'ListItem.Icon';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -77,12 +81,16 @@ ListItemContent.displayName = 'ListItem.Content';
 // ----------------------------------------------------------------------------
 
 const ListItemDescription = polymorphic('iui-list-item-description');
-ListItemDescription.displayName = 'ListItem.Description';
+if (process.env.NODE_ENV === 'development') {
+  ListItemDescription.displayName = 'ListItem.Description';
+}
 
 // ----------------------------------------------------------------------------
 
 const ListItemAction = LinkAction;
-ListItemAction.displayName = 'ListItem.Action';
+if (process.env.NODE_ENV === 'development') {
+  ListItemAction.displayName = 'ListItem.Action';
+}
 
 // ----------------------------------------------------------------------------
 // Exported compound component

--- a/packages/itwinui-react/src/core/List/ListItem.tsx
+++ b/packages/itwinui-react/src/core/List/ListItem.tsx
@@ -76,7 +76,9 @@ if (process.env.NODE_ENV === 'development') {
 // ----------------------------------------------------------------------------
 
 const ListItemContent = polymorphic('iui-list-item-content');
-ListItemContent.displayName = 'ListItem.Content';
+if (process.env.NODE_ENV === 'development') {
+  ListItemContent.displayName = 'ListItem.Content';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/Overlay/Overlay.tsx
+++ b/packages/itwinui-react/src/core/Overlay/Overlay.tsx
@@ -31,7 +31,9 @@ const OverlayComponent = React.forwardRef((props, forwardedRef) => {
     </OverlayWrapper>
   );
 }) as PolymorphicForwardRefComponent<'div', OverlayComponentProps>;
-OverlayComponent.displayName = 'Overlay';
+if (process.env.NODE_ENV === 'development') {
+  OverlayComponent.displayName = 'Overlay';
+}
 
 // --------------------------------------------------------------------------------
 
@@ -44,17 +46,23 @@ const OverlayHiddenContent = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div'>;
-OverlayHiddenContent.displayName = 'Overlay.HiddenContent';
+if (process.env.NODE_ENV === 'development') {
+  OverlayHiddenContent.displayName = 'Overlay.HiddenContent';
+}
 
 // --------------------------------------------------------------------------------
 
 const OverlayOverlay = polymorphic('iui-overlay');
-OverlayOverlay.displayName = 'Overlay.Overlay';
+if (process.env.NODE_ENV === 'development') {
+  OverlayOverlay.displayName = 'Overlay.Overlay';
+}
 
 // --------------------------------------------------------------------------------
 
 const OverlayWrapper = polymorphic('iui-overlay-wrapper');
-OverlayWrapper.displayName = 'Overlay.Wrapper';
+if (process.env.NODE_ENV === 'development') {
+  OverlayWrapper.displayName = 'Overlay.Wrapper';
+}
 
 // --------------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/SearchBox/SearchBox.tsx
+++ b/packages/itwinui-react/src/core/SearchBox/SearchBox.tsx
@@ -198,7 +198,9 @@ const SearchBoxCollapsedState = ({
 
   return <>{children ?? <SearchBoxExpandButton />}</>;
 };
-SearchBoxCollapsedState.displayName = 'SearchBox.CollapsedState';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxCollapsedState.displayName = 'SearchBox.CollapsedState';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -215,7 +217,9 @@ const SearchBoxExpandedState = ({
 
   return <>{children}</>;
 };
-SearchBoxExpandedState.displayName = 'SearchBox.ExpandedState';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxExpandedState.displayName = 'SearchBox.ExpandedState';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -233,7 +237,9 @@ const SearchBoxIcon = React.forwardRef((props, ref) => {
     </InputFlexContainerIcon>
   );
 }) as PolymorphicForwardRefComponent<'span', IconProps>;
-SearchBoxIcon.displayName = 'SearchBox.Icon';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxIcon.displayName = 'SearchBox.Icon';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -262,7 +268,9 @@ const SearchBoxInput = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'input'>;
-SearchBoxInput.displayName = 'SearchBox.Input';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxInput.displayName = 'SearchBox.Input';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -281,7 +289,9 @@ const SearchBoxButton = React.forwardRef((props, ref) => {
     </InputFlexContainerButton>
   );
 }) as PolymorphicForwardRefComponent<'button', IconButtonProps>;
-SearchBoxButton.displayName = 'SearchBox.Button';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxButton.displayName = 'SearchBox.Button';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -307,7 +317,9 @@ const SearchBoxCollapseButton = React.forwardRef((props, ref) => {
     </SearchBoxButton>
   );
 }) as PolymorphicForwardRefComponent<'button', IconButtonProps>;
-SearchBoxCollapseButton.displayName = 'SearchBox.CollapseButton';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxCollapseButton.displayName = 'SearchBox.CollapseButton';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -335,7 +347,9 @@ const SearchBoxExpandButton = React.forwardRef((props, ref) => {
     </SearchBoxButton>
   );
 }) as PolymorphicForwardRefComponent<'button', IconButtonProps>;
-SearchBoxExpandButton.displayName = 'SearchBox.ExpandButton';
+if (process.env.NODE_ENV === 'development') {
+  SearchBoxExpandButton.displayName = 'SearchBox.ExpandButton';
+}
 
 // ----------------------------------------------------------------------------
 
@@ -390,4 +404,6 @@ export const SearchBox = Object.assign(SearchBoxComponent, {
   CollapsedState: SearchBoxCollapsedState,
 });
 
-SearchBox.displayName = 'SearchBox';
+if (process.env.NODE_ENV === 'development') {
+  SearchBox.displayName = 'SearchBox';
+}

--- a/packages/itwinui-react/src/core/Tabs/Tabs.tsx
+++ b/packages/itwinui-react/src/core/Tabs/Tabs.tsx
@@ -130,7 +130,9 @@ const TabsWrapper = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TabsWrapperOwnProps>;
-TabsWrapper.displayName = 'Tabs.Wrapper';
+if (process.env.NODE_ENV === 'development') {
+  TabsWrapper.displayName = 'Tabs.Wrapper';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.TabList component
@@ -185,7 +187,9 @@ const TabList = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TabListOwnProps>;
-TabList.displayName = 'Tabs.TabList';
+if (process.env.NODE_ENV === 'development') {
+  TabList.displayName = 'Tabs.TabList';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.Tab component
@@ -367,7 +371,9 @@ const Tab = React.forwardRef((props, forwardedRef) => {
     </ButtonBase>
   );
 }) as PolymorphicForwardRefComponent<'button', TabOwnProps>;
-Tab.displayName = 'Tabs.Tab';
+if (process.env.NODE_ENV === 'development') {
+  Tab.displayName = 'Tabs.Tab';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.TabIcon component
@@ -381,13 +387,17 @@ const TabIcon = React.forwardRef((props, ref) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'span', React.ComponentProps<typeof Icon>>;
-TabIcon.displayName = 'Tabs.TabIcon';
+if (process.env.NODE_ENV === 'development') {
+  TabIcon.displayName = 'Tabs.TabIcon';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.TabLabel component
 
 const TabLabel = polymorphic.span('iui-tab-label');
-TabLabel.displayName = 'Tabs.TabLabel';
+if (process.env.NODE_ENV === 'development') {
+  TabLabel.displayName = 'Tabs.TabLabel';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.TabDescription component
@@ -413,7 +423,9 @@ const TabDescription = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'span'>;
-TabDescription.displayName = 'Tabs.TabDescription';
+if (process.env.NODE_ENV === 'development') {
+  TabDescription.displayName = 'Tabs.TabDescription';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.Actions component
@@ -439,7 +451,9 @@ const TabsActions = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TabsActionsOwnProps>;
-TabsActions.displayName = 'Tabs.Actions';
+if (process.env.NODE_ENV === 'development') {
+  TabsActions.displayName = 'Tabs.Actions';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs.Panel component
@@ -474,7 +488,9 @@ const TabsPanel = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TabsPanelOwnProps>;
-TabsPanel.displayName = 'Tabs.Panel';
+if (process.env.NODE_ENV === 'development') {
+  TabsPanel.displayName = 'Tabs.Panel';
+}
 
 // ----------------------------------------------------------------------------
 // Tabs legacy component
@@ -600,7 +616,9 @@ const LegacyTabsComponent = React.forwardRef((props, forwardedRef) => {
     </TabsWrapper>
   );
 }) as PolymorphicForwardRefComponent<'div', TabsLegacyProps>;
-LegacyTabsComponent.displayName = 'Tabs';
+if (process.env.NODE_ENV === 'development') {
+  LegacyTabsComponent.displayName = 'Tabs';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -205,7 +205,9 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
     </ScopeProvider>
   );
 }) as PolymorphicForwardRefComponent<'div', ThemeProviderOwnProps>;
-ThemeProvider.displayName = 'ThemeProvider';
+if (process.env.NODE_ENV === 'development') {
+  ThemeProvider.displayName = 'ThemeProvider';
+}
 
 // ----------------------------------------------------------------------------
 

--- a/packages/itwinui-react/src/core/Tile/Tile.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.tsx
@@ -61,7 +61,9 @@ const TileContext = React.createContext<
     }
   | undefined
 >(undefined);
-TileContext.displayName = 'TileContext';
+if (process.env.NODE_ENV === 'development') {
+  TileContext.displayName = 'TileContext';
+}
 
 // ----------------------------------------------------------------------------
 // Main Tile component
@@ -148,7 +150,9 @@ const TileWrapper = React.forwardRef((props, forwardedRef) => {
     </TileContext.Provider>
   );
 }) as PolymorphicForwardRefComponent<'div', TileWrapperOwnProps>;
-TileWrapper.displayName = 'Tile.Wrapper';
+if (process.env.NODE_ENV === 'development') {
+  TileWrapper.displayName = 'Tile.Wrapper';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.Action component
@@ -175,13 +179,17 @@ const TileAction = React.forwardRef((props, forwardedRef) => {
     </LinkAction>
   );
 }) as PolymorphicForwardRefComponent<'a'>;
-TileAction.displayName = 'Tile.Action';
+if (process.env.NODE_ENV === 'development') {
+  TileAction.displayName = 'Tile.Action';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.ThumbnailArea component
 
 const TileThumbnailArea = polymorphic('iui-tile-thumbnail');
-TileThumbnailArea.displayName = 'Tile.ThumbnailArea';
+if (process.env.NODE_ENV === 'development') {
+  TileThumbnailArea.displayName = 'Tile.ThumbnailArea';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.ThumbnailPicture component
@@ -219,19 +227,25 @@ const TileThumbnailPicture = React.forwardRef((props, forwardedRef) => {
   );
 }) as PolymorphicForwardRefComponent<'div', TileThumbnailPictureOwnProps>;
 
-TileThumbnailPicture.displayName = 'Tile.TileThumbnailPicture';
+if (process.env.NODE_ENV === 'development') {
+  TileThumbnailPicture.displayName = 'Tile.TileThumbnailPicture';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.QuickAction component
 
 const TileQuickAction = polymorphic('iui-tile-thumbnail-quick-action');
-TileQuickAction.displayName = 'Tile.QuickAction';
+if (process.env.NODE_ENV === 'development') {
+  TileQuickAction.displayName = 'Tile.QuickAction';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.TypeIndicator component
 
 const TileTypeIndicator = polymorphic('iui-tile-thumbnail-type-indicator');
-TileTypeIndicator.displayName = 'Tile.TypeIndicator';
+if (process.env.NODE_ENV === 'development') {
+  TileTypeIndicator.displayName = 'Tile.TypeIndicator';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.IconButton component
@@ -253,13 +267,17 @@ const TileIconButton = React.forwardRef((props, forwardedRef) => {
   'button',
   React.ComponentPropsWithoutRef<typeof IconButton>
 >;
-TileIconButton.displayName = 'Tile.IconButton';
+if (process.env.NODE_ENV === 'development') {
+  TileIconButton.displayName = 'Tile.IconButton';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.BadgeContainer component
 
 const TileBadgeContainer = polymorphic('iui-tile-thumbnail-badge-container');
-TileBadgeContainer.displayName = 'Tile.BadgeContainer';
+if (process.env.NODE_ENV === 'development') {
+  TileBadgeContainer.displayName = 'Tile.BadgeContainer';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.Name component
@@ -279,7 +297,9 @@ const TileName = React.forwardRef((props, forwardedRef) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TileNameOwnProps>;
-TileBadgeContainer.displayName = 'Tile.Name';
+if (process.env.NODE_ENV === 'development') {
+  TileBadgeContainer.displayName = 'Tile.Name';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.NameIcon component
@@ -314,31 +334,41 @@ const TileNameIcon = React.forwardRef((props, forwardedRef) => {
     </Box>
   ) : null;
 }) as PolymorphicForwardRefComponent<'div'>;
-TileNameIcon.displayName = 'Tile.NameIcon';
+if (process.env.NODE_ENV === 'development') {
+  TileNameIcon.displayName = 'Tile.NameIcon';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.NameLabel component
 
 const TileNameLabel = polymorphic.span('iui-tile-name-label');
-TileNameLabel.displayName = 'Tile.NameLabel';
+if (process.env.NODE_ENV === 'development') {
+  TileNameLabel.displayName = 'Tile.NameLabel';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.ContentArea component
 
 const TileContentArea = polymorphic('iui-tile-content');
-TileContentArea.displayName = 'Tile.ContentArea';
+if (process.env.NODE_ENV === 'development') {
+  TileContentArea.displayName = 'Tile.ContentArea';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.Description component
 
 const TileDescription = polymorphic('iui-tile-description');
-TileDescription.displayName = 'Tile.Description';
+if (process.env.NODE_ENV === 'development') {
+  TileDescription.displayName = 'Tile.Description';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.Metadata component
 
 const TileMetadata = polymorphic('iui-tile-metadata');
-TileMetadata.displayName = 'Tile.Metadata';
+if (process.env.NODE_ENV === 'development') {
+  TileMetadata.displayName = 'Tile.Metadata';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.MoreOptions component
@@ -388,13 +418,17 @@ const TileMoreOptions = React.forwardRef((props, forwardedRef) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TileMoreOptionsOwnProps>;
-TileMoreOptions.displayName = 'Tile.MoreOptions';
+if (process.env.NODE_ENV === 'development') {
+  TileMoreOptions.displayName = 'Tile.MoreOptions';
+}
 
 // ----------------------------------------------------------------------------
 // Tile.Buttons component
 
 const TileButtons = polymorphic('iui-tile-buttons');
-TileButtons.displayName = 'Tile.Buttons';
+if (process.env.NODE_ENV === 'development') {
+  TileButtons.displayName = 'Tile.Buttons';
+}
 
 // ----------------------------------------------------------------------------
 type TileLegacyProps = {
@@ -576,7 +610,9 @@ const TileComponent = React.forwardRef((props, forwardedRef) => {
     </TileWrapper>
   );
 }) as PolymorphicForwardRefComponent<'div', TileLegacyProps>;
-TileComponent.displayName = 'Tile';
+if (process.env.NODE_ENV === 'development') {
+  TileComponent.displayName = 'Tile';
+}
 
 /**
  * Tile with customizable Thumbnail, Name, Content and Buttons subcomponents

--- a/packages/itwinui-react/src/core/Toast/Toaster.tsx
+++ b/packages/itwinui-react/src/core/Toast/Toaster.tsx
@@ -152,7 +152,9 @@ const toastReducer = (state: ToasterState, action: ToasterAction) => {
 export const ToasterStateContext = React.createContext<
   ToasterState | undefined
 >(undefined);
-ToasterStateContext.displayName = 'ToasterStateContext';
+if (process.env.NODE_ENV === 'development') {
+  ToasterStateContext.displayName = 'ToasterStateContext';
+}
 
 type ToasterState = { toasts: ToastProps[]; settings: ToasterSettings };
 
@@ -161,7 +163,9 @@ type ToasterState = { toasts: ToastProps[]; settings: ToasterSettings };
 const ToasterDispatchContext = React.createContext<
   React.Dispatch<ToasterAction> | undefined
 >(undefined);
-ToasterDispatchContext.displayName = 'ToasterDispatchContext';
+if (process.env.NODE_ENV === 'development') {
+  ToasterDispatchContext.displayName = 'ToasterDispatchContext';
+}
 
 type ToasterAction =
   | { type: 'add'; toast: ToastProps }

--- a/packages/itwinui-react/src/core/TransferList/TransferList.tsx
+++ b/packages/itwinui-react/src/core/TransferList/TransferList.tsx
@@ -21,7 +21,9 @@ import { Label } from '../Label/Label.js';
 // TransferListComponent
 
 const TransferListComponent = polymorphic('iui-transfer-list-wrapper');
-TransferListComponent.displayName = 'TransferList';
+if (process.env.NODE_ENV === 'development') {
+  TransferListComponent.displayName = 'TransferList';
+}
 
 // ----------------------------------------------------------------------------
 // TransferList.ListboxWrapper component
@@ -47,7 +49,9 @@ const TransferListListboxWrapper = React.forwardRef((props, ref) => {
     </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TransferListListboxWrapperOwnProps>;
-TransferListListboxWrapper.displayName = 'TransferList.ListboxWrapper';
+if (process.env.NODE_ENV === 'development') {
+  TransferListListboxWrapper.displayName = 'TransferList.ListboxWrapper';
+}
 
 // ----------------------------------------------------------------------------
 // TransferList.Listbox component
@@ -124,7 +128,9 @@ const TransferListListbox = React.forwardRef((props, ref) => {
     </List>
   );
 }) as PolymorphicForwardRefComponent<'ul', TransferListListboxOwnProps>;
-TransferListListbox.displayName = 'TransferList.Listbox';
+if (process.env.NODE_ENV === 'development') {
+  TransferListListbox.displayName = 'TransferList.Listbox';
+}
 
 // ----------------------------------------------------------------------------
 // TransferList.Item component
@@ -182,7 +188,9 @@ const TransferListItem = React.forwardRef((props, ref) => {
     </ListItem>
   );
 }) as PolymorphicForwardRefComponent<'li', TransferListItemOwnProps>;
-TransferListItem.displayName = 'TransferList.Item';
+if (process.env.NODE_ENV === 'development') {
+  TransferListItem.displayName = 'TransferList.Item';
+}
 
 // ----------------------------------------------------------------------------
 // TransferList.ListboxLabel component
@@ -211,7 +219,9 @@ const TransferListListboxLabel = React.forwardRef((props, ref) => {
     </Label>
   );
 }) as PolymorphicForwardRefComponent<'div', TransferListListboxLabelOwnProps>;
-TransferListListboxLabel.displayName = 'TransferList.ListboxLabel';
+if (process.env.NODE_ENV === 'development') {
+  TransferListListboxLabel.displayName = 'TransferList.ListboxLabel';
+}
 
 // ----------------------------------------------------------------------------
 // TransferList.Toolbar component
@@ -219,7 +229,9 @@ TransferListListboxLabel.displayName = 'TransferList.ListboxLabel';
 const TransferListToolbar = polymorphic('iui-transfer-list-toolbar', {
   role: 'toolbar',
 });
-TransferListToolbar.displayName = 'TransferList.Toolbar';
+if (process.env.NODE_ENV === 'development') {
+  TransferListToolbar.displayName = 'TransferList.Toolbar';
+}
 
 /**
  * The TransferList component is used to display a list within a box

--- a/packages/itwinui-react/src/utils/components/ButtonBase.tsx
+++ b/packages/itwinui-react/src/utils/components/ButtonBase.tsx
@@ -49,7 +49,9 @@ export const ButtonBase = React.forwardRef((props, forwardedRef) => {
     />
   );
 }) as PolymorphicForwardRefComponent<'button', ButtonBaseProps>;
-ButtonBase.displayName = 'ButtonBase';
+if (process.env.NODE_ENV === 'development') {
+  ButtonBase.displayName = 'ButtonBase';
+}
 
 type ButtonBaseProps = {
   /**

--- a/packages/itwinui-react/src/utils/components/InputWithIcon.tsx
+++ b/packages/itwinui-react/src/utils/components/InputWithIcon.tsx
@@ -6,4 +6,6 @@ import { polymorphic } from '../functions/polymorphic.js';
 
 /** @private */
 export const InputWithIcon = polymorphic.div('iui-input-with-icon');
-InputWithIcon.displayName = 'InputWithIcon';
+if (process.env.NODE_ENV === 'development') {
+  InputWithIcon.displayName = 'InputWithIcon';
+}

--- a/packages/itwinui-react/src/utils/functions/polymorphic.tsx
+++ b/packages/itwinui-react/src/utils/functions/polymorphic.tsx
@@ -38,7 +38,9 @@ const _base = <As extends keyof JSX.IntrinsicElements = 'div'>(
       return <Element ref={ref} {...props} />;
     }) as PolymorphicForwardRefComponent<NonNullable<typeof defaultElement>>;
 
-    Comp.displayName = getDisplayNameFromClass(className);
+    if (process.env.NODE_ENV === 'development') {
+      Comp.displayName = getDisplayNameFromClass(className);
+    }
 
     return Comp;
   };

--- a/packages/itwinui-react/src/utils/hooks/useSafeContext.ts
+++ b/packages/itwinui-react/src/utils/hooks/useSafeContext.ts
@@ -11,7 +11,7 @@ import * as React from 'react';
 export const useSafeContext = <T>(context: React.Context<T>) => {
   const value = React.useContext(context);
   if (!value) {
-    throw new Error(`${context.displayName} is undefined`);
+    throw new Error(`${context.displayName || 'Context'} is undefined`);
   }
   return value!; // eslint-disable-line @typescript-eslint/no-non-null-assertion -- we already checked for undefined
 };


### PR DESCRIPTION
## Changes

Follow-up to #2131, all `displayName`s are now conditionally added only during development.

While this shouldn't make a big difference in the bundle size, the code is only useful for React developer tools, and does add up over time when there are lots of components, so it's good to not have it in the prod build.

## Testing

Manually inspected the build outputs to verify that `.displayName` assignments are correctly present only in the dev build and removed from the prod build.

## Docs

Added patch changeset.