### PR TITLE
`Tree` respects `size` prop regardless of virtualization

### DIFF
--- a/.changeset/few-apples-jog.md
+++ b/.changeset/few-apples-jog.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a `Tree` bug where the `size` prop was not respected when virtualization was enabled.

--- a/packages/itwinui-react/src/core/Tree/Tree.test.tsx
+++ b/packages/itwinui-react/src/core/Tree/Tree.test.tsx
@@ -348,8 +348,13 @@ it('should set correct computed aria attributes to nodes', () => {
   expect(node3_1.getAttribute('aria-posinset')).toBe('1');
 });
 
-it('should respect size prop', () => {
-  const { container } = renderComponent({ props: { size: 'small' } });
-  const tree = container.querySelector('.iui-tree') as HTMLElement;
-  expect(tree).toHaveAttribute('data-iui-size', 'small');
-});
+it.each([true, false])(
+  'should respect size prop (enableVirtualization=%s)',
+  (enableVirtualization) => {
+    const { container } = renderComponent({
+      props: { size: 'small', enableVirtualization },
+    });
+    const tree = container.querySelector('.iui-tree') as HTMLElement;
+    expect(tree).toHaveAttribute('data-iui-size', 'small');
+  },
+);

--- a/packages/itwinui-react/src/core/Tree/Tree.tsx
+++ b/packages/itwinui-react/src/core/Tree/Tree.tsx
@@ -353,6 +353,7 @@ export const Tree = <T,>(props: TreeProps<T>) => {
           onKeyDown={handleKeyDown}
           ref={treeRef}
           className={className}
+          data-iui-size={size === 'small' ? 'small' : undefined}
           style={style}
           {...rest}
         />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes #2325 by adding the missing `data-iui-size` data attribute to the `<TreeElement>` in the conditional branch where `enableVirtualization={true}`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

* Edited the unit test to confirm that the `size` prop is respected regardless of virtualization.
* Confirmed the the bug is fixed in the user's playground.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changeset