### PR TITLE
Dont add line clamp, if column id is not defined

### DIFF
--- a/.changeset/happy-badgers-move.md
+++ b/.changeset/happy-badgers-move.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-Fix cell not taking full width, where custom `Cell` implementation is passed.
+Fix `Table` cell not taking full width when custom `Cell` implementation is passed.

--- a/.changeset/happy-badgers-move.md
+++ b/.changeset/happy-badgers-move.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fix cell not taking full width, where custom `Cell` implementation is passed.

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -3994,3 +3994,42 @@ it('should pass custom props to different parts of Table', () => {
   expect(emptyTableContent).toBeTruthy();
   expect(emptyTableContent.style.fontSize).toBe('12px');
 });
+
+it('should apply clamp, if cell is string value and no custom Cell is rendered', () => {
+  const data = [{ name: 'name' }];
+  const columns: Column<TestDataType>[] = [
+    {
+      Header: 'Name',
+      accessor: 'name',
+      cellClassName: 'test-cell',
+    },
+  ];
+  const { container } = renderComponent({
+    columns,
+    data,
+  });
+  const host = container.querySelector('.test-cell');
+  expect(host?.shadowRoot).toBeTruthy();
+  const lineClamp = host?.shadowRoot?.querySelector('div');
+  expect(lineClamp).toBeTruthy();
+});
+
+it('should not apply clamp, if custom Cell is used', () => {
+  const data = [{ name: 'name' }];
+  const columns: Column<TestDataType>[] = [
+    {
+      Header: 'Name',
+      accessor: 'name',
+      cellClassName: 'test-cell',
+      Cell: () => 'my custom content',
+    },
+  ];
+  const { container } = renderComponent({
+    columns,
+    data,
+  });
+  const host = container.querySelector('.test-cell');
+  expect(host?.shadowRoot).toBeTruthy();
+  const lineClamp = host?.shadowRoot?.querySelector('div');
+  expect(lineClamp).toBeNull();
+});

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -25,6 +25,7 @@ import type {
   ActionType,
   TableInstance,
   Column,
+  ColumnInstance,
 } from '../../react-table/react-table.js';
 import { ProgressRadial } from '../ProgressIndicators/ProgressRadial.js';
 import {
@@ -906,9 +907,7 @@ export const Table = <
   }, []);
 
   return (
-    <TableColumnsContext.Provider
-      value={columns as Column<Record<string, unknown>>[]}
-    >
+    <TableColumnsContext.Provider value={instance.columns as ColumnInstance[]}>
       <Box
         ref={useMergedRefs<HTMLDivElement>(
           tableRef,

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
@@ -34,7 +34,7 @@ it('should not apply clamp, if id of column is not defined', () => {
         key: 'key',
         className: 'original-class',
       }}
-      cellProps={{ column: {} } as any}
+      cellProps={{ column: {}, value: 'string' } as any}
     >
       {null}
     </DefaultCell>,

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
@@ -26,39 +26,3 @@ it('should merge className/style with cellElementProps', () => {
   expect(cellElement.style.width).toBe('100px');
   expect(cellElement.style.color).toBe('red');
 });
-
-it('should not apply clamp, if id of column is not defined', () => {
-  const { container } = render(
-    <DefaultCell
-      cellElementProps={{
-        key: 'key',
-        className: 'original-class',
-      }}
-      cellProps={{ column: {}, value: 'string' } as any}
-    >
-      {null}
-    </DefaultCell>,
-  );
-  const host = container.querySelector('.original-class');
-  expect(host?.shadowRoot).toBeTruthy();
-  const lineClamp = host?.shadowRoot?.querySelector('div');
-  expect(lineClamp).toBeNull();
-});
-
-it('should apply clamp, if id of column is defined and cell value is string', () => {
-  const { container } = render(
-    <DefaultCell
-      cellElementProps={{
-        key: 'key',
-        className: 'original-class',
-      }}
-      cellProps={{ column: { id: 'id' }, value: 'string' } as any}
-    >
-      {null}
-    </DefaultCell>,
-  );
-  const host = container.querySelector('.original-class');
-  expect(host?.shadowRoot).toBeTruthy();
-  const lineClamp = host?.shadowRoot?.querySelector('div');
-  expect(lineClamp).toBeTruthy();
-});

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.test.tsx
@@ -26,3 +26,39 @@ it('should merge className/style with cellElementProps', () => {
   expect(cellElement.style.width).toBe('100px');
   expect(cellElement.style.color).toBe('red');
 });
+
+it('should not apply clamp, if id of column is not defined', () => {
+  const { container } = render(
+    <DefaultCell
+      cellElementProps={{
+        key: 'key',
+        className: 'original-class',
+      }}
+      cellProps={{ column: {} } as any}
+    >
+      {null}
+    </DefaultCell>,
+  );
+  const host = container.querySelector('.original-class');
+  expect(host?.shadowRoot).toBeTruthy();
+  const lineClamp = host?.shadowRoot?.querySelector('div');
+  expect(lineClamp).toBeNull();
+});
+
+it('should apply clamp, if id of column is defined and cell value is string', () => {
+  const { container } = render(
+    <DefaultCell
+      cellElementProps={{
+        key: 'key',
+        className: 'original-class',
+      }}
+      cellProps={{ column: { id: 'id' }, value: 'string' } as any}
+    >
+      {null}
+    </DefaultCell>,
+  );
+  const host = container.querySelector('.original-class');
+  expect(host?.shadowRoot).toBeTruthy();
+  const lineClamp = host?.shadowRoot?.querySelector('div');
+  expect(lineClamp).toBeTruthy();
+});

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -48,7 +48,6 @@ export const DefaultCell = <T extends Record<string, unknown>>(
   const columnsProp = React.useContext(TableColumnsContext);
   const isCustomCell = React.useMemo(
     () =>
-      !!props.cellProps.column.id &&
       columnsProp
         .find(({ id }) => props.cellProps.column.id === id)
         ?.hasOwnProperty('Cell'),
@@ -69,7 +68,9 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     className,
     style,
     status,
-    clamp = typeof cellProps.value === 'string' && !isCustomCell,
+    clamp = typeof cellProps.value === 'string' &&
+      !!props.cellProps.column.id &&
+      !isCustomCell,
     ...rest
   } = props;
 

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import { defaultColumn } from 'react-table';
 import type { CellRendererProps } from '../../../react-table/react-table.js';
 import cx from 'classnames';
 import { Box, LineClamp, ShadowRoot } from '../../../utils/index.js';
@@ -45,13 +46,12 @@ export type DefaultCellProps<T extends Record<string, unknown>> = {
 export const DefaultCell = <T extends Record<string, unknown>>(
   props: DefaultCellProps<T>,
 ) => {
-  const columnsProp = React.useContext(TableColumnsContext);
+  const instanceColumns = React.useContext(TableColumnsContext);
   const isCustomCell = React.useMemo(
     () =>
-      columnsProp
-        .find(({ id }) => props.cellProps.column.id === id)
-        ?.hasOwnProperty('Cell'),
-    [props.cellProps.column.id, columnsProp],
+      instanceColumns.find(({ id }) => props.cellProps.column.id === id)
+        ?.Cell !== defaultColumn.Cell,
+    [instanceColumns, props.cellProps.column.id],
   );
 
   const {
@@ -68,9 +68,7 @@ export const DefaultCell = <T extends Record<string, unknown>>(
     className,
     style,
     status,
-    clamp = typeof cellProps.value === 'string' &&
-      !!props.cellProps.column.id &&
-      !isCustomCell,
+    clamp = typeof cellProps.value === 'string' && !isCustomCell,
     ...rest
   } = props;
 

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -48,6 +48,7 @@ export const DefaultCell = <T extends Record<string, unknown>>(
   const columnsProp = React.useContext(TableColumnsContext);
   const isCustomCell = React.useMemo(
     () =>
+      !!props.cellProps.column.id &&
       columnsProp
         .find(({ id }) => props.cellProps.column.id === id)
         ?.hasOwnProperty('Cell'),

--- a/packages/itwinui-react/src/core/Table/utils.ts
+++ b/packages/itwinui-react/src/core/Table/utils.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import type { ColumnInstance, Column } from '../../react-table/react-table.js';
+import type { ColumnInstance } from '../../react-table/react-table.js';
 
 export const getCellStyle = <T extends Record<string, unknown>>(
   column: ColumnInstance<T>,
@@ -82,6 +82,4 @@ export const getSubRowStyle = ({ density = 'default', depth = 1 }) => {
   } satisfies React.CSSProperties;
 };
 
-export const TableColumnsContext = React.createContext<
-  Column<Record<string, unknown>>[]
->([]);
+export const TableColumnsContext = React.createContext<ColumnInstance[]>([]);


### PR DESCRIPTION
## Changes

~~Added validation if column id is present before checking for `Cell` property. If column has no id, we cannot know about the `Cell` property. As a result, not adding line clamp styling.~~

Fixed the column `id` check to use `instance.columns` instead of `props.column`. This ensures that columns always have ids (`react-table` generates a backup id if the user-specified column object does not have one).

This fixes an issue where a column with a `Cell` but without an `id` wasn't being detected properly.

## Testing

Added unit test;

~~TODO: validate in storybook, failing local build for now.~~

## Docs

N/A
