### PR TITLE
remove deprecated `useDelayGroupContext`

### DIFF
--- a/.changeset/ten-dryers-sleep.md
+++ b/.changeset/ten-dryers-sleep.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Bumped the minimum version of `@floating-ui/react` to `0.26.20`.
+Bumped the minimum version of `@floating-ui/react` to `0.26.22`.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -101,7 +101,7 @@
     "dev:styles": "pnpm build:styles --watch"
   },
   "dependencies": {
-    "@floating-ui/react": "^0.26.20",
+    "@floating-ui/react": "^0.26.22",
     "@itwin/itwinui-illustrations-react": "^2.1.0",
     "@swc/helpers": "^0.5.11",
     "@tanstack/react-virtual": "^3.8.2",

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -19,7 +19,6 @@ import {
   autoPlacement,
   hide,
   inline,
-  useDelayGroupContext,
   useDelayGroup,
 } from '@floating-ui/react';
 import type { Placement } from '@floating-ui/react';
@@ -200,9 +199,7 @@ const useTooltip = (options: TooltipOptions = {}) => {
     [ariaStrategy, id],
   );
 
-  const { delay } = useDelayGroupContext();
-
-  useDelayGroup(floating.context, { id: useId() });
+  const { delay } = useDelayGroup(floating.context, { id: useId() });
 
   const interactions = useInteractions([
     useHover(floating.context, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,8 +335,8 @@ importers:
   packages/itwinui-react:
     dependencies:
       '@floating-ui/react':
-        specifier: ^0.26.20
-        version: 0.26.20(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^0.26.22
+        version: 0.26.22(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@itwin/itwinui-illustrations-react':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2184,19 +2184,19 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.20':
+  '@floating-ui/react@0.26.22':
     resolution:
       {
-        integrity: sha512-RixKJJG92fcIsVoqrFr4Onpzh7hlOx4U7NV4aLhMLmtvjZ5oTB/WzXaANYUZATKqXvvW7t9sCxtzejip26N5Ag==,
+        integrity: sha512-LNv4azPt8SpT4WW7Kku5JNVjLk2GcS0bGGjFTAgqOONRFo9r/aaGHHPpdiIuQbB1t8shmWyWqTTUDmZ9fcNshg==,
       }
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.5':
+  '@floating-ui/utils@0.2.7':
     resolution:
       {
-        integrity: sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==,
+        integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==,
       }
 
   '@fontsource/noto-sans-mono@5.0.18':
@@ -15064,12 +15064,12 @@ snapshots:
 
   '@floating-ui/core@1.6.0':
     dependencies:
-      '@floating-ui/utils': 0.2.5
+      '@floating-ui/utils': 0.2.7
 
   '@floating-ui/dom@1.6.3':
     dependencies:
       '@floating-ui/core': 1.6.0
-      '@floating-ui/utils': 0.2.5
+      '@floating-ui/utils': 0.2.7
 
   '@floating-ui/react-dom@2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -15077,15 +15077,15 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react@0.26.20(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react@0.26.22(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/utils': 0.2.5
+      '@floating-ui/utils': 0.2.7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.2.0
 
-  '@floating-ui/utils@0.2.5': {}
+  '@floating-ui/utils@0.2.7': {}
 
   '@fontsource/noto-sans-mono@5.0.18': {}
 


### PR DESCRIPTION
## Changes

`useDelayGroupContext` is deprecated and the suggested replacement is the main `useDelayGroup` hook (see [docs](https://floating-ui.com/docs/FloatingDelayGroup#usage)).

While I'm here I also bumped to the latest version of floating-ui again, since we haven't released #2169 yet.

## Testing

Confirmed that delay continues to work fine in ButtonGroup tooltips.

https://github.com/user-attachments/assets/a51f8dad-986b-4c07-ba56-3d0b4e181e36


## Docs

Updated existing changeset for version bump.