### PR TITLE
Fix css styles not updating in react-workshop

### DIFF
--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -94,7 +94,7 @@
     "format": "prettier --config .prettierrc **/*.{tsx,ts,js} --ignore-path .gitignore --write",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --max-warnings=0",
     "lint:fix": "pnpm lint --fix && node ../../scripts/copyrightLinter.js --fix \"*/**/*.{js,ts,tsx}\"",
-    "dev": "pnpm clean:build && concurrently \"pnpm dev:esm\" \"pnpm dev:cjs\" \"pnpm build:styles --watch\" \"pnpm dev:types\"",
+    "dev": "pnpm clean:build && concurrently \"pnpm dev:esm\" \"pnpm dev:cjs\" \"pnpm dev:styles\" \"pnpm dev:types\"",
     "dev:esm": "swc src -d esm --watch --strip-leading-paths",
     "dev:cjs": "swc src -d cjs --watch --strip-leading-paths -C module.type=commonjs",
     "dev:types": "concurrently \"tsc -p tsconfig.build.json --outDir esm --watch --preserveWatchOutput\" \"tsc -p tsconfig.build.json --outDir cjs --watch --preserveWatchOutput\"",

--- a/packages/itwinui-react/src/styles.js/vite.config.mjs
+++ b/packages/itwinui-react/src/styles.js/vite.config.mjs
@@ -99,12 +99,18 @@ const outEsmDevDir = path.join(root, 'DEV-esm');
 const outCjsDevDir = path.join(root, 'DEV-cjs');
 
 const copyBuildOutput = async () => {
-  // create cjs/ and esm/ directories if they don't exist
+  // create cjs/, esm/, DEV-cjs/, and DEV-esm/ directories if they don't exist
+  if (!fs.existsSync(outEsmDir)) {
+    await fs.promises.mkdir(outEsmDir);
+  }
   if (!fs.existsSync(outCjsDir)) {
     await fs.promises.mkdir(outCjsDir);
   }
-  if (!fs.existsSync(outEsmDir)) {
-    await fs.promises.mkdir(outEsmDir);
+  if (!fs.existsSync(outEsmDevDir)) {
+    await fs.promises.mkdir(outEsmDevDir);
+  }
+  if (!fs.existsSync(outCjsDevDir)) {
+    await fs.promises.mkdir(outCjsDevDir);
   }
 
   // copy styles.js from src/styles.js/dist/ into cjs/, esm/, DEV-cjs/, and DEV-esm/


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I noticed that the changes made in `.scss` files were not reflected in `react-workshop` (and maybe other workspaces too). I had to restart the dev server for those styling changes to be reflected.

Looks like the `DEV-esm` and `DEV-cjs` folders were not created beforehand. Thus, the copyfile gave the following error as the destination path didn't exist:

```bash
[Error: ENOENT: no such file or directory, copyfile '/iTwinUI/packages/itwinui-react/src/styles.js/dist/esm/styles.js' -> '/iTwinUI/packages/itwinui-react/DEV-esm/styles.js'] {
  errno: -2,
  code: 'PLUGIN_ERROR',
  syscall: 'copyfile',
  path: '/iTwinUI/packages/itwinui-react/src/styles.js/dist/esm/styles.js',
  dest: '/iTwinUI/packages/itwinui-react/DEV-esm/styles.js',
  pluginCode: 'ENOENT',
  plugin: 'copy-files-after-build',
  hook: 'closeBundle'
}
```

Thus, this PR creates the `DEV-esm` and `DEV-cjs` folders before running the copyfile commands.

Unrelated: used the unused `dev:styles` script in the `dev` command instead of inlining the `dev:styles` script in the `dev` script.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that changes in the `.scss` files were showing up in the react-workshop upon saving the `.scss` files.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".

-->

N/A