### PR TITLE
Configure dependabot to automatically bump deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@
 version: 2
 updates:
   - package-ecosystem: 'pnpm'
-    directory: '/'
+    directories:
+      - '/'
+      - '/apps/*'
+      - '/packages/*'
+      - '/playgrounds/*'
+      - '/internal/*'
+      - '/examples'
+      - '/testing/*'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
+      timezone: 'US/Eastern'


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

WIP

Docs I'm following:
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

WIP

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

WIP