### PR TITLE
bump `lightningcss`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,10 +91,10 @@ importers:
         version: 0.20.0
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       astro-relative-links:
         specifier: ^0.3.7
-        version: 0.3.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 0.3.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       backstopjs:
         specifier: ~6.2.1
         version: 6.2.2(typescript@5.5.2)
@@ -106,7 +106,7 @@ importers:
     dependencies:
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
 
   apps/react-workshop:
     devDependencies:
@@ -127,7 +127,7 @@ importers:
         version: link:../../packages/itwinui-variables
       '@ladle/react':
         specifier: ^4.0.2
-        version: 4.0.2(@swc/helpers@0.5.11)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 4.0.2(@swc/helpers@0.5.11)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.5.2)
       '@types/node':
         specifier: '*'
         version: 18.17.19
@@ -160,16 +160,16 @@ importers:
         version: 5.5.2
       vite:
         specifier: '*'
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
 
   apps/website:
     dependencies:
       '@astrojs/mdx':
         specifier: '2'
-        version: 2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2))
+        version: 2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2))
       '@astrojs/react':
         specifier: '3'
-        version: 3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       '@astrojs/sitemap':
         specifier: '3'
         version: 3.1.1
@@ -202,13 +202,13 @@ importers:
         version: 18.2.14
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       astro-auto-import:
         specifier: ^0.4.2
-        version: 0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2))
+        version: 0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2))
       astro-expressive-code:
         specifier: ^0.33.5
-        version: 0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2))
+        version: 0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2))
       examples:
         specifier: workspace:*
         version: link:../../examples
@@ -217,7 +217,7 @@ importers:
         version: 3.1.1
       lightningcss:
         specifier: ^1.25.0
-        version: 1.25.0
+        version: 1.25.1
       nanoid:
         specifier: '*'
         version: 5.0.6
@@ -318,7 +318,7 @@ importers:
         version: 3.5.3
       lightningcss:
         specifier: ^1.25.0
-        version: 1.25.0
+        version: 1.25.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -367,7 +367,7 @@ importers:
         version: 1.5.28(@swc/helpers@0.5.11)
       '@testing-library/jest-dom':
         specifier: ^6.3.0
-        version: 6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0))
       '@testing-library/react':
         specifier: ^13.2.0
         version: 13.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -388,7 +388,7 @@ importers:
         version: 4.4.10
       '@vitest/coverage-v8':
         specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0))
       eslint:
         specifier: ^8
         version: 8.56.0
@@ -412,10 +412,10 @@ importers:
         version: 5.5.2
       vite:
         specifier: ^5.1.7
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
       vitest:
         specifier: ^1.2.1
-        version: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0)
 
   packages/itwinui-variables:
     devDependencies:
@@ -427,13 +427,13 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: '3'
-        version: 3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       '@itwin/itwinui-react':
         specifier: '*'
         version: link:../../packages/itwinui-react
       astro:
         specifier: ~4.5.6
-        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+        version: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -494,7 +494,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       '@types/react':
         specifier: 18.2.14
         version: 18.2.14
@@ -506,10 +506,10 @@ importers:
         version: 5.5.2
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
 
   playgrounds/vite:
     dependencies:
@@ -534,13 +534,13 @@ importers:
         version: 18.2.18
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       typescript:
         specifier: ~5.5.2
         version: 5.5.2
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
 
   testing/a11y:
     dependencies:
@@ -589,7 +589,7 @@ importers:
         version: 1.42.1
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))
       '@types/node':
         specifier: '*'
         version: 18.17.19
@@ -607,10 +607,10 @@ importers:
         version: 5.5.2
       vite:
         specifier: ^5
-        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+        version: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
+        version: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))
 
 packages:
   '@aashutoshrathi/word-wrap@1.2.6':
@@ -2229,6 +2229,7 @@ packages:
         integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==,
       }
     engines: { node: '>=10.10.0' }
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution:
@@ -2242,6 +2243,7 @@ packages:
       {
         integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==,
       }
+    deprecated: Use @eslint/object-schema instead
 
   '@isaacs/cliui@8.0.2':
     resolution:
@@ -8294,91 +8296,91 @@ packages:
       }
     engines: { node: '>= 0.8.0' }
 
-  lightningcss-darwin-arm64@1.25.0:
+  lightningcss-darwin-arm64@1.25.1:
     resolution:
       {
-        integrity: sha512-neCU5PrQUAec/b2mpXv13rrBWObQVaG/y0yhGKzAqN9cj7lOv13Wegnpiro0M66XAxx/cIkZfmJstRfriOR2SQ==,
+        integrity: sha512-G4Dcvv85bs5NLENcu/s1f7ehzE3D5ThnlWSDwE190tWXRQCQaqwcuHe+MGSVI/slm0XrxnaayXY+cNl3cSricw==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.25.0:
+  lightningcss-darwin-x64@1.25.1:
     resolution:
       {
-        integrity: sha512-h1XBxDHdED7TY4/1V30UNjiqXceGbcL8ARhUfbf8CWAEhD7wMKK/4UqMHi94RDl31ko4LTmt9fS2u1uyeWYE6g==,
+        integrity: sha512-dYWuCzzfqRueDSmto6YU5SoGHvZTMU1Em9xvhcdROpmtOQLorurUZz8+xFxZ51lCO2LnYbfdjZ/gCqWEkwixNg==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.25.0:
+  lightningcss-freebsd-x64@1.25.1:
     resolution:
       {
-        integrity: sha512-f7v6QwrqCFtQOG1Y7iZ4P1/EAmMsyUyRBrYbSmDxihMzdsL7xyTM753H2138/oCpam+maw2RZrXe/NA1r/I5cQ==,
+        integrity: sha512-hXoy2s9A3KVNAIoKz+Fp6bNeY+h9c3tkcx1J3+pS48CqAt+5bI/R/YY4hxGL57fWAIquRjGKW50arltD6iRt/w==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.25.0:
+  lightningcss-linux-arm-gnueabihf@1.25.1:
     resolution:
       {
-        integrity: sha512-7KSVcjci9apHxUKNjiLKXn8hVQJqCtwFg5YNvTeKi/BM91A9lQTuO57RpmpPbRIb20Qm8vR7fZtL1iL5Yo3j9A==,
+        integrity: sha512-tWyMgHFlHlp1e5iW3EpqvH5MvsgoN7ZkylBbG2R2LWxnvH3FuWCJOhtGcYx9Ks0Kv0eZOBud789odkYLhyf1ng==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.25.0:
+  lightningcss-linux-arm64-gnu@1.25.1:
     resolution:
       {
-        integrity: sha512-1+6tuAsUyMVG5N2rzgwaOOf84yEU+Gjl71b+wLcz26lyM/ohgFgeqPWeB/Dor0wyUnq7vg184l8goGT26cRxoQ==,
+        integrity: sha512-Xjxsx286OT9/XSnVLIsFEDyDipqe4BcLeB4pXQ/FEA5+2uWCCuAEarUNQumRucnj7k6ftkAHUEph5r821KBccQ==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.25.0:
+  lightningcss-linux-arm64-musl@1.25.1:
     resolution:
       {
-        integrity: sha512-4kw3ZnGQzxD8KkaB4doqfi32hP5h3o04OlrdfZ7T9VLTbUxeh3YZUKcJmhINV2rdMOOmVODqaRw1kuvvF16Q+Q==,
+        integrity: sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.25.0:
+  lightningcss-linux-x64-gnu@1.25.1:
     resolution:
       {
-        integrity: sha512-oVEP5rBrFQB5V7fRIPYkDxKLmd2fAbz9VagKWIRu1TlYDUFWXK4F3KztAtAKuD7tLMBSGGi1LMUueFzVe+cZbw==,
+        integrity: sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.25.0:
+  lightningcss-linux-x64-musl@1.25.1:
     resolution:
       {
-        integrity: sha512-7ssY6HwCvmPDohqtXuZG2Mh9q32LbVBhiF/SS/VMj2jUcXcsBilUEviq/zFDzhZMxl5f1lXi5/+mCuSGrMir1A==,
+        integrity: sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-x64-msvc@1.25.0:
+  lightningcss-win32-x64-msvc@1.25.1:
     resolution:
       {
-        integrity: sha512-DUVxj1S6dCQkixQ5qiHcYojamxE02bgmSpc4p6lejPwW7WRd/pvDPDAr+BvZWAkX5MRphxB7ei6+93+42ZtvmQ==,
+        integrity: sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==,
       }
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.25.0:
+  lightningcss@1.25.1:
     resolution:
       {
-        integrity: sha512-B08o6QQikGaY4rPuQohtFVE+X2++mm/QemwAJ/1sgnMgTwwUnafJbTmSSBWC8Tv4JPfhelXZB6sWA0Y/6eYJmQ==,
+        integrity: sha512-V0RMVZzK1+rCHpymRv4URK2lNhIRyO8g7U7zOFwVAhJuat74HtkjIQpQRKNCwFEYkRGpafOpmXXLoaoBcyVtBg==,
       }
     engines: { node: '>= 12.0.0' }
 
@@ -11073,7 +11075,7 @@ packages:
       {
         integrity: sha512-39olGaX2djYUdhaQQHDZ0T0GwEp+5f9UB9HmEP0qHfdQHIq0xGQZuAZ5TLnJIc/88SrPLpEflPC+xUqOTv3c5g==,
       }
-    deprecated: < 22.5.0 is no longer supported
+    deprecated: < 21.9.0 is no longer supported
 
   qs@6.10.5:
     resolution:
@@ -14150,12 +14152,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2))':
+  '@astrojs/mdx@2.2.0(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2))':
     dependencies:
       '@astrojs/markdown-remark': 4.3.0
       '@mdx-js/mdx': 3.0.1
       acorn: 8.11.3
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       es-module-lexer: 1.4.2
       estree-util-visit: 2.0.0
       github-slugger: 2.0.0
@@ -14175,11 +14177,11 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/react@3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@astrojs/react@3.0.8(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@types/react': 18.2.14
       '@types/react-dom': 18.2.18
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       ultrahtml: 1.5.2
@@ -14187,11 +14189,11 @@ snapshots:
       - supports-color
       - vite
 
-  '@astrojs/react@3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@astrojs/react@3.1.0(@types/react-dom@18.2.18)(@types/react@18.2.14)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@types/react': 18.2.14
       '@types/react-dom': 18.2.18
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       ultrahtml: 1.5.3
@@ -15175,7 +15177,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@ladle/react@4.0.2(@swc/helpers@0.5.11)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.5.2)':
+  '@ladle/react@4.0.2(@swc/helpers@0.5.11)(@types/node@18.17.19)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.72.0)(typescript@5.5.2)':
     dependencies:
       '@babel/code-frame': 7.23.5
       '@babel/core': 7.23.6
@@ -15187,8 +15189,8 @@ snapshots:
       '@ladle/react-context': 1.0.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mdx-js/mdx': 3.0.0
       '@mdx-js/react': 3.0.0(@types/react@18.2.14)(react@18.2.0)
-      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
-      '@vitejs/plugin-react-swc': 3.5.0(@swc/helpers@0.5.11)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
+      '@vitejs/plugin-react': 4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))
+      '@vitejs/plugin-react-swc': 3.5.0(@swc/helpers@0.5.11)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))
       axe-core: 4.8.2
       boxen: 7.1.1
       chokidar: 3.5.3
@@ -15216,8 +15218,8 @@ snapshots:
       remark-gfm: 4.0.0
       source-map: 0.7.4
       vfile: 6.0.1
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
-      vite-tsconfig-paths: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
+      vite-tsconfig-paths: 4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))
     transitivePeerDependencies:
       - '@swc/helpers'
       - '@types/node'
@@ -15603,7 +15605,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/generator': 7.24.1
@@ -15619,7 +15621,7 @@ snapshots:
       '@remix-run/router': 1.15.3-pre.0
       '@remix-run/server-runtime': 2.8.1(typescript@5.5.2)
       '@types/mdx': 2.0.11
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -15661,7 +15663,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.8.1(typescript@5.5.2)
       typescript: 5.5.2
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - bluebird
@@ -15676,7 +15678,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@remix-run/dev@2.8.1(@remix-run/serve@2.8.1(typescript@5.5.2))(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/generator': 7.24.1
@@ -15692,7 +15694,7 @@ snapshots:
       '@remix-run/router': 1.15.3-pre.0
       '@remix-run/server-runtime': 2.8.1(typescript@5.5.2)
       '@types/mdx': 2.0.11
-      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      '@vanilla-extract/integration': 6.5.0(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -15734,7 +15736,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.8.1(typescript@5.5.2)
       typescript: 5.5.2
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - bluebird
@@ -15984,7 +15986,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@testing-library/jest-dom@6.3.0(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.23.9
@@ -15995,7 +15997,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
+      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0)
 
   '@testing-library/react@13.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -16288,7 +16290,7 @@ snapshots:
       modern-ahocorasick: 1.0.1
       outdent: 0.8.0
 
-  '@vanilla-extract/integration@6.5.0(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.1)
@@ -16301,8 +16303,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.5.0
       outdent: 0.8.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16313,7 +16315,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/integration@6.5.0(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)':
+  '@vanilla-extract/integration@6.5.0(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)':
     dependencies:
       '@babel/core': 7.24.1
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.1)
@@ -16326,8 +16328,8 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.5.0
       outdent: 0.8.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16340,36 +16342,36 @@ snapshots:
 
   '@vanilla-extract/private@1.0.3': {}
 
-  '@vitejs/plugin-react-swc@3.5.0(@swc/helpers@0.5.11)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@vitejs/plugin-react-swc@3.5.0(@swc/helpers@0.5.11)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@swc/core': 1.5.28(@swc/helpers@0.5.11)
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.23.6)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.23.6)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.23.6)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.23.6)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0))':
+  '@vitest/coverage-v8@1.2.1(vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0))':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -16384,7 +16386,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0)
+      vitest: 1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16615,21 +16617,21 @@ snapshots:
 
   astring@1.8.4: {}
 
-  astro-auto-import@0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)):
+  astro-auto-import@0.4.2(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)):
     dependencies:
       '@types/node': 18.19.26
       acorn: 8.11.3
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
 
-  astro-expressive-code@0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)):
+  astro-expressive-code@0.33.5(astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)):
     dependencies:
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       hast-util-to-html: 8.0.4
       remark-expressive-code: 0.33.5
 
-  astro-relative-links@0.3.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2):
+  astro-relative-links@0.3.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2):
     dependencies:
-      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2)
+      astro: 4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2)
       glob: 10.3.10
     transitivePeerDependencies:
       - '@types/node'
@@ -16642,7 +16644,7 @@ snapshots:
       - terser
       - typescript
 
-  astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)(typescript@5.5.2):
+  astro@4.5.6(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)(typescript@5.5.2):
     dependencies:
       '@astrojs/compiler': 2.7.0
       '@astrojs/internal-helpers': 0.3.0
@@ -16700,8 +16702,8 @@ snapshots:
       tsconfck: 3.0.3(typescript@5.5.2)
       unist-util-visit: 5.0.0
       vfile: 6.0.1
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
-      vitefu: 0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0))
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
+      vitefu: 0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0))
       which-pm: 2.1.1
       yargs-parser: 21.1.1
       zod: 3.22.4
@@ -19605,46 +19607,46 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-darwin-arm64@1.25.0:
+  lightningcss-darwin-arm64@1.25.1:
     optional: true
 
-  lightningcss-darwin-x64@1.25.0:
+  lightningcss-darwin-x64@1.25.1:
     optional: true
 
-  lightningcss-freebsd-x64@1.25.0:
+  lightningcss-freebsd-x64@1.25.1:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.25.0:
+  lightningcss-linux-arm-gnueabihf@1.25.1:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.25.0:
+  lightningcss-linux-arm64-gnu@1.25.1:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.25.0:
+  lightningcss-linux-arm64-musl@1.25.1:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.25.0:
+  lightningcss-linux-x64-gnu@1.25.1:
     optional: true
 
-  lightningcss-linux-x64-musl@1.25.0:
+  lightningcss-linux-x64-musl@1.25.1:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.25.0:
+  lightningcss-win32-x64-msvc@1.25.1:
     optional: true
 
-  lightningcss@1.25.0:
+  lightningcss@1.25.1:
     dependencies:
       detect-libc: 1.0.3
     optionalDependencies:
-      lightningcss-darwin-arm64: 1.25.0
-      lightningcss-darwin-x64: 1.25.0
-      lightningcss-freebsd-x64: 1.25.0
-      lightningcss-linux-arm-gnueabihf: 1.25.0
-      lightningcss-linux-arm64-gnu: 1.25.0
-      lightningcss-linux-arm64-musl: 1.25.0
-      lightningcss-linux-x64-gnu: 1.25.0
-      lightningcss-linux-x64-musl: 1.25.0
-      lightningcss-win32-x64-msvc: 1.25.0
+      lightningcss-darwin-arm64: 1.25.1
+      lightningcss-darwin-x64: 1.25.1
+      lightningcss-freebsd-x64: 1.25.1
+      lightningcss-linux-arm-gnueabihf: 1.25.1
+      lightningcss-linux-arm64-gnu: 1.25.1
+      lightningcss-linux-arm64-musl: 1.25.1
+      lightningcss-linux-x64-gnu: 1.25.1
+      lightningcss-linux-x64-musl: 1.25.1
+      lightningcss-win32-x64-msvc: 1.25.1
 
   lilconfig@3.0.0: {}
 
@@ -23400,13 +23402,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0):
+  vite-node@1.2.1(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23417,13 +23419,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.2.1(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0):
+  vite-node@1.2.1(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23434,29 +23436,29 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)):
+  vite-tsconfig-paths@4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.5.2)
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)):
+  vite-tsconfig-paths@4.2.1(typescript@5.5.2)(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)):
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.5.2)
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0):
+  vite@5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.37
@@ -23464,10 +23466,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.17.19
       fsevents: 2.3.3
-      lightningcss: 1.25.0
+      lightningcss: 1.25.1
       sass: 1.72.0
 
-  vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0):
+  vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.37
@@ -23475,14 +23477,14 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.26
       fsevents: 2.3.3
-      lightningcss: 1.25.0
+      lightningcss: 1.25.1
       sass: 1.72.0
 
-  vitefu@0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)):
+  vitefu@0.2.5(vite@5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)):
     optionalDependencies:
-      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.19.26)(lightningcss@1.25.1)(sass@1.72.0)
 
-  vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.0)(sass@1.72.0):
+  vitest@1.2.1(@types/node@18.17.19)(jsdom@24.0.0)(lightningcss@1.25.1)(sass@1.72.0):
     dependencies:
       '@vitest/expect': 1.2.1
       '@vitest/runner': 1.2.1
@@ -23502,8 +23504,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.1
-      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
-      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.0)(sass@1.72.0)
+      vite: 5.1.7(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
+      vite-node: 1.2.1(@types/node@18.17.19)(lightningcss@1.25.1)(sass@1.72.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 18.17.19


### PR DESCRIPTION
## Changes

[1.25.1](https://github.com/parcel-bundler/lightningcss/releases/tag/v1.25.1) includes a very important bug fix related to `all` property ordering.

## Testing

See [Before](https://dev-itwinui.bentley.com/docs/list#props) vs After

## Docs

N/A