### PR TITLE
use form validation in `TextFilter`

### DIFF
--- a/.changeset/gold-dolphins-nail.md
+++ b/.changeset/gold-dolphins-nail.md
@@ -1,0 +1,16 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`BaseFilter` now renders as a `<form>` and `FilterButtonBar` now renders a `<button type="submit">`. Together, this enables the use of browser's built-in validation before applying filters. The `setFilter` prop in `FilterButtonBar` has been deprecated, as `onSubmit` should be used instead.
+
+```diff
+  <BaseFilter
++   onSubmit={() => setFilter(text)}
+  >
+    …
+    <FilterButtonBar
+-     setFilter={() => setFilter(text)}
+    />
+  </BaseFilter>
+```

--- a/.changeset/silent-humans-leave.md
+++ b/.changeset/silent-humans-leave.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`tableFilters.TextFilter` now prevents the user from applying the filter when the text input is empty.

--- a/packages/itwinui-react/src/core/Table/filters/BaseFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/BaseFilter.tsx
@@ -4,15 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import cx from 'classnames';
-import { Box, useGlobals } from '../../../utils/index.js';
-import type { CommonProps } from '../../../utils/index.js';
-
-export type BaseFilterProps = {
-  /**
-   * Filter body.
-   */
-  children: React.ReactNode;
-} & Omit<CommonProps, 'title'>;
+import { Box, mergeEventHandlers } from '../../../utils/index.js';
+import type { PolymorphicForwardRefComponent } from '../../../utils/index.js';
 
 /**
  * Filter wrapper that should be used when creating custom filters.
@@ -28,22 +21,21 @@ export type BaseFilterProps = {
  *   />
  * </BaseFilter>
  */
-export const BaseFilter = (props: BaseFilterProps) => {
-  const { children, className, style, id } = props;
-
-  useGlobals();
-
+export const BaseFilter = React.forwardRef((props, forwardedRef) => {
   return (
     <Box
-      className={cx('iui-table-column-filter', className)}
-      style={style}
-      // Prevents from triggering sort
-      onClick={(e: React.MouseEvent) => {
-        e.stopPropagation();
+      as='form'
+      {...props}
+      ref={forwardedRef}
+      className={cx('iui-table-column-filter', props.className)}
+      onSubmit={(e) => {
+        e.preventDefault(); // prevent default browser form submission
+        props.onSubmit?.(e);
       }}
-      id={id}
-    >
-      {children}
-    </Box>
+      onClick={mergeEventHandlers(props.onClick, (e) => {
+        // Prevents from triggering sort
+        e.stopPropagation();
+      })}
+    />
   );
-};
+}) as PolymorphicForwardRefComponent<'form'>;

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.test.tsx
@@ -112,29 +112,6 @@ it('should set filter when only To is entered', () => {
   ]);
 });
 
-it('should set filter when both values entered and Enter is pressed', () => {
-  const setFilter = vi.fn();
-  const { container } = renderComponent({ setFilter });
-
-  const labeledInputs = container.querySelectorAll(
-    '.iui-input-flex-container > input',
-  ) as NodeListOf<HTMLInputElement>;
-  expect(labeledInputs.length).toBe(2);
-
-  fireEvent.change(labeledInputs[0], { target: { value: 'May 1, 2021' } });
-  fireEvent.change(labeledInputs[1], { target: { value: 'May 3, 2021' } });
-
-  fireEvent.keyDown(labeledInputs[1], {
-    key: 'Enter',
-    charCode: 13,
-  });
-
-  expect(setFilter).toHaveBeenCalledWith([
-    new Date(2021, 4, 1, 0, 0, 0, 0),
-    new Date(2021, 4, 3, 23, 59, 59, 999),
-  ]);
-});
-
 it('should set filter with empty values when invalid date is entered', () => {
   const setFilter = vi.fn();
   const { container } = renderComponent({ setFilter });

--- a/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/DateRangeFilter/DateRangeFilter.tsx
@@ -114,18 +114,8 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
     });
   }, []);
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.altKey) {
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      setFilter([from, to]);
-    }
-  };
-
   return (
-    <BaseFilter>
+    <BaseFilter onSubmit={() => setFilter([from, to])}>
       <DatePickerInput
         ref={inputRef}
         label={translatedStrings.from}
@@ -133,7 +123,6 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         onChange={onFromChange}
         formatDate={formatDate}
         parseInput={parseInput}
-        onKeyDown={onKeyDown}
         placeholder={placeholder}
         selectedDate={to}
         isFromOrTo='from'
@@ -146,7 +135,6 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         onChange={onToChange}
         formatDate={formatDate}
         parseInput={parseInput}
-        onKeyDown={onKeyDown}
         placeholder={placeholder}
         selectedDate={from}
         isFromOrTo='to'
@@ -154,7 +142,6 @@ export const DateRangeFilter = <T extends Record<string, unknown>>(
         showYearSelection={showYearSelection}
       />
       <FilterButtonBar
-        setFilter={() => setFilter([from, to])}
         clearFilter={clearFilter}
         translatedLabels={translatedLabels}
       />

--- a/packages/itwinui-react/src/core/Table/filters/FilterButtonBar.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/FilterButtonBar.tsx
@@ -24,9 +24,11 @@ export type FilterButtonBarProps = {
    */
   children?: React.ReactNode;
   /**
-   * Callback used for Filter button click. Should come from `BaseFilter`.
+   * Callback used for Filter button click.
+   *
+   * @deprecated Use the onSubmit callback from `BaseFilter` instead.
    */
-  setFilter: () => void;
+  setFilter?: () => void;
   /**
    * Callback used for Clear button click. Should come from `BaseFilter`.
    */
@@ -60,7 +62,7 @@ export const FilterButtonBar = (props: FilterButtonBarProps) => {
   return (
     <Box className={cx('iui-button-bar', className)} style={style} id={id}>
       {children}
-      <Button styleType='high-visibility' onClick={setFilter}>
+      <Button type='submit' styleType='high-visibility' onClick={setFilter}>
         {translatedStrings.filter}
       </Button>
       <Button onClick={clearFilter}>{translatedStrings.clear}</Button>

--- a/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.test.tsx
@@ -102,26 +102,6 @@ it('should set filter when only To is entered', () => {
   expect(setFilter).toHaveBeenCalledWith([undefined, 3]);
 });
 
-it('should set filter when both values entered and Enter is pressed', () => {
-  const setFilter = vi.fn();
-  const { container } = renderComponent({ setFilter });
-
-  const labeledInputs = container.querySelectorAll(
-    '.iui-input-grid input',
-  ) as NodeListOf<HTMLInputElement>;
-  expect(labeledInputs.length).toBe(2);
-
-  fireEvent.change(labeledInputs[0], { target: { value: '1' } });
-  fireEvent.change(labeledInputs[1], { target: { value: '3' } });
-
-  fireEvent.keyDown(labeledInputs[1], {
-    key: 'Enter',
-    charCode: 13,
-  });
-
-  expect(setFilter).toHaveBeenCalledWith([1, 3]);
-});
-
 it('should set filter with empty values when invalid number is entered', () => {
   const setFilter = vi.fn();
   const { container } = renderComponent({ setFilter });

--- a/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/NumberRangeFilter/NumberRangeFilter.tsx
@@ -53,24 +53,15 @@ export const NumberRangeFilter = <T extends Record<string, unknown>>(
     return !value || isNaN(Number(value)) ? undefined : Number(value);
   };
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.altKey) {
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      setFilter([parseInputValue(from), parseInputValue(to)]);
-    }
-  };
-
   return (
-    <BaseFilter>
+    <BaseFilter
+      onSubmit={() => setFilter([parseInputValue(from), parseInputValue(to)])}
+    >
       <LabeledInput
         ref={inputRef}
         label={translatedStrings.from}
         value={from}
         onChange={(e) => setFrom(e.target.value)}
-        onKeyDown={onKeyDown}
         type='number'
         displayStyle='inline'
       />
@@ -80,12 +71,8 @@ export const NumberRangeFilter = <T extends Record<string, unknown>>(
         onChange={(e) => setTo(e.target.value)}
         type='number'
         displayStyle='inline'
-        onKeyDown={onKeyDown}
       />
       <FilterButtonBar
-        setFilter={() =>
-          setFilter([parseInputValue(from), parseInputValue(to)])
-        }
         clearFilter={clearFilter}
         translatedLabels={translatedLabels}
       />

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.test.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.test.tsx
@@ -37,21 +37,6 @@ it('should call setFilter with input value', () => {
   expect(setFilter).toHaveBeenCalledWith('test filter');
 });
 
-it('should call setFilter when Enter is pressed', () => {
-  const { container } = renderComponent();
-
-  const input = container.querySelector('input') as HTMLInputElement;
-  expect(input).toBeTruthy();
-
-  fireEvent.change(input, { target: { value: 'test filter' } });
-  fireEvent.keyDown(input, {
-    key: 'Enter',
-    charCode: 13,
-  });
-
-  expect(setFilter).toHaveBeenCalledWith('test filter');
-});
-
 it('should load filter with set value and clear it', () => {
   const { container } = renderComponent({
     column: { filterValue: 'test filter' } as HeaderGroup<any>,

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
@@ -43,15 +43,15 @@ export const TextFilter = <T extends Record<string, unknown>>(
   };
 
   return (
-    <BaseFilter>
+    <BaseFilter onSubmit={() => setFilter(text)}>
       <Input
         ref={inputRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onKeyDown}
+        required
       />
       <FilterButtonBar
-        setFilter={() => setFilter(text)}
         clearFilter={clearFilter}
         translatedLabels={translatedLabels}
       />

--- a/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
+++ b/packages/itwinui-react/src/core/Table/filters/TextFilter/TextFilter.tsx
@@ -32,23 +32,12 @@ export const TextFilter = <T extends Record<string, unknown>>(
     }
   }, []);
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.altKey) {
-      return;
-    }
-
-    if (event.key === 'Enter') {
-      setFilter(text);
-    }
-  };
-
   return (
     <BaseFilter onSubmit={() => setFilter(text)}>
       <Input
         ref={inputRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
-        onKeyDown={onKeyDown}
         required
       />
       <FilterButtonBar

--- a/packages/itwinui-react/src/core/Table/filters/index.ts
+++ b/packages/itwinui-react/src/core/Table/filters/index.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 export { BaseFilter } from './BaseFilter.js';
-export type { BaseFilterProps } from './BaseFilter.js';
 
 export { tableFilters } from './tableFilters.js';
 export type { DateRangeFilterOptions } from './tableFilters.js';

--- a/packages/itwinui-react/src/core/Table/index.ts
+++ b/packages/itwinui-react/src/core/Table/index.ts
@@ -7,7 +7,6 @@ export type { TablePaginatorRendererProps } from './Table.js';
 
 export { BaseFilter, FilterButtonBar, tableFilters } from './filters/index.js';
 export type {
-  BaseFilterProps,
   DateRangeFilterOptions,
   FilterButtonBarProps,
   FilterButtonBarTranslation,


### PR DESCRIPTION
## Changes

Fixes #2200

1. `BaseFilter` now renders a `<form>` element.
2. `TextFilter` now renders `<input required>` for built-in browser validation.
3. `FilterButtonBar` now renders `<button type="submit">`.

Together, this prevents the filter from submitting when the text input is empty.

**Note**: `<form>` comes with built-in keyboard support ([`submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) event is dispatched when <kbd>enter</kbd> is pressed), so I was able to remove explicit `keydown` handlers and related tests.

## Testing

Confirmed that browser prevents submitting TextFilter with an empty value.

![](https://github.com/user-attachments/assets/3febf2e5-8dac-4691-a703-5c474306bed7)

Also confirmed that all filters in the [Filters story](https://itwin.github.io/iTwinUI/2205/react/?story=table--filters&theme=dark) continue to work ok, both with mouse and keyboard.

## Docs

Added changesets.

## After-PR TODOs

- [ ] Fix datepicker popover (see [comment](https://github.com/iTwin/iTwinUI/pull/2205#discussion_r1731714448)).