### PR TITLE
Removes cuts from expanded `Table` row border

### DIFF
--- a/.changeset/tough-scissors-heal.md
+++ b/.changeset/tough-scissors-heal.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added `border-block: none` to the `TableCell` of expanded `Table` rows to remove cuts from the expanded table row border.

--- a/.changeset/violet-masks-rest.md
+++ b/.changeset/violet-masks-rest.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Added `border-block: none` to `.iui-table-cell` on expanded rows to remove cuts from the expanded table row border.

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -189,7 +189,7 @@
       .iui-table-cell {
         border-inline-start-color: var(--iui-color-border);
         border-inline-end-color: var(--iui-color-border);
-        border-block-end-color: transparent;
+        border-block: none;
       }
 
       .iui-table-row-expander > .iui-button-icon {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Removes cuts from the expanded `Table` row border by adding `border-block: none` to the `Table` cells when the row is expanded. This change removes two 1px wide transparent borders from the expanded `Table` row, which were causing the cuts in the border to appear. Video highlighting the visual change:

https://github.com/user-attachments/assets/848fba0e-b427-4b95-9f78-1768793f2148

Also removed the `border-block-end-color` style from the selector, since that border is being removed in this case. Resolves after PR TODO from #2143
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Manually tested the Expanded `Table` react story. Also ran the visual tests and saw no changes. I do find it odd that the visual tests for the expanded `Table` examples pass. Perhaps cypress has a hidden amount of leniency on visual changes.

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

Added patch changesets for the react and css packages.
<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
