### PR TITLE
allow `portal` customization in `ComboBox` and `Select`

### DIFF
--- a/.changeset/hungry-rocks-matter.md
+++ b/.changeset/hungry-rocks-matter.md
@@ -19,7 +19,7 @@ To turn off the default portaling behavior, use `portal: false`.
 ```
 
 ```jsx
-<ComboBox
+<Select
   options={[…]}
   popoverProps={{ portal: false }}
 />

--- a/.changeset/hungry-rocks-matter.md
+++ b/.changeset/hungry-rocks-matter.md
@@ -1,0 +1,28 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`ComboBox` and `Select` now allow customizing the portal behavior of the floating listbox.
+- To customize `ComboBox` portaling behavior, use `dropdownMenuProps.portal`.
+- To customize `Select` portaling behavior, use `popoverProps.portal`.
+
+<details>
+<summary>Example</summary>
+
+To turn off the default portaling behavior, use `portal: false`.
+
+```jsx
+<ComboBox
+  options={[…]}
+  dropdownMenuProps={{ portal: false }}
+/>
+```
+
+```jsx
+<ComboBox
+  options={[…]}
+  popoverProps={{ portal: false }}
+/>
+```
+
+</details>

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -17,7 +17,11 @@ import {
   useControlledState,
 } from '../../utils/index.js';
 import { usePopover } from '../Popover/Popover.js';
-import type { InputContainerProps, CommonProps } from '../../utils/index.js';
+import type {
+  InputContainerProps,
+  CommonProps,
+  PortalProps,
+} from '../../utils/index.js';
 import { ComboBoxRefsContext, ComboBoxStateContext } from './helpers.js';
 import { ComboBoxEndIcon } from './ComboBoxEndIcon.js';
 import { ComboBoxInput } from './ComboBoxInput.js';
@@ -111,7 +115,8 @@ export type ComboBoxProps<T> = {
    * Props to customize dropdown menu behavior.
    */
   dropdownMenuProps?: React.ComponentProps<'div'> &
-    Pick<Parameters<typeof usePopover>['0'], 'middleware'>;
+    Pick<Parameters<typeof usePopover>['0'], 'middleware'> &
+    Pick<PortalProps, 'portal'>;
   /**
    * End icon props.
    */

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenu.tsx
@@ -115,7 +115,7 @@ const VirtualizedComboBoxMenu = (props: React.ComponentProps<'div'>) => {
 };
 
 export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
-  const { className, children, style, ...rest } = props;
+  const { className, children, style, portal = true, ...rest } = props;
   const { id, enableVirtualization, popover } =
     useSafeContext(ComboBoxStateContext);
   const { menuRef } = useSafeContext(ComboBoxRefsContext);
@@ -124,7 +124,7 @@ export const ComboBoxMenu = React.forwardRef((props, forwardedRef) => {
 
   return (
     popover.open && (
-      <Portal portal>
+      <Portal portal={portal}>
         <List
           as='div'
           className={cx('iui-menu', className)}

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -21,6 +21,7 @@ import {
 import type {
   CommonProps,
   PolymorphicForwardRefComponent,
+  PortalProps,
 } from '../../utils/index.js';
 import { SelectTag } from './SelectTag.js';
 import { SelectTagContainer } from './SelectTagContainer.js';
@@ -293,7 +294,7 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
     multiple = false,
     triggerProps,
     status,
-    popoverProps,
+    popoverProps: { portal = true, ...popoverProps } = {},
     // @ts-expect-error -- this prop is disallowed by types but should still be handled at runtime
     styleType,
     ...rest
@@ -490,7 +491,7 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
       </InputWithIcon>
 
       {popover.open && (
-        <Portal>
+        <Portal portal={portal}>
           <SelectListbox
             defaultFocusedIndex={defaultFocusedIndex}
             className={menuClassName}
@@ -562,7 +563,7 @@ export type CustomSelectProps<T> = SelectCommonProps & {
     middleware?: {
       hide?: boolean;
     };
-  };
+  } & Pick<PortalProps, 'portal'>;
   /**
    * Props to pass to the select button (trigger) element.
    */


### PR DESCRIPTION
## Changes

- **ComboBox**: Exposes the `portal` key under the `dropdownMenuProps` prop.
- **Select**: Exposes the `portal` key under the `popoverProps` prop.

This enables users to work around issues with the default portaling behavior (e.g. #2245).

## Testing

Manually verified in vite playground that #2245 is fixed when overriding the `portal`.

```jsx
<Popover
  content={
    <ComboBox
      options={[…]}
      dropdownMenuProps={{ portal: false }}
    />
  }
>
  <Button>Open</Button>
</Popover>
```

<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/48826a18-388c-481e-8de7-d772a0eeb3b9

</details>

## Docs

Added `minor` changeset to document new prop customization.