### PR TITLE
fix `ProgressLinear` to merge `style` correctly

### DIFF
--- a/.changeset/silent-news-press.md
+++ b/.changeset/silent-news-press.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `ProgressLinear` where passing a `style` prop would cause it to lose its `value`.

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.test.tsx
@@ -77,6 +77,23 @@ it('renders ProgressLinear with 2 labels', () => {
   screen.getByText('test.dgn');
 });
 
+it('should accept custom props', () => {
+  const { container } = render(
+    <ProgressLinear
+      value={50}
+      className='custom-class'
+      style={{ color: 'var(--red)' }}
+      data-foo
+    />,
+  );
+  const progress = container.querySelector('.iui-progress-indicator-linear');
+  expect(progress).toHaveClass('custom-class');
+  expect(progress).toHaveStyle(
+    '--iui-progress-percentage: 50%;color: var(--red);',
+  );
+  expect(progress).toHaveAttribute('data-foo');
+});
+
 it('passes custom props to ProgressLinear parts', () => {
   const value = 100;
   const labels = ['Upload done!', '100%'];

--- a/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
+++ b/packages/itwinui-react/src/core/ProgressIndicators/ProgressLinear.tsx
@@ -82,12 +82,13 @@ export const ProgressLinear = React.forwardRef((props, forwardedRef) => {
       data-iui-status={status}
       data-iui-indeterminate={indeterminate ? 'true' : undefined}
       data-iui-animated={isAnimated ? 'true' : undefined}
+      {...rest}
       style={
         {
           '--iui-progress-percentage': `${boundedValue}%`,
+          ...props.style,
         } as React.CSSProperties
       }
-      {...rest}
     >
       <ShadowRoot>
         {value !== 100 && <VisuallyHidden>Loading.</VisuallyHidden>}


### PR DESCRIPTION
## Changes

Merges `style` prop with internal styles, so that `<ProgressLinear style={customStyles} value={50}>` doesn't break.

## Testing

Added unit test.

## Docs

Added `patch` changeset.