### PR TITLE
disable `Table` virtualizer based on prop

### DIFF
--- a/.changeset/ten-carpets-accept.md
+++ b/.changeset/ten-carpets-accept.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Table` where the virtualizer was being initialized when the `enableVirtualization` prop wasn't set to `true`.

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -830,6 +830,7 @@ export const Table = <
   });
 
   const { virtualizer, css: virtualizerCss } = useVirtualScroll({
+    enabled: enableVirtualization,
     count: page.length,
     getScrollElement: () => tableRef.current,
     estimateSize: () => rowHeight,


### PR DESCRIPTION
## Changes

The `Table` component calls the `useVirtualScroll` unconditionally, which results in the virtualizer being initialized even when `enableVirtualization` is not set. While this hook should probably be moved into a conditionally rendered component (similar to `VirtualizedTree`/`VirtualizedComboBoxMenu`), I've just set the [`enabled`](https://tanstack.com/virtual/latest/docs/api/virtualizer#enabled) option for now.

## Testing

N/A

## Docs

Added `patch` changeset.