### PR TITLE
Fix range `DatePicker` docs examples

### DIFF
--- a/examples/DatePicker.daterange.jsx
+++ b/examples/DatePicker.daterange.jsx
@@ -19,9 +19,6 @@ export default () => {
           enableRangeSelect={true}
           startDate={startDate}
           endDate={endDate}
-          onChange={() => {
-            setVisible(false);
-          }}
           setFocus
           showDatesOutsideMonth={false}
         />

--- a/examples/DatePicker.datesdisabled.jsx
+++ b/examples/DatePicker.datesdisabled.jsx
@@ -30,9 +30,6 @@ export default () => {
           startDate={startDate}
           endDate={endDate}
           isDateDisabled={isDateDisabled}
-          onChange={() => {
-            setVisible(false);
-          }}
           setFocus
           showDatesOutsideMonth={false}
         />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Earlier, range `DatePicker`s in the docs examples were closing when a date was chosen. This small PR fixes those examples.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Tested that the range `DatePicker` examples no longer close when a date is chosen.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/66cddf49-3f3a-4275-a30e-3e8922b35c5f"/>|<video src="https://github.com/user-attachments/assets/8f5091ff-f13d-468a-993f-b42ec4ea4e1f" />|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A