### PR TITLE
Replace `React.useLayoutEffect` with `useIsomorphicLayoutEffect`

### DIFF
--- a/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
+++ b/packages/itwinui-react/src/core/DatePicker/DatePicker.tsx
@@ -12,6 +12,7 @@ import {
   isBefore,
   Box,
   useId,
+  useLayoutEffect,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { IconButton } from '../Buttons/IconButton.js';
@@ -345,7 +346,7 @@ export const DatePicker = React.forwardRef((props, forwardedRef) => {
   const popoverInitialFocusContext = React.useContext(
     PopoverInitialFocusContext,
   );
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     // If setFocus and the DatePicker is in a Popover, tell Popover to not focus anything since we handle focus.
     if (setFocus && popoverInitialFocusContext) {
       popoverInitialFocusContext.setInitialFocus(-1);

--- a/packages/itwinui-react/src/core/Table/TablePaginator.tsx
+++ b/packages/itwinui-react/src/core/Table/TablePaginator.tsx
@@ -17,6 +17,7 @@ import {
   SvgChevronRight,
   Box,
   OverflowContainer,
+  useLayoutEffect,
 } from '../../utils/index.js';
 import type { CommonProps } from '../../utils/index.js';
 import type { TablePaginatorRendererProps } from './Table.js';
@@ -148,7 +149,7 @@ export const TablePaginator = (props: TablePaginatorProps) => {
   const pageListRef = React.useRef<HTMLDivElement | null>(null);
 
   const [focusedIndex, setFocusedIndex] = React.useState<number>(currentPage);
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     setFocusedIndex(currentPage);
   }, [currentPage]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Replaced uses of `React.useLayoutEffect` with the SSR safe `useIsomorphicLayoutEffect`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Didn't add a changeset since it didn't seem like a significant enough change. Can add one if others feel so.