### PR TITLE
create `useWarningLogger` hook

### DIFF
--- a/.changeset/mighty-spiders-repair.md
+++ b/.changeset/mighty-spiders-repair.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Dev-only warnings have been improved so that they are correctly shown for every individual instance of a component. Additionally, these warnings are now logged using `console.error`, which results in a better stack trace.

--- a/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/itwinui-react/src/core/Breadcrumbs/Breadcrumbs.tsx
@@ -9,13 +9,11 @@ import {
   useOverflow,
   SvgChevronRight,
   Box,
-  createWarningLogger,
+  useWarningLogger,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { Button } from '../Buttons/Button.js';
 import { Anchor } from '../Typography/Anchor.js';
-
-const logWarning = createWarningLogger();
 
 type BreadcrumbsProps = {
   /**
@@ -197,6 +195,8 @@ const ListItem = ({
   isActive: boolean;
 }) => {
   let children = item as any;
+
+  const logWarning = useWarningLogger();
 
   if (
     children?.type === 'span' ||

--- a/packages/itwinui-react/src/core/Buttons/IconButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton.tsx
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import * as React from 'react';
-import { Box, ButtonBase, createWarningLogger } from '../../utils/index.js';
+import { Box, ButtonBase, useWarningLogger } from '../../utils/index.js';
 import { Tooltip } from '../Tooltip/Tooltip.js';
 import type { ButtonProps } from './Button.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { VisuallyHidden } from '../VisuallyHidden/VisuallyHidden.js';
 import { ButtonGroupContext } from '../ButtonGroup/ButtonGroup.js';
 import { PopoverOpenContext } from '../Popover/Popover.js';
-
-const logWarning = createWarningLogger();
 
 export type IconButtonProps = {
   /**
@@ -73,6 +71,8 @@ export const IconButton = React.forwardRef((props, ref) => {
 
   const buttonGroupOrientation = React.useContext(ButtonGroupContext);
   const hasPopoverOpen = React.useContext(PopoverOpenContext);
+
+  const logWarning = useWarningLogger();
 
   if (
     process.env.NODE_ENV === 'development' &&

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -7,15 +7,13 @@ import {
   SvgCaretRightSmall,
   useMergedRefs,
   useId,
-  createWarningLogger,
+  useWarningLogger,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { Menu, MenuContext } from './Menu.js';
 import { ListItem } from '../List/ListItem.js';
 import type { ListItemOwnProps } from '../List/ListItem.js';
 import cx from 'classnames';
-
-const logWarning = createWarningLogger();
 
 export type MenuItemProps = {
   /**
@@ -99,6 +97,8 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
     subMenuItems = [],
     ...rest
   } = props;
+
+  const logWarning = useWarningLogger();
 
   if (
     process.env.NODE_ENV === 'development' &&

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -32,7 +32,7 @@ import {
   useResizeObserver,
   useLayoutEffect,
   Box,
-  createWarningLogger,
+  useWarningLogger,
   ShadowRoot,
   useMergedRefs,
   useLatestRef,
@@ -70,8 +70,6 @@ const singleRowSelectedAction = 'singleRowSelected';
 const shiftRowSelectedAction = 'shiftRowSelected';
 export const tableResizeStartAction = 'tableResizeStart';
 const tableResizeEndAction = 'tableResizeEnd';
-
-const logWarning = createWarningLogger();
 
 export type TablePaginatorRendererProps = {
   /**
@@ -630,6 +628,8 @@ export const Table = <
   } = instance;
 
   let headerGroups = _headerGroups;
+
+  const logWarning = useWarningLogger();
 
   if (columns.length === 1 && 'columns' in columns[0]) {
     headerGroups = _headerGroups.slice(1);

--- a/packages/itwinui-react/src/utils/functions/dev.ts
+++ b/packages/itwinui-react/src/utils/functions/dev.ts
@@ -3,6 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import * as React from 'react';
+
 // @ts-expect-error -- jest is not used in iTwinUI but may be used in consuming apps
 const isJest = typeof jest !== 'undefined';
 
@@ -14,20 +16,6 @@ const isVitest = typeof (globalThis as any).__vitest_index__ !== 'undefined';
 
 const isUnitTest = isJest || isVitest || isMocha;
 
-/**
- * Returns a function that can be used to log one-time warnings in dev environments.
- *
- * **Note**: The actual log call should be wrapped in a check against `process.env.NODE_ENV === 'development'`
- * to ensure that it is removed from the production build output (by SWC).
- * Read more about the [`NODE_ENV` convention](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production).
- *
- * @example
- * const logWarning = createWarningLogger();
- *
- * if (process.env.NODE_ENV === 'development') {
- *   logWarning("please don't use this")
- * }
- */
 const createWarningLogger =
   process.env.NODE_ENV === 'development' && !isUnitTest
     ? () => {
@@ -41,4 +29,23 @@ const createWarningLogger =
       }
     : () => () => {};
 
-export { isUnitTest, createWarningLogger };
+/**
+ * Returns a function that can be used to log one-time warnings in dev environments.
+ *
+ * **Note**: The actual log call should be wrapped in a check against `process.env.NODE_ENV === 'development'`
+ * to ensure that it is removed from the production build output (by SWC).
+ * Read more about the [`NODE_ENV` convention](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production).
+ *
+ * @example
+ * const logWarning = useWarningLogger();
+ *
+ * if (process.env.NODE_ENV === 'development') {
+ *   logWarning("please don't use this")
+ * }
+ */
+function useWarningLogger() {
+  const logWarning = React.useMemo(() => createWarningLogger(), []);
+  return logWarning;
+}
+
+export { isUnitTest, useWarningLogger };

--- a/packages/itwinui-react/src/utils/functions/dev.ts
+++ b/packages/itwinui-react/src/utils/functions/dev.ts
@@ -3,8 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import * as React from 'react';
-
 // @ts-expect-error -- jest is not used in iTwinUI but may be used in consuming apps
 const isJest = typeof jest !== 'undefined';
 
@@ -16,36 +14,4 @@ const isVitest = typeof (globalThis as any).__vitest_index__ !== 'undefined';
 
 const isUnitTest = isJest || isVitest || isMocha;
 
-const createWarningLogger =
-  process.env.NODE_ENV === 'development' && !isUnitTest
-    ? () => {
-        let logged = false;
-        return (message: string) => {
-          if (!logged) {
-            console.warn(message);
-            logged = true;
-          }
-        };
-      }
-    : () => () => {};
-
-/**
- * Returns a function that can be used to log one-time warnings in dev environments.
- *
- * **Note**: The actual log call should be wrapped in a check against `process.env.NODE_ENV === 'development'`
- * to ensure that it is removed from the production build output (by SWC).
- * Read more about the [`NODE_ENV` convention](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production).
- *
- * @example
- * const logWarning = useWarningLogger();
- *
- * if (process.env.NODE_ENV === 'development') {
- *   logWarning("please don't use this")
- * }
- */
-function useWarningLogger() {
-  const logWarning = React.useMemo(() => createWarningLogger(), []);
-  return logWarning;
-}
-
-export { isUnitTest, useWarningLogger };
+export { isUnitTest };

--- a/packages/itwinui-react/src/utils/hooks/index.ts
+++ b/packages/itwinui-react/src/utils/hooks/index.ts
@@ -18,3 +18,4 @@ export * from './useId.js';
 export * from './useControlledState.js';
 export * from './useSyncExternalStore.js';
 export * from './useVirtualScroll.js';
+export * from './useWarningLogger.js';

--- a/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
+++ b/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
@@ -6,7 +6,9 @@
 import * as React from 'react';
 import { isUnitTest } from '../functions/dev.js';
 
-const internalsKey = '__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED';
+const _React = React as any;
+const ReactInternals =
+  _React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 
 /**
  * Returns a function that can be used to log one-time warnings in dev environments.
@@ -29,9 +31,8 @@ export const useWarningLogger =
         const timeoutRef = React.useRef<number | null>(null);
 
         // https://stackoverflow.com/a/71685253
-        const stack = (React as any)[
-          internalsKey
-        ]?.ReactDebugCurrentFrame?.getCurrentStack?.();
+        const stack =
+          ReactInternals?.ReactDebugCurrentFrame?.getCurrentStack?.();
 
         // Second line in the stack is the component name.
         const componentName = stack?.trim().split('\n')[1];

--- a/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
+++ b/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
@@ -30,7 +30,7 @@ export const useWarningLogger =
           // Using setTimeout to delay execution until after rendering is complete.
           timeoutRef.current = window.setTimeout(() => {
             if (!loggedRef.current) {
-              console.warn(message);
+              console.error('Warning:', message);
               loggedRef.current = true;
             }
           });

--- a/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
+++ b/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
@@ -35,7 +35,7 @@ export const useWarningLogger =
           ReactInternals?.ReactDebugCurrentFrame?.getCurrentStack?.();
 
         // Second line in the stack is the component name.
-        const componentName = stack?.trim().split('\n')[1];
+        const componentName = stack?.trim().split('\n')[1]?.trim();
 
         const prefix = componentName
           ? `Warning (${componentName}):`

--- a/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
+++ b/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
@@ -26,7 +26,7 @@ export const useWarningLogger =
         const loggedRef = React.useRef(false);
         const timeoutRef = React.useRef<number | null>(null);
 
-        const logWarning = (message: string) => {
+        const logWarning = React.useCallback((message: string) => {
           // Using setTimeout to delay execution until after rendering is complete.
           timeoutRef.current = window.setTimeout(() => {
             if (!loggedRef.current) {
@@ -34,7 +34,7 @@ export const useWarningLogger =
               loggedRef.current = true;
             }
           });
-        };
+        }, []);
 
         React.useEffect(() => {
           // Clearing timeout on unmount to avoid double execution in StrictMode.

--- a/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
+++ b/packages/itwinui-react/src/utils/hooks/useWarningLogger.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from 'react';
+import { isUnitTest } from '../functions/dev.js';
+
+/**
+ * Returns a function that can be used to log one-time warnings in dev environments.
+ *
+ * **Note**: The actual log call should be wrapped in a check against `process.env.NODE_ENV === 'development'`
+ * to ensure that it is removed from the production build output (by SWC).
+ * Read more about the [`NODE_ENV` convention](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production).
+ *
+ * @example
+ * const logWarning = useWarningLogger();
+ *
+ * if (process.env.NODE_ENV === 'development') {
+ *   logWarning("please don't use this")
+ * }
+ */
+export const useWarningLogger =
+  process.env.NODE_ENV === 'development' && !isUnitTest
+    ? () => {
+        const loggedRef = React.useRef(false);
+        const timeoutRef = React.useRef<number | null>(null);
+
+        const logWarning = (message: string) => {
+          // Using setTimeout to delay execution until after rendering is complete.
+          timeoutRef.current = window.setTimeout(() => {
+            if (!loggedRef.current) {
+              console.warn(message);
+              loggedRef.current = true;
+            }
+          });
+        };
+
+        React.useEffect(() => {
+          // Clearing timeout on unmount to avoid double execution in StrictMode.
+          // The warning should be logged only once per component instance.
+          return () => {
+            if (timeoutRef.current) {
+              window.clearTimeout(timeoutRef.current);
+            }
+          };
+        }, []);
+
+        return logWarning;
+      }
+    : () => () => {};


### PR DESCRIPTION
## Changes

Fixes https://github.com/iTwin/iTwinUI/pull/2202#discussion_r1729170659

I've converted `createWarningLogger` into a `useWarningLogger` hook, and made some changes along the way.
1. Immediately I noticed that warnings were showing up twice, so I added a workaround using `setTimeout` to only show them once.
2. I also noticed that `console.warn` doesn't allow looking at the stack trace, so I changed it to `console.error`. This also makes the warnings more prominent and better distinguishes them from the browser's own warnings.
3. I then noticed that the stack trace doesn't include the original component name that's calling our component, so I added some very cursed code to get the component name. I think it is fine because this code is only present during development and property access is guarded using `?.`, so it will not crash even if React internals change.

## Testing

Tested that warnings are showing in the vite playground.

<details><summary>Code</summary>

```jsx
const App = () => {
  return (
    <>
      <IconButton>🥝</IconButton>
      <Test />
    </>
  );
};

const Test = () => {
  return <IconButton>💩</IconButton>;
};
```

</details> 

![](https://github.com/user-attachments/assets/b270cd13-1f9d-496b-91f5-fd21998d13cb)


## Docs

Added `patch` changeset.
