### PR TITLE
`ButtonGroup`'s `Vertical Overflow` story logic fix

### DIFF
--- a/apps/react-workshop/src/ButtonGroup.stories.tsx
+++ b/apps/react-workshop/src/ButtonGroup.stories.tsx
@@ -61,33 +61,30 @@ export const Overflow = () => {
   return (
     <ButtonGroup
       orientation='horizontal'
-      overflowButton={(overflowStart) => {
-        return (
-          <DropdownMenu
-            menuItems={(close) => {
-              const length = items.length - overflowStart;
-
-              return Array.from({ length }, (_, _index) => {
+      overflowButton={(overflowStart) => (
+        <DropdownMenu
+          menuItems={(close) =>
+            Array(items.length - overflowStart)
+              .fill(null)
+              .map((_, _index) => {
                 const index = overflowStart + _index;
-
                 return (
                   <MenuItem
                     key={index}
                     onClick={close}
-                    icon={<SvgPlaceholder />}
+                    startIcon={<SvgPlaceholder />}
                   >
                     Item #{index}
                   </MenuItem>
                 );
-              });
-            }}
-          >
-            <IconButton label='More'>
-              <SvgMore />
-            </IconButton>
-          </DropdownMenu>
-        );
-      }}
+              })
+          }
+        >
+          <IconButton label='More'>
+            <SvgMore />
+          </IconButton>
+        </DropdownMenu>
+      )}
     >
       {items}
     </ButtonGroup>
@@ -165,51 +162,42 @@ export const Vertical = () => {
 };
 
 export const VerticalOverflow = () => {
-  const buttons = Array(10)
-    .fill(null)
-    .map((_, index) => (
-      <IconButton
-        key={index}
-        onClick={() => console.log(`Clicked on button ${index + 1}`)}
-      >
-        <SvgPlaceholder />
-      </IconButton>
-    ));
+  const items = Array.from({ length: 10 }, (_, index) => (
+    <IconButton key={index} label={`Item #${index}`}>
+      <SvgPlaceholder />
+    </IconButton>
+  ));
 
   return (
     <ButtonGroup
       orientation='vertical'
-      style={{ height: 'clamp(100px, 40vmax, 80vh)' }}
+      style={{ blockSize: '100%' }}
       overflowButton={(overflowStart) => (
         <DropdownMenu
           menuItems={(close) =>
-            Array(buttons.length - overflowStart + 1)
+            Array(items.length - overflowStart)
               .fill(null)
               .map((_, _index) => {
                 const index = overflowStart + _index;
-                const onClick = () => {
-                  console.log(`Clicked button ${index} (overflow)`);
-                  close();
-                };
                 return (
                   <MenuItem
                     key={index}
-                    onClick={onClick}
-                    icon={<SvgPlaceholder />}
+                    onClick={close}
+                    startIcon={<SvgPlaceholder />}
                   >
-                    Button #{index}
+                    Item #{index}
                   </MenuItem>
                 );
               })
           }
         >
-          <IconButton onClick={() => console.log('Clicked on overflow icon')}>
+          <IconButton label='More'>
             <SvgMore />
           </IconButton>
         </DropdownMenu>
       )}
     >
-      {buttons}
+      {items}
     </ButtonGroup>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

I noticed a small logic issue in the `ButtonGroup`'s `Vertical Overflow` story. The `overflowButton` was showing one extra `MenuItem` that didn't exist. i.e. it shows "Item 10" even though the items go from "Item 0" to "Item 9".

This PR fixes that extra `MenuItem` issue and also makes the `Overflow` and `Vertical Overflow` stories similar and simpler. Additionally, it fixes issues like missing `label` on `IconButton` and deprecated prop uses.

This PR helps in testing #2154.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that Vertical Overflow story `overflowButton` index logic is correct. Confirmed that missing `IconButton` labels now appear.

|Old|New|
|-|-|
|<img width="155" alt="image" src="https://github.com/user-attachments/assets/9c8a63c4-1a53-455e-ac9d-b6605f230805">|<img width="146" alt="image" src="https://github.com/user-attachments/assets/677c68fb-efce-4fa9-9e27-a94ed250a764">|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A since not user facing change.