### PR TITLE
fix grid blowout in `ExpandableBlock`

### DIFF
--- a/.changeset/silly-bats-hear.md
+++ b/.changeset/silly-bats-hear.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed grid blowout in `iui-expandable-content` using `grid-template-columns: minmax(0, 1fr)`.

--- a/.changeset/swift-chairs-trade.md
+++ b/.changeset/swift-chairs-trade.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a CSS issue in `ExpandableBlock` where its content wouldn't stay constrained by the width of the parent.

--- a/packages/itwinui-css/src/expandable-block/expandable-block.scss
+++ b/packages/itwinui-css/src/expandable-block/expandable-block.scss
@@ -157,6 +157,7 @@
   // using transition technique from https://css-tricks.com/css-grid-can-do-auto-height-transitions/
   display: grid;
   grid-template-rows: 0fr;
+  grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
   transition: all var(--iui-duration-1) ease-out;
   transition-property: opacity;


### PR DESCRIPTION
## Changes

Fixes #2144 

When using CSS grid, [grid blowout](https://css-tricks.com/preventing-a-grid-blowout/) is a common problem: the content inside the grid can become too wide, escaping the bounds of the intended grid layout. This is already bad enough as a default, but the problem gets compounded by the fact that we hide overflow in our expandable content. Adding `grid-template-columns: minmax(0, 1fr)` is the recommended way to fix this problem.

## Testing

Verified that the linked issue is fixed by recreating it in vite playground

<details><summary>App.tsx</summary>

```tsx
import { Anchor, ExpandableBlock } from '@itwin/itwinui-react';

const lorem =
  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';

export default function App() {
  return (
    <>
      <ExpandableBlock title='Warning'>
        <Anchor
          href='https://www.example.com'
          isExternal
          target='_blank'
          style={{
            textOverflow: 'ellipsis',
            overflow: 'hidden',
            whiteSpace: 'nowrap',
            display: 'block',
          }}
        >
          {lorem}
        </Anchor>
      </ExpandableBlock>
    </>
  );
}
```

</details> 

![](https://github.com/user-attachments/assets/4d9b6d3c-3f04-44bf-ab97-6d35d1e898e4)


## Docs

Added patch changesets for both CSS and React.
