### PR TITLE
Add `itwinui-icons-react` dep to `minimal-sandbox`

### DIFF
--- a/minimal-sandbox/src/App.tsx
+++ b/minimal-sandbox/src/App.tsx
@@ -1,10 +1,10 @@
+import * as React from 'react';
 import { Button } from '@itwin/itwinui-react';
-import { SvgPlaceholder } from '@itwin/itwinui-icons-react';
 
 export default function App() {
   return (
     <>
-      <Button startIcon={<SvgPlaceholder />}>Hello world</Button>
+      <Button>Hello world</Button>
     </>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Since the [recommended](https://github.com/iTwin/iTwinUI/blob/2029579ef09478925668bb5ed3d8d5e5a6d36638/.github/ISSUE_TEMPLATE/bug_report.yml?plain=1#L27) iTwinUI starter [sandbox](https://stackblitz.com/github/iTwin/iTwinUI/tree/main/minimal-sandbox) is based on the `minimal-sandbox` workspace and since `@itwin/itwinui-icons-react` package is commonly needed in sandboxes, this PR adds a dependency to `@itwin/itwinui-icons-react` to `minimal-sandbox`.

When testing in the new resulting stackblitz [sandbox](https://stackblitz.com/github/iTwin/iTwinUI/tree/r/add-icons-dep-to-sandbox/minimal-sandbox), I noticed that for some reason, the auto import for `@itwin/itwinui-icons-react` was not working unless an import was already present.

~So, I added an import and usage of it.~ Reverted those changes to keep `App.tsx` simple (https://github.com/iTwin/iTwinUI/pull/2305#discussion_r1802052891). Thus, the auto-import does not work.

<img width="275" alt="image" src="https://github.com/user-attachments/assets/4bef7dc7-8a34-44cd-ba17-93d8818fb45b">

But at least this PR saves time by not having to specify the dependency in the sandbox and then restart the sandbox.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Testing that the dependency to `@itwin/itwinui-icons-react` exists in the new resulting stackblitz [sandbox](https://stackblitz.com/github/iTwin/iTwinUI/tree/r/add-icons-dep-to-sandbox/minimal-sandbox).

<details><summary>Old testing</summary>
<p>

Tested that the auto import for `@itwin/itwinui-icons-react` works in the new resulting stackblitz [sandbox](https://stackblitz.com/github/iTwin/iTwinUI/tree/r/add-icons-dep-to-sandbox/minimal-sandbox).

<img width="355" alt="image" src="https://github.com/user-attachments/assets/366d09f7-ff00-4796-abc0-f2e894212bd9">

</p>
</details> 

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A

## After PR TODOs

- [ ] Try fixing auto-import issue in stackblitz sandbox ([#2305 (comment)](https://github.com/iTwin/iTwinUI/pull/2305#discussion_r1802072551))