### PR TITLE
Adds `ColumnHeader` component to `Table`

### DIFF
--- a/.changeset/lucky-goats-kneel.md
+++ b/.changeset/lucky-goats-kneel.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Reduced layout thrashing on `Table` component by wrapping an expensive ref function in a callback.
+Reduced layout thrashing on `Table` component by memoizing an expensive `ref` function.

--- a/.changeset/lucky-goats-kneel.md
+++ b/.changeset/lucky-goats-kneel.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed layout thrashing on `Table` component by wrapping an expensive ref function in a callback.
+Reduced layout thrashing on `Table` component by wrapping an expensive ref function in a callback.

--- a/.changeset/lucky-goats-kneel.md
+++ b/.changeset/lucky-goats-kneel.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed layout thrashing on `Table` component by wrapping an expensive ref function in a callback.

--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { Box } from '../../utils/index.js';
-import type { ColumnInstance, HeaderGroup, TableKeyedProps } from 'react-table';
+import type {
+  ColumnInstance,
+  HeaderGroup,
+  TableKeyedProps,
+} from '../../react-table/react-table.js';
 import { SELECTION_CELL_ID } from './columns/index.js';
 import { getCellStyle, getSubRowStyle, getStickyStyle } from './utils.js';
 import cx from 'classnames';

--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -17,11 +17,9 @@ type ColumnHeaderProps<
   index: number;
   hasAnySubRows: boolean;
   headers: HeaderGroup<T>[];
-  columnMinWidths: { default: number; withExpander: number };
   isTableResizing: boolean | undefined;
   density: string | undefined;
   visibleColumns: ColumnInstance<T>[];
-  isHeaderDirectClick: React.MutableRefObject<boolean>;
   showSortButton: (column: HeaderGroup<T>) => boolean;
   children: React.ReactNode;
 };
@@ -34,11 +32,9 @@ export const ColumnHeader = <
   const {
     columnRefs,
     column,
-    isHeaderDirectClick,
     index,
     hasAnySubRows,
     headers,
-    columnMinWidths,
     isTableResizing,
     density,
     visibleColumns,
@@ -46,6 +42,13 @@ export const ColumnHeader = <
     children,
     ...rest
   } = props;
+
+  const isHeaderDirectClick = React.useRef(false);
+
+  const COLUMN_MIN_WIDTHS = {
+    default: 72,
+    withExpander: 108, // expander column should be wider to accommodate the expander icon
+  };
 
   const { onClick, ...restSortProps } = column.getSortByToggleProps();
 
@@ -59,8 +62,8 @@ export const ColumnHeader = <
   if ([undefined, 0].includes(column.minWidth)) {
     // override "undefined" or zero min-width with default value
     column.minWidth = columnHasExpanders
-      ? columnMinWidths.withExpander
-      : columnMinWidths.default;
+      ? COLUMN_MIN_WIDTHS.withExpander
+      : COLUMN_MIN_WIDTHS.default;
 
     // set the minWidth to the user provided width instead if the width is less than the default minWidth
     if (typeof column.width === 'number' && column.minWidth > column.width) {

--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import { Box } from '../../utils/index.js';
+import type {
+  HeaderGroup,
+  TableHeaderProps,
+  TableKeyedProps,
+} from 'react-table';
+
+type ColumnHeaderProps<
+  T extends Record<string, unknown> = Record<string, unknown>,
+> = TableHeaderProps &
+  TableKeyedProps & {
+    columnRefs: React.MutableRefObject<Record<string, HTMLDivElement>>;
+    column: HeaderGroup<T>;
+    isHeaderDirectClick: React.MutableRefObject<boolean>;
+    onClick: ((e: React.MouseEvent) => void) | undefined;
+    showSortButton: (column: HeaderGroup<T>) => boolean;
+    children: React.ReactNode;
+  };
+
+export const ColumnHeader = <
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
+  props: ColumnHeaderProps<T>,
+): JSX.Element => {
+  const {
+    columnRefs,
+    column,
+    isHeaderDirectClick,
+    onClick,
+    showSortButton,
+    children,
+    ...rest
+  } = props;
+
+  return (
+    <Box
+      {...rest}
+      title={undefined}
+      ref={React.useCallback(
+        (el: HTMLDivElement) => {
+          if (el) {
+            columnRefs.current[column.id] = el;
+            column.resizeWidth = el.getBoundingClientRect().width;
+          }
+        },
+        [column, columnRefs],
+      )}
+      onMouseDown={() => {
+        isHeaderDirectClick.current = true;
+      }}
+      onClick={(e) => {
+        // Prevents from triggering sort when resizing and mouse is released in the middle of header
+        if (isHeaderDirectClick.current) {
+          onClick?.(e);
+          isHeaderDirectClick.current = false;
+        }
+      }}
+      tabIndex={showSortButton(column) ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (e.key == 'Enter' && showSortButton(column)) {
+          column.toggleSortBy();
+        }
+      }}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -73,6 +73,7 @@ import {
 } from './actionHandlers/index.js';
 import { SELECTION_CELL_ID } from './columns/index.js';
 import { Virtualizer, type VirtualItem } from '@tanstack/react-virtual';
+import { ColumnHeader } from './ColumnHeader.js';
 
 const singleRowSelectedAction = 'singleRowSelected';
 const shiftRowSelectedAction = 'shiftRowSelected';
@@ -926,16 +927,6 @@ export const Table = <
 
   const isHeaderDirectClick = React.useRef(false);
 
-  const columnResizeRef = React.useCallback(
-    (el: HTMLDivElement | null, column: HeaderGroup<T>) => {
-      if (el) {
-        columnRefs.current[column.id] = el;
-        column.resizeWidth = el.getBoundingClientRect().width;
-      }
-    },
-    [],
-  );
-
   return (
     <TableColumnsContext.Provider
       value={columns as Column<Record<string, unknown>>[]}
@@ -1033,30 +1024,15 @@ export const Table = <
                     });
 
                     return (
-                      <Box
+                      <ColumnHeader<T>
                         {...columnProps}
                         {...column.getDragAndDropProps()}
                         key={columnProps.key}
-                        title={undefined}
-                        ref={(el) => {
-                          columnResizeRef(el, column);
-                        }}
-                        onMouseDown={() => {
-                          isHeaderDirectClick.current = true;
-                        }}
-                        onClick={(e) => {
-                          // Prevents from triggering sort when resizing and mouse is released in the middle of header
-                          if (isHeaderDirectClick.current) {
-                            onClick?.(e);
-                            isHeaderDirectClick.current = false;
-                          }
-                        }}
-                        tabIndex={showSortButton(column) ? 0 : undefined}
-                        onKeyDown={(e) => {
-                          if (e.key == 'Enter' && showSortButton(column)) {
-                            column.toggleSortBy();
-                          }
-                        }}
+                        onClick={onClick}
+                        columnRefs={columnRefs}
+                        column={column}
+                        isHeaderDirectClick={isHeaderDirectClick}
+                        showSortButton={showSortButton}
                       >
                         <>
                           <ShadowRoot>
@@ -1135,7 +1111,7 @@ export const Table = <
                               />
                             )}
                         </>
-                      </Box>
+                      </ColumnHeader>
                     );
                   })}
                 </Box>

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -75,11 +75,6 @@ const shiftRowSelectedAction = 'shiftRowSelected';
 export const tableResizeStartAction = 'tableResizeStart';
 const tableResizeEndAction = 'tableResizeEnd';
 
-const COLUMN_MIN_WIDTHS = {
-  default: 72,
-  withExpander: 108, // expander column should be wider to accommodate the expander icon
-};
-
 const logWarning = createWarningLogger();
 
 export type TablePaginatorRendererProps = {
@@ -920,8 +915,6 @@ export const Table = <
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const isHeaderDirectClick = React.useRef(false);
-
   return (
     <TableColumnsContext.Provider
       value={columns as Column<Record<string, unknown>>[]}
@@ -982,11 +975,9 @@ export const Table = <
                         index={index}
                         hasAnySubRows={hasAnySubRows}
                         headers={headerGroup.headers}
-                        columnMinWidths={COLUMN_MIN_WIDTHS}
                         isTableResizing={state.isTableResizing}
                         density={density}
                         visibleColumns={visibleColumns}
-                        isHeaderDirectClick={isHeaderDirectClick}
                         showSortButton={showSortButton}
                       >
                         <>

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -30,13 +30,10 @@ import { ProgressRadial } from '../ProgressIndicators/ProgressRadial.js';
 import {
   useGlobals,
   useResizeObserver,
-  SvgSortDown,
-  SvgSortUp,
   useLayoutEffect,
   Box,
   createWarningLogger,
   ShadowRoot,
-  LineClamp,
   useMergedRefs,
   useLatestRef,
   useVirtualScroll,
@@ -44,7 +41,6 @@ import {
 import type { CommonProps } from '../../utils/index.js';
 import { TableColumnsContext } from './utils.js';
 import { TableRowMemoized } from './TableRowMemoized.js';
-import { FilterToggle } from './filters/index.js';
 import type { TableFilterValue } from './filters/index.js';
 import { customFilterFunctions } from './filters/customFilterFunctions.js';
 import {
@@ -659,12 +655,6 @@ export const Table = <
       (column) => column.filterValue != null && column.filterValue !== '',
     ) || !!globalFilterValue;
 
-  const showFilterButton = (column: HeaderGroup<T>) =>
-    (data.length !== 0 || areFiltersSet) && column.canFilter && !!column.Filter;
-
-  const showSortButton = (column: HeaderGroup<T>) =>
-    data.length !== 0 && column.canSort;
-
   const onRowClickHandler = React.useCallback(
     (event: React.MouseEvent, row: Row<T>) => {
       const isDisabled = isRowDisabled?.(row.original);
@@ -973,91 +963,17 @@ export const Table = <
                         columnRefs={columnRefs}
                         column={column}
                         index={index}
+                        areFiltersSet={areFiltersSet}
                         hasAnySubRows={hasAnySubRows}
                         headers={headerGroup.headers}
-                        isTableResizing={state.isTableResizing}
+                        state={state}
+                        data={data}
+                        isResizable={isResizable}
+                        columnResizeMode={columnResizeMode}
+                        enableColumnReordering={enableColumnReordering}
                         density={density}
                         visibleColumns={visibleColumns}
-                        showSortButton={showSortButton}
-                      >
-                        <>
-                          <ShadowRoot>
-                            {typeof column.Header === 'string' ? (
-                              <LineClamp>
-                                <slot />
-                              </LineClamp>
-                            ) : (
-                              <slot />
-                            )}
-                            <slot name='actions' />
-                            <slot name='resizers' />
-                            <slot name='shadows' />
-                          </ShadowRoot>
-
-                          {column.render('Header')}
-                          {(showFilterButton(column) ||
-                            showSortButton(column)) && (
-                            <Box
-                              className='iui-table-header-actions-container'
-                              onKeyDown={(e) => e.stopPropagation()} // prevents from triggering sort
-                              slot='actions'
-                            >
-                              {showFilterButton(column) && (
-                                <FilterToggle column={column} />
-                              )}
-                              {showSortButton(column) && (
-                                <Box className='iui-table-cell-end-icon'>
-                                  {column.isSortedDesc ||
-                                  (!column.isSorted && column.sortDescFirst) ? (
-                                    <SvgSortDown
-                                      className='iui-table-sort'
-                                      aria-hidden
-                                    />
-                                  ) : (
-                                    <SvgSortUp
-                                      className='iui-table-sort'
-                                      aria-hidden
-                                    />
-                                  )}
-                                </Box>
-                              )}
-                            </Box>
-                          )}
-                          {isResizable &&
-                            column.isResizerVisible &&
-                            (index !== headerGroup.headers.length - 1 ||
-                              columnResizeMode === 'expand') && (
-                              <Box
-                                {...column.getResizerProps()}
-                                className='iui-table-resizer'
-                                slot='resizers'
-                              >
-                                <Box className='iui-table-resizer-bar' />
-                              </Box>
-                            )}
-                          {enableColumnReordering &&
-                            !column.disableReordering && (
-                              <Box
-                                className='iui-table-reorder-bar'
-                                slot='resizers'
-                              />
-                            )}
-                          {column.sticky === 'left' &&
-                            state.sticky.isScrolledToRight && (
-                              <Box
-                                className='iui-table-cell-shadow-right'
-                                slot='shadows'
-                              />
-                            )}
-                          {column.sticky === 'right' &&
-                            state.sticky.isScrolledToLeft && (
-                              <Box
-                                className='iui-table-cell-shadow-left'
-                                slot='shadows'
-                              />
-                            )}
-                        </>
-                      </ColumnHeader>
+                      />
                     );
                   })}
                 </Box>

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -956,10 +956,11 @@ export const Table = <
               >
                 <Box {...headerGroupProps}>
                   {headerGroup.headers.map((column, index) => {
+                    const dragAndDropProps = column.getDragAndDropProps();
                     return (
                       <ColumnHeader<T>
-                        {...column.getDragAndDropProps()}
-                        key={column.getDragAndDropProps().key}
+                        {...dragAndDropProps}
+                        key={dragAndDropProps.key}
                         columnRefs={columnRefs}
                         column={column}
                         index={index}

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -42,12 +42,7 @@ import {
   useVirtualScroll,
 } from '../../utils/index.js';
 import type { CommonProps } from '../../utils/index.js';
-import {
-  TableColumnsContext,
-  getCellStyle,
-  getStickyStyle,
-  getSubRowStyle,
-} from './utils.js';
+import { TableColumnsContext } from './utils.js';
 import { TableRowMemoized } from './TableRowMemoized.js';
 import { FilterToggle } from './filters/index.js';
 import type { TableFilterValue } from './filters/index.js';
@@ -978,59 +973,19 @@ export const Table = <
               >
                 <Box {...headerGroupProps}>
                   {headerGroup.headers.map((column, index) => {
-                    const { onClick, ...restSortProps } =
-                      column.getSortByToggleProps();
-
-                    const columnHasExpanders =
-                      hasAnySubRows &&
-                      index ===
-                        headerGroup.headers.findIndex(
-                          (c) => c.id !== SELECTION_CELL_ID, // first non-selection column is the expander column
-                        );
-
-                    if ([undefined, 0].includes(column.minWidth)) {
-                      // override "undefined" or zero min-width with default value
-                      column.minWidth = columnHasExpanders
-                        ? COLUMN_MIN_WIDTHS.withExpander
-                        : COLUMN_MIN_WIDTHS.default;
-
-                      // set the minWidth to the user provided width instead if the width is less than the default minWidth
-                      if (
-                        typeof column.width === 'number' &&
-                        column.minWidth > column.width
-                      ) {
-                        column.minWidth = column.width;
-                      }
-                    }
-
-                    const columnProps = column.getHeaderProps({
-                      ...restSortProps,
-                      className: cx(
-                        'iui-table-cell',
-                        {
-                          'iui-actionable': column.canSort,
-                          'iui-sorted': column.isSorted,
-                          'iui-table-cell-sticky': !!column.sticky,
-                        },
-                        column.columnClassName,
-                      ),
-                      style: {
-                        ...getCellStyle(column, !!state.isTableResizing),
-                        ...(columnHasExpanders && getSubRowStyle({ density })),
-                        ...getStickyStyle(column, visibleColumns),
-                        flexWrap: 'wrap',
-                        columnGap: 'var(--iui-size-xs)',
-                      },
-                    });
-
                     return (
                       <ColumnHeader<T>
-                        {...columnProps}
                         {...column.getDragAndDropProps()}
-                        key={columnProps.key}
-                        onClick={onClick}
+                        key={column.getDragAndDropProps().key}
                         columnRefs={columnRefs}
                         column={column}
+                        index={index}
+                        hasAnySubRows={hasAnySubRows}
+                        headers={headerGroup.headers}
+                        columnMinWidths={COLUMN_MIN_WIDTHS}
+                        isTableResizing={state.isTableResizing}
+                        density={density}
+                        visibleColumns={visibleColumns}
                         isHeaderDirectClick={isHeaderDirectClick}
                         showSortButton={showSortButton}
                       >


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Adds a `ColumnHeader` component to the `Table` component. The primary purpose of this change is to make it possible to wrap the column resizing ref function in `React.useCallback` in order to prevent layout thrashing. This PR addresses an after PR TODO from #2092
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Ran automated tests and confirmed that the new component did not add any visual changes. Compared performance and confirmed that the `Recalculate Style` task performs significantly better after this change.

Before:
![Screenshot 2024-07-30 142111](https://github.com/user-attachments/assets/9d1b7540-6d47-4a16-beac-bf879fd644df)

After:
![Screenshot 2024-07-30 142045](https://github.com/user-attachments/assets/6615716d-4dcb-4585-ae40-67d614742c6e)
 
It should be noted that the overall performance of the virtualized `Table` component remains around the same on high levels of throttling. While the rendering itself has become inexpensive, the scripting for the `Table` component seems to take a very long time.
![image](https://github.com/user-attachments/assets/c8945955-4704-457f-b00d-1c3067aac431)

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Added react patch changeset.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
