### PR TITLE
remove `user-select: all`

### DIFF
--- a/.changeset/dull-colts-repair.md
+++ b/.changeset/dull-colts-repair.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+All instances of `user-select: all` have been removed. Affected components: `code`, `information-panel`, `slider`, `stepper`, `tile`.

--- a/.changeset/shiny-lobsters-deliver.md
+++ b/.changeset/shiny-lobsters-deliver.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+All instances of `user-select: all` have been removed. Affected components: `Code`, `InformationPanel`, `Slider`, `Stepper`, `Tile`.

--- a/packages/itwinui-css/src/code/code.scss
+++ b/packages/itwinui-css/src/code/code.scss
@@ -26,7 +26,6 @@
 
     > .iui-title {
       margin-inline-start: var(--iui-size-s);
-      user-select: all;
     }
 
     > .iui-button {

--- a/packages/itwinui-css/src/information-panel/information-panel.scss
+++ b/packages/itwinui-css/src/information-panel/information-panel.scss
@@ -123,7 +123,6 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        user-select: all;
       }
 
       svg {

--- a/packages/itwinui-css/src/slider/slider.scss
+++ b/packages/itwinui-css/src/slider/slider.scss
@@ -150,7 +150,6 @@ $iui-slider-tick-thickness: 1px;
 
 .iui-slider-min,
 .iui-slider-max {
-  user-select: all;
   display: flex;
 }
 

--- a/packages/itwinui-css/src/stepper/stepper.scss
+++ b/packages/itwinui-css/src/stepper/stepper.scss
@@ -129,7 +129,6 @@
 
 @mixin iui-stepper-step-name {
   text-align: center;
-  user-select: all;
   color: var(--_iui-stepper-step-text-color);
 }
 

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -224,7 +224,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   flex-shrink: 0;
   align-items: center;
   font-size: var(--iui-font-size-2);
-  user-select: all;
   color: var(--_iui-tile-title-text-color);
   padding-inline: var(--iui-size-s);
 }


### PR DESCRIPTION
## Changes

Some components were using `user-select: all`. I believe the original intention was to make it easier to select the entire label in a single click. However, this was often undesirable.
- Sometimes the end user just wants to select part of the text. This became impossible when using `user-select: all`.
- Sometimes the label is an actionable (clickable/draggable) element, which would lead to the text unnecessarily being selected when clicked. I noticed some consumers overriding `user-select` in their custom CSS to avoid this.
- Sometimes the consumer of our components wants to place multiple standalone elements inside the "label" portion.

Removing `user-select: all` has no downsides. The user can still select the whole text, either manually or by OS-specific shortcuts (e.g. triple click on macOS).

## Testing

Manually tested affected components to ensure that clicking does not automatically select the whole text, and that text is selectable in the usual ways.

## Docs

Added `patch` changesets. Can be released in the next version (together with #2263).