### PR TITLE
Bump `@ladle/react` to `^4.1.2`

### DIFF
--- a/apps/react-workshop/.ladle/global.css
+++ b/apps/react-workshop/.ladle/global.css
@@ -27,8 +27,3 @@ main {
   position: relative;
   transform: translateZ(0);
 }
-
-/* TODO: Remove when the sidenav scroll is fixed in Chrome. See https://github.com/tajo/ladle/issues/574 */
-nav.ladle-aside {
-  min-height: unset;
-}

--- a/apps/react-workshop/package.json
+++ b/apps/react-workshop/package.json
@@ -9,7 +9,7 @@
     "@itwin/itwinui-icons-react": "2.8.0",
     "@itwin/itwinui-variables": "*",
     "@itwin/itwinui-react": "*",
-    "@ladle/react": "^4.1.1",
+    "@ladle/react": "^4.1.2",
     "@types/node": "*",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: '*'
         version: link:../../packages/itwinui-variables
       '@ladle/react':
-        specifier: ^4.1.1
-        version: 4.1.1(@swc/helpers@0.5.11)(@types/node@22.5.5)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass-embedded@1.64.1)(sass@1.72.0)(typescript@5.5.2)
+        specifier: ^4.1.2
+        version: 4.1.2(@swc/helpers@0.5.11)(@types/node@22.5.5)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass-embedded@1.64.1)(sass@1.72.0)(typescript@5.5.2)
       '@types/node':
         specifier: '*'
         version: 22.5.5
@@ -2594,10 +2594,10 @@ packages:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
 
-  '@ladle/react@4.1.1':
+  '@ladle/react@4.1.2':
     resolution:
       {
-        integrity: sha512-WSH+abvPwXMgy1PquYBcgmuV8R1WeZhaLKIfoPm4YgfmD3tgsA9MOwa+SFNkIrIHI71Q6J41sguObToof13WfQ==,
+        integrity: sha512-6nMIPCsnkGCjIRz5kpRojJyieqcFPsq34QeqJp5mFpT1xFeX7sKwdCpQJ92d5ORsejmxTyp9gkQA+AXG3i3AGw==,
       }
     engines: { node: '>=20.0.0' }
     hasBin: true
@@ -14964,7 +14964,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@ladle/react@4.1.1(@swc/helpers@0.5.11)(@types/node@22.5.5)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass-embedded@1.64.1)(sass@1.72.0)(typescript@5.5.2)':
+  '@ladle/react@4.1.2(@swc/helpers@0.5.11)(@types/node@22.5.5)(@types/react@18.2.14)(lightningcss@1.25.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass-embedded@1.64.1)(sass@1.72.0)(typescript@5.5.2)':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.25.2


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Bumped `@ladle/react` from `^4.1.1` to `^4.1.2`. This is because [4.1.2](https://redirect.github.com/tajo/ladle/releases/tag/%40ladle%2Freact%404.1.2) includes the out-of-the-box fix to the problem that #2283 tried to work around.

After this bump, the workaround from #2283 is no longer needed and thus is undone. 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

The right scroll bar still appears in Chrome 129.0.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A