### PR TITLE
`dev` script properly builds all outputs

### DIFF
--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -99,7 +99,7 @@
     "dev:dev-esm": "swc src -d DEV-esm --env-name='development' --watch --strip-leading-paths",
     "dev:cjs": "swc src -d cjs --env-name='production' --watch --strip-leading-paths -C module.type=commonjs",
     "dev:dev-cjs": "swc src -d DEV-cjs --env-name='development' --watch --strip-leading-paths -C module.type=commonjs",
-    "dev:types": "concurrently \"tsc -p tsconfig.build.json --outDir DEV-esm --watch --preserveWatchOutput\" \"tsc -p tsconfig.build.json --outDir DEV-cjs --watch --preserveWatchOutput\"",
+    "dev:types": "concurrently \"tsc -p tsconfig.build.json --outDir esm --watch --preserveWatchOutput\" \"tsc -p tsconfig.build.json --outDir cjs --watch --preserveWatchOutput\"",
     "dev:styles": "pnpm build:styles --watch"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes Next playground giving a "Failed to compile" error:

![image](https://github.com/user-attachments/assets/4715a587-3b60-4da3-984f-f4087a0531ac)

The error was because [#2246 (comment)](https://github.com/iTwin/iTwinUI/pull/2246#discussion_r1763732973):

> Next.js (Webpack) is trying to resolve the [`"development"` entrypoint](https://github.com/iTwin/iTwinUI/blob/b243bd22fd70282d5e59f8bf07cb2c9fc3694887/packages/itwinui-react/package.json#L14), which `swc` does not currently produce.

The fix involves properly generating the package code for the `DEV-cjs` and `DEV-esm` folders. To do this, I added two sub-scripts that use swc to build package code for the two `DEV-*` folders.

|`dev` before|`dev` after|
|-|-|
|<img width="137" alt="image" src="https://github.com/user-attachments/assets/4d4c32bb-04fb-4319-8c69-b7b25f41cd45">|<img width="131" alt="image" src="https://github.com/user-attachments/assets/4d44bca6-d24f-4413-9759-0dc155eb0515">|

<!-- <img width="134" alt="image" src="https://github.com/user-attachments/assets/be2be694-2251-4fbd-9e90-d7083f950b77"> -->

Types are only generated for the `esm` and `cjs` folders ([#2246 (comment)](https://github.com/iTwin/iTwinUI/pull/2246#discussion_r1763970385)).

I had also thought about just building the `DEV-esm` and DEV-cjs` folders when running the `dev` script. But looks like we need to always build all four folders for the reasons mentioned in [#2246 (comment)](https://github.com/iTwin/iTwinUI/pull/2246#discussion_r1763926380).

Unrelated: I noticed that `styles.css` was a build output but was not added to the `build:clean`. So, I added it.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

All playgrounds except the next playground used to work. Confirmed that now all playgrounds work. 

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A

## After PR TODOs:

- [ ] Consider not including the next playground in the top-level dev script ([#2246 (comment)](https://github.com/iTwin/iTwinUI/pull/2246#discussion_r1763926380)). This makes things easiers and reduces resource consumption when using the top level `dev` script. Not having the `next` playground in the top level `dev` script is alright as we usually use the vite playground. Even if we want to use the next playground, we can do so manually using own `dev` script.
- [ ] See if the next playground can directly use tsx files ([#2246 (comment)](https://github.com/iTwin/iTwinUI/pull/2246#discussion_r1763926380)).