### PR TITLE
Fixes virtualized `Table` empty content

### DIFF
--- a/.changeset/quiet-kangaroos-teach.md
+++ b/.changeset/quiet-kangaroos-teach.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed issue where `emptyTableContent` would not appear on virutalized `Table` components.

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -1153,7 +1153,7 @@ export const Table = <
           }
         >
           <ShadowRoot>
-            {enableVirtualization ? (
+            {enableVirtualization && data.length !== 0 ? (
               <div
                 style={{
                   minBlockSize: virtualizer.getTotalSize(),

--- a/testing/e2e/app/routes/Table/route.tsx
+++ b/testing/e2e/app/routes/Table/route.tsx
@@ -22,16 +22,17 @@ export default function Resizing() {
 
   const virtualizedData = React.useMemo(() => {
     const size = oneRow ? 1 : 100000;
+    if (empty) {
+      return [];
+    }
     const arr = new Array(size);
-    if (!empty) {
-      for (let i = 0; i < size; ++i) {
-        arr[i] = {
-          index: i,
-          name: `Name${i}`,
-          description: `Description${i}`,
-          id: i,
-        };
-      }
+    for (let i = 0; i < size; ++i) {
+      arr[i] = {
+        index: i,
+        name: `Name${i}`,
+        description: `Description${i}`,
+        id: i,
+      };
     }
     return arr;
   }, [oneRow, empty]);

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -450,7 +450,11 @@ test.describe('Virtual Scroll Tests', () => {
     }); //Need to wait until the virtual rows are able to be rendered for the tests to work.
 
     const rows = page.getByRole('rowgroup').getByRole('row');
+    const emptyContent = page.getByRole('rowgroup').getByText('No Data.');
     expect((await rows.all()).length).toBe(0);
+
+    //Checks empty content to make sure it appears correctly.
+    await expect(emptyContent).toBeInViewport();
   });
 
   test('virtualized table should scroll to provided row', async ({ page }) => {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Fixes the virtualized `Table` components `emptyTableContent` value. This is done by making sure that the `<div>` meant to wrap around the virtual items is only added when there is data being passed into the `Table`, since this `<div>` has a height of 0 when there are no virtual items, causing the `emptyTableContent` to not display.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Updated the e2e test for empty virtualized table to check for the `emptyTableContent`. Also tested with this code in the vite playground: 
```tsx
import * as React from 'react';
import { Table } from '@itwin/itwinui-react';
import { Column } from '@itwin/itwinui-react/react-table';

const App = () => {
  type CustomStoryDataType = {
    name: string;
    description: string;
  };

  const columns = React.useMemo(
    () => [
      {
        id: 'name',
        Header: 'Name',
        accessor: 'name',
      },
      {
        id: 'description',
        Header: 'Description',
        accessor: 'description',
        maxWidth: 200,
      },
    ],
    [],
  ) satisfies Column<CustomStoryDataType>[];

  return (
    <Table<CustomStoryDataType>
      columns={columns}
      data={[]}
      enableVirtualization={true}
      isLoading={false}
      emptyTableContent='No data.'
    />
  );
};

export default App;

```
<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Added patch react changeset.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
