### PR TITLE
set `showDatesOutsideMonth={false}` in `DatePicker` examples

### DIFF
--- a/apps/website/src/content/docs/datepicker.mdx
+++ b/apps/website/src/content/docs/datepicker.mdx
@@ -26,6 +26,8 @@ This component is recommended to be used inside the [`Popover`](popover) compone
 
 If you would rather see an example of the date picker being used on its own, look at the [standalone usage](#standalone-usage).
 
+**Note**: The `showDatesOutsideMonth` prop is recommended to be set to `false`, so that dates that are not in the currently selected month are not displayed. Currently, this prop defaults to `true` for backwards compatibility reasons.
+
 ### Localized
 
 You are able to create a localized version of the date picker that uses local names for week days and months.

--- a/examples/DatePicker.basic.jsx
+++ b/examples/DatePicker.basic.jsx
@@ -20,18 +20,14 @@ export default () => {
               setVisible(false);
             }}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>

--- a/examples/DatePicker.daterange.jsx
+++ b/examples/DatePicker.daterange.jsx
@@ -23,18 +23,14 @@ export default () => {
             setVisible(false);
           }}
           setFocus
+          showDatesOutsideMonth={false}
         />
       }
       placement='bottom-start'
       visible={visible}
       onVisibleChange={setVisible}
     >
-      <IconButton
-        label='Choose date'
-        onClick={() => {
-          setVisible(!visible);
-        }}
-      >
+      <IconButton label='Choose date'>
         <SvgCalendar />
       </IconButton>
     </Popover>

--- a/examples/DatePicker.datesdisabled.jsx
+++ b/examples/DatePicker.datesdisabled.jsx
@@ -34,18 +34,14 @@ export default () => {
             setVisible(false);
           }}
           setFocus
+          showDatesOutsideMonth={false}
         />
       }
       placement='bottom-start'
       visible={visible}
       onVisibleChange={setVisible}
     >
-      <IconButton
-        label='Choose date'
-        onClick={() => {
-          setVisible(!visible);
-        }}
-      >
+      <IconButton label='Choose date'>
         <SvgCalendar />
       </IconButton>
     </Popover>

--- a/examples/DatePicker.localized.jsx
+++ b/examples/DatePicker.localized.jsx
@@ -27,18 +27,14 @@ export default () => {
               setVisible(false);
             }}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>

--- a/examples/DatePicker.main.jsx
+++ b/examples/DatePicker.main.jsx
@@ -21,18 +21,14 @@ export default () => {
               setVisible(false);
             }}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>

--- a/examples/DatePicker.menu.jsx
+++ b/examples/DatePicker.menu.jsx
@@ -17,6 +17,7 @@ export default () => {
           setCurrentDate(date);
         }}
         applyBackground={false}
+        showDatesOutsideMonth={false}
       />
       <div className='demo-label'>{currentDate.toDateString()}</div>
     </Wrapper>

--- a/examples/DatePicker.withcombinedtime.jsx
+++ b/examples/DatePicker.withcombinedtime.jsx
@@ -26,18 +26,14 @@ export default () => {
             minuteStep={30}
             use12Hours={true}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>

--- a/examples/DatePicker.withtime.jsx
+++ b/examples/DatePicker.withtime.jsx
@@ -21,18 +21,14 @@ export default () => {
             }}
             showTime={true}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>

--- a/examples/DatePicker.withyear.jsx
+++ b/examples/DatePicker.withyear.jsx
@@ -22,18 +22,14 @@ export default () => {
               setVisible(false);
             }}
             setFocus
+            showDatesOutsideMonth={false}
           />
         }
         placement='bottom-start'
         visible={visible}
         onVisibleChange={setVisible}
       >
-        <IconButton
-          label='Choose date'
-          onClick={() => {
-            setVisible(!visible);
-          }}
-        >
+        <IconButton label='Choose date'>
           <SvgCalendar />
         </IconButton>
       </Popover>


### PR DESCRIPTION
## Changes

This prop was added in #1822 with the default value `true` but recommended value `false`. The documentation still needed to be updated, so this PR finally does that. All docs examples now set `showDatesOutsideMonth={false}`

## Testing

Confirmed that the demos look correct on the `/docs/datepicker` page.

## Docs

Added a small note near the beginning of the page to remind users to set this prop to `false`.