### PR TITLE
ensure that toaster doesn't block clicks

### DIFF
--- a/.changeset/forty-files-arrive-1.md
+++ b/.changeset/forty-files-arrive-1.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Ensured that the `useToaster` wrapper does not block clicks when used within other portal containers (e.g. from AppUI).

--- a/.changeset/forty-files-arrive.md
+++ b/.changeset/forty-files-arrive.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Ensured that `.iui-toast-wrapper` does not block clicks when used within other portal containers (e.g. from AppUI).

--- a/packages/itwinui-css/src/toast/toast.scss
+++ b/packages/itwinui-css/src/toast/toast.scss
@@ -42,7 +42,7 @@
 // ----------------------------------------------------------------------------
 
 .iui-toast-wrapper {
-  pointer-events: none;
+  pointer-events: none !important; // Ensuring that toast-wrapper doesn't block clicks
   position: fixed;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Changes

This PR adds `!important` to `pointer-events: none` to ensure that it can't be overridden by consumers. This is a justified use of `!important` since we know it should never be overridden.

This is mainly needed to work around https://github.com/iTwin/appui/issues/1076. AppUI will investigate a proper fix in their next **minor**, but this should help in the meantime.

## Testing

N/A. This doesn't change anything within iTwinUI in isolation.

Do see https://github.com/iTwin/iTwinUI/pull/2323#issuecomment-2454916449

## Docs

Added `patch` changesets.