### PR TITLE
fix fallback CSS version

### DIFF
--- a/.changeset/spotty-comics-carry.md
+++ b/.changeset/spotty-comics-carry.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fixed the fallback CSS logic to load the correct stylesheet version.
+Fixed the fallback CSS logic in `ThemeProvider` to load the correct stylesheet version.

--- a/.changeset/spotty-comics-carry.md
+++ b/.changeset/spotty-comics-carry.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed the fallback CSS logic to load the correct stylesheet version.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -428,7 +428,7 @@ const FallbackStyles = ({ root }: { root: HTMLElement }) => {
       } catch (error) {
         console.log('Error loading styles.css locally', error);
         const css = await importCss(
-          'https://cdn.jsdelivr.net/npm/@itwin/itwinui-react@3/styles.css',
+          `https://cdn.jsdelivr.net/npm/@itwin/itwinui-react@${meta.version}/styles.css`,
         );
         document.adoptedStyleSheets = [
           ...document.adoptedStyleSheets,


### PR DESCRIPTION
## Changes

Updated the CDN url to use the exact version number (which we now have after #2107).

Previously we were hardcoding `3`, which would always load the latest 3.x version.

## Testing

Manually verified by forcing the fallback logic to run in vite playground. The CDN url in the Network tab contains the exact version number.

![](https://github.com/user-attachments/assets/195bdf53-d493-40da-98db-a751e78394e9)

## Docs

Added `patch` changeset.