### PR TITLE
Improved and fixed `NonIdealState` JSDocs

### DIFF
--- a/packages/itwinui-react/src/core/NonIdealState/NonIdealState.tsx
+++ b/packages/itwinui-react/src/core/NonIdealState/NonIdealState.tsx
@@ -9,7 +9,7 @@ import cx from 'classnames';
 
 type NonIdealStateProps = {
   /**
-   * An svg component, preferably from @itwin/itwinui-illustrations-react.
+   * An svg component, preferably from `@itwin/itwinui-illustrations-react`.
    *
    * @example
    * import { Svg404 } from '@itwin/itwinui-illustrations-react';
@@ -18,14 +18,18 @@ type NonIdealStateProps = {
   svg: React.ReactNode;
 
   /**
-   * Primary heading for the error page
+   * Primary heading for the `NonIdealState`
    */
   heading?: React.ReactNode;
 
   /**
    * Secondary text to explain the error
    * Can include html in order to provide a hyperlink
-   * E.g. `Please visit <a href="https://www.bentley.com/help">our support page</a> for help.`
+   *
+   * @example
+   * <>
+   *   Please visit <Anchor href="https://www.bentley.com/help">our support page</Anchor> for help.
+   * </>
    */
   description?: React.ReactNode;
 
@@ -34,13 +38,13 @@ type NonIdealStateProps = {
    * Typically should be a primary and secondary button.
    *
    * @example
-   * <ErrorPage
-   *  actions={
-   *   <>
-   *    <Button styleType={'high-visibility'}>Retry</Button>
-   *    <Button>Contact us</Button>
-   *   </>
-   *  }
+   * <NonIdealState
+   *   actions={
+   *     <>
+   *       <Button styleType={'high-visibility'}>Retry</Button>
+   *       <Button>Contact us</Button>
+   *     </>
+   *   }
    * />
    */
   actions?: React.ReactNode;
@@ -64,7 +68,7 @@ type NonIdealStateProps = {
 
 /**
  * A stylized display to communicate common http errors and other non-ideal states.
- * Works well with svgs from @itwin/itwinui-illustrations-react.
+ * Works well with svgs from `@itwin/itwinui-illustrations-react`.
  *
  * @example
  * <NonIdealState svg={<Svg404 />} heading='Not found' />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

A user pointed out how `NonIdealState`'s JSDocs still mentioned the deprecated `ErrorPage`. This PR fixes that and other parts of the JSDocs.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Didn't add a changeset since JSDocs updates are not public facing changes.

## After PR TODO

- [ ] Document `NonIdealState`'s `actions` prop and add it to some examples ([#2307 (review)](https://github.com/iTwin/iTwinUI/pull/2307#pullrequestreview-2376317628)).