### PR TITLE
Fixed `if` condition when handling `labelPosition` in Radio Astro component

### DIFF
--- a/apps/css-workshop/src/components/Radio.astro
+++ b/apps/css-workshop/src/components/Radio.astro
@@ -31,13 +31,12 @@ const { disabled, status, class: className, labelPosition, ...props } = Astro.pr
   }
   <input class:list={['iui-radio', className]} type='radio' disabled={disabled} {...props} />
   {
-    labelPosition === 'right' ||
-      (!labelPosition && (
-        <>
-          <span class='iui-radio-label'>
-            <slot />
-          </span>
-        </>
-      ))
+    (labelPosition === 'right' || !labelPosition) && (
+      <>
+        <span class='iui-radio-label'>
+          <slot />
+        </span>
+      </>
+    )
   }
 </label>

--- a/apps/css-workshop/src/components/Radio.astro
+++ b/apps/css-workshop/src/components/Radio.astro
@@ -8,7 +8,7 @@ type Props = {
   name: string;
 } & astroHTML.JSX.HTMLAttributes;
 
-const { disabled, status, class: className, labelPosition, ...props } = Astro.props;
+const { disabled, status, class: className, labelPosition = 'right', ...props } = Astro.props;
 ---
 
 <label
@@ -22,21 +22,17 @@ const { disabled, status, class: className, labelPosition, ...props } = Astro.pr
 >
   {
     labelPosition === 'left' && (
-      <>
-        <span class='iui-radio-label'>
-          <slot />
-        </span>
-      </>
+      <span class='iui-radio-label'>
+        <slot />
+      </span>
     )
   }
   <input class:list={['iui-radio', className]} type='radio' disabled={disabled} {...props} />
   {
-    (labelPosition === 'right' || !labelPosition) && (
-      <>
-        <span class='iui-radio-label'>
-          <slot />
-        </span>
-      </>
+    labelPosition === 'right' && (
+      <span class='iui-radio-label'>
+        <slot />
+      </span>
     )
   }
 </label>


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

In my previous [PR](https://github.com/iTwin/iTwinUI/pull/2191) regarding the Radio Astro component, I merged the PR before getting this error reviewed, which contained an issue of having wrong behavior when `labelPosition` is set to `right`. This issue is addressed in this PR.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed all tests passed.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
