### PR TITLE
Add `#region` in long files like `Tabs`

### DIFF
--- a/packages/itwinui-react/src/core/Tabs/Tabs.tsx
+++ b/packages/itwinui-react/src/core/Tabs/Tabs.tsx
@@ -22,7 +22,7 @@ import { Icon } from '../Icon/Icon.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
 // ----------------------------------------------------------------------------
-// TabsWrapper
+// #region TabsWrapper
 
 type TabsOrientationProps =
   | {
@@ -134,8 +134,9 @@ if (process.env.NODE_ENV === 'development') {
   TabsWrapper.displayName = 'Tabs.Wrapper';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.TabList component
+// #region Tabs.TabList
 
 type TabListOwnProps = {
   /**
@@ -191,8 +192,9 @@ if (process.env.NODE_ENV === 'development') {
   TabList.displayName = 'Tabs.TabList';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.Tab component
+// #region Tabs.Tab
 
 type TabOwnProps = {
   /**
@@ -375,8 +377,9 @@ if (process.env.NODE_ENV === 'development') {
   Tab.displayName = 'Tabs.Tab';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.TabIcon component
+// #region Tabs.TabIcon
 
 const TabIcon = React.forwardRef((props, ref) => {
   return (
@@ -391,16 +394,18 @@ if (process.env.NODE_ENV === 'development') {
   TabIcon.displayName = 'Tabs.TabIcon';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.TabLabel component
+// #region Tabs.TabLabel
 
 const TabLabel = polymorphic.span('iui-tab-label');
 if (process.env.NODE_ENV === 'development') {
   TabLabel.displayName = 'Tabs.TabLabel';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.TabDescription component
+// #region Tabs.TabDescription
 
 const TabDescription = React.forwardRef((props, ref) => {
   const { className, children, ...rest } = props;
@@ -427,8 +432,9 @@ if (process.env.NODE_ENV === 'development') {
   TabDescription.displayName = 'Tabs.TabDescription';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.Actions component
+// #region Tabs.Actions
 
 type TabsActionsOwnProps = {
   /**
@@ -455,8 +461,9 @@ if (process.env.NODE_ENV === 'development') {
   TabsActions.displayName = 'Tabs.Actions';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs.Panel component
+// #region Tabs.Panel
 
 type TabsPanelOwnProps = {
   /**
@@ -492,8 +499,9 @@ if (process.env.NODE_ENV === 'development') {
   TabsPanel.displayName = 'Tabs.Panel';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
-// Tabs legacy component
+// #region LegacyTabsComponent
 
 type TabsLegacyProps = {
   /**
@@ -620,7 +628,9 @@ if (process.env.NODE_ENV === 'development') {
   LegacyTabsComponent.displayName = 'Tabs';
 }
 
+// #endregion
 // ----------------------------------------------------------------------------
+// #region LegacyTab
 
 type TabLegacyProps = {
   /**
@@ -677,8 +687,9 @@ const LegacyTab = React.forwardRef((props, forwardedRef) => {
   );
 }) as PolymorphicForwardRefComponent<'button', TabLegacyProps>;
 
+// #endregion
 // ----------------------------------------------------------------------------
-// exports
+// #region exports and helpers
 
 export { LegacyTab as Tab };
 
@@ -868,3 +879,5 @@ const useScrollbarGutter = () => {
     }
   }, []);
 };
+
+// #endregion


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Since Tabs is a big file (850+ lines), it could be hard to follow, even with the "Outline" panel in VSCode. Thus, this quick nit PR just adds some `#region` + `#endregion` comments to make the regions show in the minimap and also make the regions collapsable.

<details>
<summary>Screenshots</summary>

<img width="142" alt="image" src="https://github.com/user-attachments/assets/29711468-3f9c-4340-bf45-15b5523b71d4">

<img width="298" alt="image" src="https://github.com/user-attachments/assets/d6192ac4-b14f-4f7a-9774-aa2e6beec638">

</details>

We could consider adding regions to other similarly large files with subcomponents (e.g. Panels from #2001), or we can consider splitting them across different files (iirc, I think we decided against that for some reason in Tabs).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A