### PR TITLE
reuse `Tag` in `SelectTag`

### DIFF
--- a/.changeset/curly-donkeys-press.md
+++ b/.changeset/curly-donkeys-press.md
@@ -1,0 +1,29 @@
+---
+'@itwin/itwinui-css': major
+---
+
+`iui-select-tag` and related classes must now be used together with `iui-tag` (and related) classes. The `iui-select-tag-button-icon` class has been removed.
+
+<details>
+
+<summary>Diff</summary>
+
+```diff
+- <span class="iui-select-tag">
++ <span class="iui-select-tag iui-tag">
+-   <span class="iui-select-tag-label">
++   <span class="iui-select-tag-label iui-tag-label">
+      …
+    </span>
+    <button
+-     class="iui-button iui-field iui-select-tag-button"
++     class="iui-button iui-field iui-select-tag-button iui-tag-button"
+      aria-label="…"
+    >
+-     <svg class="iui-button-icon iui-select-tag-button-icon">…</svg>
++     <svg class="iui-button-icon">…</svg>
+    </button>
+  </span>
+```
+
+</details>

--- a/apps/css-workshop/src/components/selectTag.js
+++ b/apps/css-workshop/src/components/selectTag.js
@@ -17,18 +17,18 @@ class SelectTag extends HTMLElement {
 
     const innerHtml = `
     <span
-      class="iui-select-tag"
+      class="iui-tag iui-select-tag"
     >
       <span
-        class="iui-select-tag-label"
+        class="iui-tag-label iui-select-tag-label"
         title="${value}"
       >
         ${value}
       </span>
       ${
         dismissible
-          ? `<button class="iui-button iui-field iui-select-tag-button" data-iui-variant="borderless" aria-label="Delete ${value} tag" type="button">
-            <svg-close-small class="iui-button-icon iui-select-tag-button-icon" aria-hidden="true"></svg-close-small>
+          ? `<button class="iui-button iui-field iui-tag-button iui-select-tag-button" data-iui-variant="borderless" aria-label="Delete ${value} tag" type="button">
+            <svg-close-small class="iui-button-icon" aria-hidden="true"></svg-close-small>
           </button>`
           : ''
       }

--- a/packages/itwinui-css/src/select/select.scss
+++ b/packages/itwinui-css/src/select/select.scss
@@ -98,7 +98,6 @@
 }
 
 @mixin iui-select-tag {
-  @include tag.iui-tag;
   // Override hardcoded Tag margin
   margin-block: 0;
   display: inline-flex;
@@ -109,15 +108,12 @@
 }
 
 @mixin iui-select-tag-label {
-  @include tag.iui-tag-label;
-
   .iui-select-button[data-iui-size='small'] & {
     font-size: var(--iui-font-size-0);
   }
 }
 
 @mixin iui-select-tag-button {
-  @include tag.iui-tag-button;
   padding-inline: var(--iui-size-2xs);
   min-block-size: unset;
   min-inline-size: unset;
@@ -126,12 +122,10 @@
 
   .iui-select-button[data-iui-size='small'] & {
     font-size: var(--iui-font-size-0);
-  }
-}
 
-@mixin iui-select-tag-button-icon {
-  .iui-select-button[data-iui-size='small'] & svg {
-    @include mixins.iui-icon-style('s');
+    svg {
+      @include mixins.iui-icon-style('s');
+    }
   }
 }
 
@@ -153,18 +147,14 @@
   @include iui-select-tag-container;
 }
 
-.iui-select-tag {
+.iui-select-tag:is(.iui-tag) {
   @include iui-select-tag;
 }
 
-.iui-select-tag-label {
+.iui-select-tag-label:is(.iui-tag-label) {
   @include iui-select-tag-label;
 }
 
-.iui-select-tag-button {
+.iui-select-tag-button:is(.iui-tag-button) {
   @include iui-select-tag-button;
-}
-
-.iui-select-tag-button-icon {
-  @include iui-select-tag-button-icon;
 }

--- a/packages/itwinui-react/src/core/Select/SelectTag.tsx
+++ b/packages/itwinui-react/src/core/Select/SelectTag.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import cx from 'classnames';
 import * as React from 'react';
-import { Box } from '../../utils/index.js';
+import { Tag } from '../Tag/Tag.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
 type SelectTagProps = {
@@ -12,7 +12,7 @@ type SelectTagProps = {
    * Text inside the tag.
    */
   label: string;
-};
+} & Pick<React.ComponentProps<typeof Tag>, 'onClick' | 'onRemove'>;
 
 /**
  * Tag for showing selected value in `Select`.
@@ -22,15 +22,14 @@ export const SelectTag = React.forwardRef((props, forwardedRef) => {
   const { className, label, ...rest } = props;
 
   return (
-    <Box
-      as='span'
+    <Tag
       className={cx('iui-select-tag', className)}
+      labelProps={{ className: 'iui-select-tag-label' }}
+      removeButtonProps={{ className: 'iui-select-tag-button' }}
       ref={forwardedRef}
       {...rest}
     >
-      <Box as='span' className='iui-select-tag-label'>
-        {label}
-      </Box>
-    </Box>
+      {label}
+    </Tag>
   );
 }) as PolymorphicForwardRefComponent<'span', SelectTagProps>;


### PR DESCRIPTION
## Changes

This PR takes a small step towards #907.

- **React**: Updated `SelectTag` component to use `Tag` internally and add extra classes on top of it.
- **CSS**: Removed the use of mixins in `select-tag`. Both `tag` and `select-tag` classes need to be present now.
  - Also replaced the `select-tag-button-icon` class with a nested `svg` selector.

There are two important outcomes to these changes:
1. We are able to make use of the "remove button" code from `Tag` (which also handles some edge cases; see #1824)
2. We ship less CSS (mixins create unnecessary duplication).

## Testing

All existing tests passing. No visual changes.

## Docs

Added `major` CSS changeset for DOM structure changes.

Doesn't affect usage or behavior for React package consumers.