### PR TITLE
encourage using the `label` prop in `IconButton`

### DIFF
--- a/.changeset/angry-bananas-attack.md
+++ b/.changeset/angry-bananas-attack.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`IconButton` will now reroute the HTML `title` prop to its own `label` prop for better accessibility. The `title` prop has also been marked deprecated to encourage the use of `label`.

--- a/.changeset/soft-eggs-drive.md
+++ b/.changeset/soft-eggs-drive.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`IconButton` will now display warnings during development when it's missing a label.

--- a/apps/website/src/content/docs/button.mdx
+++ b/apps/website/src/content/docs/button.mdx
@@ -105,6 +105,8 @@ Pressing this button will always open a menu. Upon selecting an option from the 
 
 Icon button gives the icon the correct styling as well as adds some clickable padding within the button, ensuring icons meet the necessary touch target size.
 
+Make sure to provide a short `label` that describes the action the button will perform. This label will be shown in a tooltip and also exposed to assistive technologies.
+
 <LiveExample src='IconButton.main.jsx'>
   <AllExamples.IconButtonMainExample client:load />
 </LiveExample>

--- a/packages/itwinui-react/src/core/Buttons/IconButton.test.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton.test.tsx
@@ -145,3 +145,16 @@ it.each(['default', 'small', 'large'] as const)(
     }
   },
 );
+
+it('should reroute title to label', () => {
+  const { container } = render(
+    <IconButton title='Add'>
+      <SvgMore />
+    </IconButton>,
+  );
+
+  const button = container.querySelector('button') as HTMLElement;
+  expect(button).toHaveAccessibleName('Add');
+  expect(button).toHaveTextContent('Add');
+  expect(button).not.toHaveAttribute('title');
+});

--- a/packages/itwinui-react/src/core/Buttons/IconButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton.tsx
@@ -4,13 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import * as React from 'react';
-import { Box, ButtonBase } from '../../utils/index.js';
+import { Box, ButtonBase, createWarningLogger } from '../../utils/index.js';
 import { Tooltip } from '../Tooltip/Tooltip.js';
 import type { ButtonProps } from './Button.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden.js';
 import { ButtonGroupContext } from '../ButtonGroup/ButtonGroup.js';
 import { PopoverOpenContext } from '../Popover/Popover.js';
+
+const logWarning = createWarningLogger();
 
 export type IconButtonProps = {
   /**
@@ -34,6 +36,10 @@ export type IconButtonProps = {
    * Passes props to IconButton icon.
    */
   iconProps?: React.ComponentProps<'span'>;
+  /**
+   * @deprecated Use `label` instead.
+   */
+  title?: string;
 } & Omit<
   ButtonProps,
   | 'startIcon'
@@ -58,7 +64,8 @@ export const IconButton = React.forwardRef((props, ref) => {
     styleType = 'default',
     size,
     className,
-    label,
+    title,
+    label = title,
     iconProps,
     labelProps,
     ...rest
@@ -66,6 +73,15 @@ export const IconButton = React.forwardRef((props, ref) => {
 
   const buttonGroupOrientation = React.useContext(ButtonGroupContext);
   const hasPopoverOpen = React.useContext(PopoverOpenContext);
+
+  if (
+    process.env.NODE_ENV === 'development' &&
+    !label &&
+    !props['aria-label'] &&
+    !props['aria-labelledby']
+  ) {
+    logWarning('IconButton is missing the `label` prop.');
+  }
 
   const button = (
     <ButtonBase


### PR DESCRIPTION
## Changes

- When `title` prop is passed, it will be rerouted to `label`. (related: #2182)
- When no `label`/`aria-label` is found, a dev-only warning will be shown.

This change helps nudge users to make their `IconButton`s more accessible. Ideally, the `label` prop would just be required, but that would be a breaking change, so this is the next best solution.

## Testing

Manually verified the behavior in vite playground. `title` and `label` behave identically, and a warning is correctly displayed when there is no `label`.

Added unit test to verify that `title` is not present in the DOM.

## Docs

Updated docs for `IconButton` to mention the `label` prop.

Added `patch` changesets for both code changes.

## After-PR TODO

- [ ] Fix `createWarningLogger` (see [comment](https://github.com/iTwin/iTwinUI/pull/2202#discussion_r1729170659)).