### PR TITLE
Memoize `onResize` in `useResizeObserver`

### DIFF
--- a/packages/itwinui-react/src/utils/hooks/useResizeObserver.tsx
+++ b/packages/itwinui-react/src/utils/hooks/useResizeObserver.tsx
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
 import { getWindow } from '../functions/dom.js';
+import { useLatestRef } from './useLatestRef.js';
 
 /**
  * Hook that uses `ResizeObserver` to access an element's size every time it updates.
  * @private
- * @param onResize callback fired with the element's new dimensions on every resize.
+ * @param onResizeProp callback fired with the element's new dimensions on every resize.
  * @returns a callback ref that needs to be set on the element, and a ResizeObserver instance.
  *
  * @example
@@ -18,8 +19,9 @@ import { getWindow } from '../functions/dom.js';
  * return <div ref={ref}>...</div>;
  */
 export const useResizeObserver = <T extends HTMLElement>(
-  onResize: (size: DOMRectReadOnly) => void,
+  onResizeProp: (size: DOMRectReadOnly) => void,
 ) => {
+  const onResize = useLatestRef(onResizeProp);
   const resizeObserver = React.useRef<ResizeObserver>();
 
   const elementRef = React.useCallback(
@@ -40,7 +42,7 @@ export const useResizeObserver = <T extends HTMLElement>(
             }
 
             const [{ contentRect }] = entries;
-            return onResize(contentRect);
+            return onResize.current(contentRect);
           });
         });
         resizeObserver.current?.observe?.(element);


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

In https://github.com/iTwin/iTwinUI/pull/2316#discussion_r1821437397, I realized that not memoizing the `onResize` callback could lead to it being called each render. It could also be called continuously in some cases.

This PR wraps the `onResize` prop with a `useLatestRef` to prevent this issue.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

- [ ] Existing tests pass

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A