### PR TITLE
increase hit target size for small `SelectTag` button

### DIFF
--- a/packages/itwinui-css/src/select/select.scss
+++ b/packages/itwinui-css/src/select/select.scss
@@ -126,6 +126,12 @@
     svg {
       @include mixins.iui-icon-style('s');
     }
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: -5px;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

This PR adds a `::before` pseudo-element to the "❌" button of a small `SelectTag`. This pseudo-element uses a negative `inset` value to increase the hit target (clickable area) size of the button, helping satisfy [SC 2.5.8](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html). The `-5px` is a magic number, eyeballed until the size exceeded 24x24.

This is another small step towards #907.

## Testing

Manually tested on the `select.html` demo page that the hit target size has been enlarged.

![](https://github.com/user-attachments/assets/110db80b-15f5-49ef-83bf-0df3fafe6363)


## Docs

Not adding a changeset, since this is somewhat of an unreleased/WIP feature (it's not supported in React).