### PR TITLE
Fix `toggleRowSelected` action value for the `Table` `stateReducer`.

### DIFF
--- a/.changeset/two-lemons-end.md
+++ b/.changeset/two-lemons-end.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed regression where the value of the `toggleRowSelected` action for the `Table` would be undefined when `selectSubRows` was set to `false`.

--- a/packages/itwinui-react/src/core/Table/columns/selectionColumn.tsx
+++ b/packages/itwinui-react/src/core/Table/columns/selectionColumn.tsx
@@ -91,7 +91,7 @@ export const SelectionColumn = <T extends Record<string, unknown>>(
               ),
             );
           } else {
-            row.toggleRowSelected();
+            row.toggleRowSelected(!row.isSelected);
           }
         }}
       />

--- a/testing/e2e/app/routes/Table/route.tsx
+++ b/testing/e2e/app/routes/Table/route.tsx
@@ -17,6 +17,7 @@ export default function Resizing() {
   const empty = searchParams.get('empty') === 'true';
   const scroll = searchParams.get('scroll') === 'true';
   const oneRow = searchParams.get('oneRow') === 'true';
+  const stateReducer = searchParams.get('stateReducer') === 'true';
   const scrollRow = Number(searchParams.get('scrollRow'));
 
   const virtualizedData = React.useMemo(() => {
@@ -156,6 +157,16 @@ export default function Resizing() {
           scroll
             ? (rows, data) =>
                 rows.findIndex((row) => row.original === data[scrollRow])
+            : undefined
+        }
+        stateReducer={
+          stateReducer
+            ? (newState, action, previousState, instance) => {
+                if (action.type === 'toggleRowSelected') {
+                  console.log(action.value);
+                }
+                return newState;
+              }
             : undefined
         }
       />

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -360,6 +360,42 @@ test.describe('Table row selection', () => {
     await expect(row21Checkbox).not.toBeChecked();
   });
 
+  test('action object for row selection in state reducer should have a defined value when selectSubRows is set to false', async ({
+    page,
+  }) => {
+    await page.goto(
+      '/Table?isSelectable=true&subRows=true&selectSubRows=false&stateReducer=true',
+    );
+
+    const row2 = page
+      .getByRole('row')
+      .filter({ has: page.getByRole('cell').getByText('2', { exact: true }) });
+    const row2SubRowExpander = row2.getByLabel('Toggle sub row');
+    await row2SubRowExpander.click();
+
+    const row21 = page.getByRole('row').filter({
+      has: page.getByRole('cell').getByText('2.1', { exact: true }),
+    });
+    const row2Checkbox = row2.getByRole('checkbox');
+    const row21Checkbox = row21.getByRole('checkbox');
+
+    //Works correctly for sub row
+    const firstSubRowMessage = page.waitForEvent('console');
+    await row21Checkbox.click();
+    expect((await firstSubRowMessage).text()).toBe('true');
+    const secondSubRowMessage = page.waitForEvent('console');
+    await row21Checkbox.click();
+    expect((await secondSubRowMessage).text()).toBe('false');
+
+    //Works correctly for parent row
+    const firstParentRowMessage = page.waitForEvent('console');
+    await row2Checkbox.click();
+    expect((await firstParentRowMessage).text()).toBe('true');
+    const secondParentRowMessage = page.waitForEvent('console');
+    await row2Checkbox.click();
+    expect((await secondParentRowMessage).text()).toBe('false');
+  });
+
   //#region Helpers for row selection tests
   const filter = async (page: Page) => {
     const filterButton = page.getByLabel('Filter');


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Fixes a user reported issue in the react teams channel where the `toggleRowSelected` action type would not have a defined value. This was fixed by adding a Boolean parameter to the `row.toggleRowSelected()` function call, instead of relying on the default behavior.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Tested with this code in the vite playground to make sure this change worked: 
```tsx
import { Table } from '@itwin/itwinui-react';

import '@itwin/itwinui-react/styles.css';
import { useMemo } from 'react';
import {
  ActionType,
  TableInstance,
  TableState,
} from '@itwin/itwinui-react/react-table';

export default function App() {
  return <ExpandableSubRowsTable />;
}

const ExpandableSubRowsTable = () => {
  const columns = useMemo(
    () => [
      {
        id: 'name',
        Header: 'Name',
        accessor: 'name',
      },
      {
        id: 'description',
        Header: 'Description',
        accessor: 'description',
      },
    ],
    [],
  );

  const data = [
    {
      name: 'Row 1',
      description: 'Description 1',
      subRows: [
        { name: 'Row 1.1', description: 'Description 1.1', subRows: [] },
        {
          name: 'Row 1.2',
          description: 'Description 1.2',
          subRows: [
            {
              name: 'Row 1.2.1',
              description: 'Description 1.2.1',
              subRows: [],
            },
            {
              name: 'Row 1.2.2',
              description: 'Description 1.2.2',
              subRows: [],
            },
            {
              name: 'Row 1.2.3',
              description: 'Description 1.2.3',
              subRows: [],
            },
            {
              name: 'Row 1.2.4',
              description: 'Description 1.2.4',
              subRows: [],
            },
          ],
        },
        { name: 'Row 1.3', description: 'Description 1.3', subRows: [] },
        { name: 'Row 1.4', description: 'Description 1.4', subRows: [] },
      ],
    },
    {
      name: 'Row 2',
      description: 'Description 2',
      subRows: [
        { name: 'Row 2.1', description: 'Description 2.1', subRows: [] },
      ],
    },
    { name: 'Row 3', description: 'Description 3', subRows: [] },
  ];

  const stateReducer = (
    newState: TableState,
    action: ActionType,
    _prevSate: TableState,
    _instance: TableInstance | undefined,
  ) => {
    console.log({ action });
    return newState;
  };

  return (
    <Table
      emptyTableContent='No data.'
      isSelectable
      selectSubRows={false}
      data={data}
      columns={columns}
      stateReducer={stateReducer}
    />
  );
};

```

Also added an e2e test for this issue to prevent future regressions.
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Added react patch changeset.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
