### PR TITLE
Workaround for unscrollable sidenav in react-workshop

### DIFF
--- a/apps/react-workshop/.ladle/global.css
+++ b/apps/react-workshop/.ladle/global.css
@@ -28,7 +28,7 @@ main {
   transform: translateZ(0);
 }
 
-/* TODO: Remove when the sidenav scroll works out-of-the-box in newer versions of Chrome. See #2283 */
+/* TODO: Remove when the sidenav scroll is fixed in Chrome. See https://github.com/tajo/ladle/issues/574 */
 nav.ladle-aside {
   min-height: unset;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@mayank99 noticed that the sidenav is _not_ scrollable in newer versions of Chrome (e.g. 129.0, Canary 131). But it works in Edge 128.0, Firefox 130.0, and Safari 16.6.

Ladle already has an issue for this: [tajo/ladle#574](https://redirect.github.com/tajo/ladle/issues/574)

Until they investigate why it doesn't work in Chrome and until either we or Ladle do a proper fix, this PR adds custom styles to make the sidenav scrollable. This is _important_ as users using the `react-workshop` on Chrome might not be able to see all demos.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

The sidenav is now scrollable in Chrome 129.0:

|Before|After|
|-|-|
|<img width="733" alt="image" src="https://github.com/user-attachments/assets/0b789734-5b09-491c-838d-505fd270d57f">|<img width="722" alt="image" src="https://github.com/user-attachments/assets/088d5749-1528-4f1c-a147-d4befefd5879">|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A