### PR TITLE
render `List`/`ListItem` as divs

### DIFF
--- a/.changeset/late-avocados-speak.md
+++ b/.changeset/late-avocados-speak.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`List` and `ListItem` will now be rendered as `<div>`s instead of `<ul>`/`<li>`. This change makes these components less restrictive and less error-prone to use.

--- a/packages/itwinui-react/src/core/List/List.tsx
+++ b/packages/itwinui-react/src/core/List/List.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { polymorphic } from '../../utils/index.js';
 
-export const List = polymorphic.ul('iui-list', { role: 'list' });
+export const List = polymorphic.div('iui-list', { role: 'list' });
 if (process.env.NODE_ENV === 'development') {
   List.displayName = 'List';
 }

--- a/packages/itwinui-react/src/core/List/ListItem.tsx
+++ b/packages/itwinui-react/src/core/List/ListItem.tsx
@@ -21,7 +21,7 @@ const ListItemComponent = React.forwardRef((props, ref) => {
 
   return (
     <Box
-      as='li'
+      role='listitem'
       className={cx('iui-list-item', className)}
       data-iui-active={active ? 'true' : undefined}
       data-iui-disabled={disabled ? 'true' : undefined}
@@ -32,7 +32,7 @@ const ListItemComponent = React.forwardRef((props, ref) => {
       {...rest}
     />
   );
-}) as PolymorphicForwardRefComponent<'li', ListItemOwnProps>;
+}) as PolymorphicForwardRefComponent<'div', ListItemOwnProps>;
 if (process.env.NODE_ENV === 'development') {
   ListItemComponent.displayName = 'ListItem';
 }

--- a/packages/itwinui-react/src/core/TransferList/TransferList.tsx
+++ b/packages/itwinui-react/src/core/TransferList/TransferList.tsx
@@ -64,7 +64,7 @@ const TransferListListbox = React.forwardRef((props, ref) => {
   const { labelId } = useSafeContext(TransferListContext);
 
   const [focusedIndex, setFocusedIndex] = React.useState<number | null>();
-  const listRef = React.useRef<HTMLUListElement>(null);
+  const listRef = React.useRef<HTMLElement>(null);
   const refs = useMergedRefs(listRef, ref);
 
   const getFocusableNodes = React.useCallback(() => {
@@ -83,7 +83,7 @@ const TransferListListbox = React.forwardRef((props, ref) => {
     }
   }, [focusedIndex, getFocusableNodes]);
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (event.altKey) {
       return;
     }
@@ -155,7 +155,7 @@ const TransferListItem = React.forwardRef((props, ref) => {
   const onClickEvents = () =>
     actionable && onActiveChange && onActiveChange(!active);
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+  const onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (event.altKey) {
       return;
     }


### PR DESCRIPTION
## Changes

Instead of `<ul>`/`<li>`, we now use `<div>`s for both components. The semantics are added using `role`.

`<ul>`/`<li>` can be very error-prone and restrictive from a DOM perspective.
- You always need the ListItem wrapper to be `<ul>`/`<ol>` (which is easy to forget, as seen in our own [docs](https://dev-itwinui.bentley.com/docs/list#interactive-states)).
- You can not add a wrapper `<div>` around a `<li>` (but you can around a `<div role=listitem>`).

Using `<div>`s avoids these issues, and there is no downside when the appropriate `role`s are present. In fact, it makes it even easier for us to add things like [`group`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) and [`separator`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role) inside the List.

## Testing

Verified that the new DOM contains only `<div>`s and that there is no invalid HTML in the [`ListItem` interactive example](https://deploy-preview-2201--itwinui-previews.netlify.app/docs/list/#interactive-states). Everything else works exactly the same, including unit tests that already check for `role=listitem`.

## Docs

N/A. Added `minor` changeset. While this is technically a very small change in an implementation detail, it could still impact users who are relying on the exact `<ul>`/`<li>` elements.