### PR TITLE
fix small issues in examples

### DIFF
--- a/examples/ButtonGroup.input.jsx
+++ b/examples/ButtonGroup.input.jsx
@@ -20,6 +20,7 @@ export default () => {
         <Input
           aria-label='URL'
           value='https://itwinui.bentley.com/docs/buttongroup'
+          readOnly
         />
         <Button styleType='high-visibility'>Copy</Button>
       </ButtonGroup>

--- a/examples/ButtonGroup.overflow.jsx
+++ b/examples/ButtonGroup.overflow.jsx
@@ -12,15 +12,11 @@ import {
 import { SvgMore, SvgPlaceholder } from '@itwin/itwinui-icons-react';
 
 export default () => {
-  const buttons = Array(12)
-    .fill(null)
-    .map((_, _index) => {
-      return (
-        <IconButton label='Placeholder'>
-          <SvgPlaceholder />
-        </IconButton>
-      );
-    });
+  const buttons = Array.from({ length: 12 }, (_, index) => (
+    <IconButton key={index} label={`Item #${index}`}>
+      <SvgPlaceholder />
+    </IconButton>
+  ));
 
   return (
     <div className='demo-container'>
@@ -28,20 +24,17 @@ export default () => {
         overflowButton={(overflowStart) => (
           <DropdownMenu
             menuItems={(close) =>
-              Array(buttons.length - overflowStart + 1)
+              Array(buttons.length - overflowStart)
                 .fill(null)
                 .map((_, _index) => {
                   const index = overflowStart + _index;
-                  const onClick = () => {
-                    close();
-                  };
                   return (
                     <MenuItem
                       key={index}
-                      onClick={onClick}
+                      onClick={close}
                       startIcon={<SvgPlaceholder />}
                     >
-                      Button #{index}
+                      Item #{index}
                     </MenuItem>
                   );
                 })

--- a/examples/Dialog.dismissible.jsx
+++ b/examples/Dialog.dismissible.jsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-// import * as ReactDOM from 'react-dom';
 import {
   Dialog,
   Button,

--- a/examples/Dialog.draggable.jsx
+++ b/examples/Dialog.draggable.jsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-// import * as ReactDOM from 'react-dom';
 import {
   Dialog,
   Button,

--- a/examples/Dialog.main.jsx
+++ b/examples/Dialog.main.jsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-// import * as ReactDOM from 'react-dom';
 import { Dialog, Button } from '@itwin/itwinui-react';
 
 export default () => {

--- a/examples/Surface.elevation.jsx
+++ b/examples/Surface.elevation.jsx
@@ -1,6 +1,5 @@
 /*---------------------------------------------------------------------------------------------
-
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';

--- a/examples/Surface.headerfooter.css
+++ b/examples/Surface.headerfooter.css
@@ -1,6 +1,0 @@
-.demo-container {
-  flex-grow: 1;
-  display: flex;
-  justify-content: space-between;
-  gap: var(--iui-size-xs);
-}

--- a/examples/Surface.headerfooter.jsx
+++ b/examples/Surface.headerfooter.jsx
@@ -3,21 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import { Surface, Text, IconButton } from '@itwin/itwinui-react';
+import { Surface, Text, IconButton, Flex } from '@itwin/itwinui-react';
 import { SvgSettings } from '@itwin/itwinui-icons-react';
 
 export default () => {
   return (
     <Surface elevation={4}>
-      <Surface.Header>
-        <div className='demo-container'>
-          <Text variant='subheading' as='h2'>
-            Custom surface
-          </Text>
-          <IconButton label='Settings' styleType='borderless'>
-            <SvgSettings />
-          </IconButton>
-        </div>
+      <Surface.Header as={Flex} justifyContent='space-between'>
+        <Text variant='subheading' as='h2'>
+          Custom surface
+        </Text>
+        <IconButton label='Settings' styleType='borderless'>
+          <SvgSettings />
+        </IconButton>
       </Surface.Header>
       <Surface.Body isPadded={true}>
         <p>


### PR DESCRIPTION
## Changes

This PR makes some very small changes to various examples:
- Fixed Surface Header example layout using `Flex` (previously was misaligned)
- Removed unused import comments in Dialog examples
- Fixed formatting for some copyright header comments
- Fixed missing keys/labels and overflow logic in ButtonGroup Overflow example (similar to #2269)
- Fixed missing `readonly` in ButtonGroup Input example

## Testing

N/A

## Docs

N/A
