### PR TITLE
Dialog: update `setFocus` default value

### DIFF
--- a/.changeset/fuzzy-bikes-move.md
+++ b/.changeset/fuzzy-bikes-move.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Updated the default value of `Dialog`'s `setFocus` prop to be based on the value of the `trapFocus` prop.

--- a/packages/itwinui-react/src/core/Dialog/Dialog.tsx
+++ b/packages/itwinui-react/src/core/Dialog/Dialog.tsx
@@ -25,7 +25,7 @@ type DialogProps = {
 const DialogComponent = React.forwardRef((props, ref) => {
   const {
     trapFocus = false,
-    setFocus = false,
+    setFocus = trapFocus,
     preventDocumentScroll = false,
     isOpen = false,
     isDismissible = true,

--- a/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
@@ -35,13 +35,17 @@ export type DialogContextProps = {
    */
   closeOnEsc?: boolean;
   /**
-   * Traps the focus inside the dialog. This is useful when the dialog is modal.
+   * Prevents focus from leaving the dialog. This is useful when the dialog is modal.
+   *
+   * Setting this prop to `true` will also set `setFocus` to `true`.
+   *
    * @default false
    */
   trapFocus?: boolean;
   /**
    * If true, focuses the dialog.
-   * @default false
+   *
+   * Defaults to `true` if `trapFocus` is set to `true`, otherwise defaults to `false`.
    */
   setFocus?: boolean;
   /**


### PR DESCRIPTION
## Changes

This PR changes the default value of Dialog's `setFocus` from `false` to `trapFocus`. So it still defaults to `false` in isolation, but becomes `true` when `trapFocus` is also `true`.

This was done because `trapFocus` would otherwise have no effect, which causes user confusion. See https://github.com/iTwin/iTwinUI/issues/2094#issuecomment-2432779584

## Testing

Manually verified that setting `trapFocus` also moves focus into the Dialog when `setFocus` is not explicitly set.

## Docs

Updated JSDocs for both props to clarify usage.

Added `patch` changeset. But this will go in the next minor release, which is good because this is a behavioral change that might require users to adjust their code if they were relying on the old defaults.