### PR TITLE
Excluded sub-component data from selected data

### DIFF
--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -1981,6 +1981,43 @@ it('should select and filter rows', async () => {
   expect(checkboxInputs[3].checked).toBe(false);
 });
 
+it('should only select main row when subComponent is present', async () => {
+  const logSpy = vitest.spyOn(console, 'log');
+  const columns = [
+    {
+      id: 'name',
+      Header: 'Name',
+      accessor: 'name',
+    },
+    {
+      id: 'description',
+      Header: 'description',
+      accessor: 'description',
+    },
+  ];
+
+  const data = mockedData();
+
+  const { container } = renderComponent({
+    columns,
+    data,
+    isSelectable: true,
+    onSelect: (selectedRows) => console.log(selectedRows),
+  });
+
+  const checkboxCells = container.querySelectorAll('.iui-slot .iui-checkbox');
+  expect(checkboxCells.length).toBe(4);
+
+  await userEvent.click(checkboxCells[0]);
+  expect(logSpy).toHaveBeenCalledWith(data);
+
+  await userEvent.click(checkboxCells[1]);
+  expect(logSpy).toHaveBeenCalledWith([data[1], data[2]]);
+
+  await userEvent.click(checkboxCells[2]);
+  expect(logSpy).toHaveBeenCalledWith([data[2]]);
+});
+
 it('should pass custom props to row', () => {
   const onMouseEnter = vi.fn();
   let element: HTMLInputElement | null = null;

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -71,7 +71,7 @@ const singleRowSelectedAction = 'singleRowSelected';
 const shiftRowSelectedAction = 'shiftRowSelected';
 export const tableResizeStartAction = 'tableResizeStart';
 const tableResizeEndAction = 'tableResizeEnd';
-const iuiId = Symbol('iui-id');
+export const iuiId = Symbol('iui-id');
 
 export type TablePaginatorRendererProps = {
   /**

--- a/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
+++ b/packages/itwinui-react/src/core/Table/actionHandlers/selectHandler.ts
@@ -9,6 +9,7 @@ import type {
   TableState,
   IdType,
 } from '../../../react-table/react-table.js';
+import { iuiId } from '../Table.js';
 
 /**
  * Handles subrow selection and validation.
@@ -190,7 +191,10 @@ const getSelectedData = <T extends Record<string, unknown>>(
 ) => {
   const selectedData: T[] = [];
   const setSelectedData = (row: Row<T>) => {
-    if (selectedRowIds[row.id]) {
+    // Check whether the row selected is a sub-component.
+    // If so, exclude it from the selected data.
+    const isMainRow = row.original[iuiId as any] === undefined;
+    if (selectedRowIds[row.id] && isMainRow) {
       selectedData.push(row.original);
     }
     row.initialSubRows.forEach((subRow) => setSelectedData(subRow));

--- a/packages/itwinui-react/src/core/Table/columns/selectionColumn.tsx
+++ b/packages/itwinui-react/src/core/Table/columns/selectionColumn.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../../react-table/react-table.js';
 import { Checkbox } from '../../Checkbox/Checkbox.js';
 import { DefaultCell } from '../cells/index.js';
+import { iuiId } from '../Table.js';
 
 export const SELECTION_CELL_ID = 'iui-table-checkbox-selector';
 
@@ -82,7 +83,12 @@ export const SelectionColumn = <T extends Record<string, unknown>>(
         disabled={isDisabled?.(row.original)}
         onClick={(e) => e.stopPropagation()} // Prevents triggering on row click
         onChange={() => {
-          if (row.subRows.length > 0 && selectSubRows) {
+          // Only goes through sub-rows if they are available and not sub-components
+          if (
+            row.subRows.length > 0 &&
+            selectSubRows &&
+            row.subRows[0].original[iuiId as any] === undefined
+          ) {
             //This code ignores any sub-rows that are not currently available(i.e disabled or filtered out).
             //If all available sub-rows are selected, then it deselects them all, otherwise it selects them all.
             row.toggleRowSelected(


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

This PR excluded the data of sub-component from the returned selected data from the `onSelect` function as it was the same as that of the main row. The only difference between these two types of data is the `Symbol` key to mark whether the row is a sub-component or not. 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Added unit test for selecting.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Adding changeset.
