### PR TITLE
Change `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
-*       @iTwin/itwinui-1 @iTwin/itwinui-2
+*       @iTwin/itwinui


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Since there usually is just one reviewer in @iTwin/itwinui-2, whenever someone from that team creates a PR, only one reviewer is assigned even though two approvals are generally required for a PR.

This PR instead uses the @iTwin/itwinui team in the CODEOWNERS files to ensure that at least two reviewers are automatically assigned to each PR. When more members join @iTwin/itwinui-2, we can revert this change, if needed.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Not sure how to confirm that two reviewers are indeed added from the new CODEOWNERS team. But since this is a small modification, I believe it would work.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A