### PR TITLE
bypass bundler import for loading `inert` polyfill

### DIFF
--- a/.changeset/few-candles-impress.md
+++ b/.changeset/few-candles-impress.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where the `Overlay` component was causing bundler warnings about a non-analyzable expression used in a dependency.

--- a/packages/itwinui-react/src/core/Overlay/Overlay.tsx
+++ b/packages/itwinui-react/src/core/Overlay/Overlay.tsx
@@ -105,7 +105,7 @@ const useInertPolyfill = () => {
   React.useEffect(() => {
     (async () => {
       if (!HTMLElement.prototype.hasOwnProperty('inert') && !loaded.current) {
-        await import(/* webpackIgnore: true */ /* @vite-ignore */ modulePath);
+        await new Function(`return import("${modulePath}")`)();
         loaded.current = true;
       }
     })();

--- a/packages/itwinui-react/src/core/Overlay/Overlay.tsx
+++ b/packages/itwinui-react/src/core/Overlay/Overlay.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Box, polymorphic } from '../../utils/index.js';
+import { Box, isUnitTest, polymorphic } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
 type OverlayComponentProps = {
@@ -104,7 +104,11 @@ const useInertPolyfill = () => {
 
   React.useEffect(() => {
     (async () => {
-      if (!HTMLElement.prototype.hasOwnProperty('inert') && !loaded.current) {
+      if (
+        !HTMLElement.prototype.hasOwnProperty('inert') &&
+        !loaded.current &&
+        !isUnitTest
+      ) {
         await new Function(`return import("${modulePath}")`)();
         loaded.current = true;
       }

--- a/packages/itwinui-react/src/core/Overlay/Overlay.tsx
+++ b/packages/itwinui-react/src/core/Overlay/Overlay.tsx
@@ -117,7 +117,7 @@ const useInertPolyfill = () => {
         !loaded.current &&
         !isUnitTest
       ) {
-        await new Function(`return import("${modulePath}")`)();
+        await new Function('url', 'return import(url)')(modulePath);
         loaded.current = true;
       }
     })();


### PR DESCRIPTION
## Changes

Ever since #2100, all code comments were stripped out from the build output. This had the adverse effect of removing the `/*@vite-ignore*/` and `/*webpackIgnore*/` comments in `useInertPolyfill` that were meant to be preserved.

In this PR, I've changed it to use [`Function()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function) so that it runs only in the browser, bypassing all static analysis by bundlers. This is perfectly ok to do because we explicitly don't want bundlers to touch this import (which is why we're using a CDN rather than an npm dependency), i.e. it should execute directly in the browser.

This fixes an issue that was reported in https://github.com/iTwin/viewer/issues/318#issuecomment-2194756091.

Unrelated: I also added `isUnitTest` to the if condition. While newer versions of `jsdom` should ~~already have a shim for `inert`~~ (edit: [or not](https://redirect.github.com/jsdom/jsdom/issues/3605)), this code is only relevant for browsers so it shouldn't run in unit tests at all.

## Testing

Verified that the dynamic import is working and a network request is made to jsdelivr for the `inert.min.js` file when simulating old browsers (by skipping the check for `inert` support).

```diff
- if (!HTMLElement.prototype.hasOwnProperty('inert') && !loaded.current && !isUnitTest) {
+ if (true) {
    await new Function('url', `return import(url)`)(modulePath);
```

![](https://github.com/user-attachments/assets/b176ca67-d020-4ee3-bbf5-af1e24d359dc)


## Docs

Added patch changeset.
