### PR TITLE
MiddleTextTruncation: preserve original text in accessibility tree

### DIFF
--- a/.changeset/short-papayas-hunt.md
+++ b/.changeset/short-papayas-hunt.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Improved the accessibility of `MiddleTextTruncation` so that the entire untruncated text is part of the accessibility tree.

--- a/apps/react-workshop/src/Select.stories.tsx
+++ b/apps/react-workshop/src/Select.stories.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import React, { useCallback } from 'react';
+import * as React from 'react';
 import { MenuItem, Select, MiddleTextTruncation } from '@itwin/itwinui-react';
 import {
   SvgSmileyHappy,
@@ -184,15 +184,6 @@ export const TruncateMiddleText = () => {
     options[0].value,
   );
 
-  const textRenderer = useCallback(
-    (truncatedText: string, originalText: string) => (
-      <span title={truncatedText !== originalText ? originalText : undefined}>
-        {truncatedText}
-      </span>
-    ),
-    [],
-  );
-
   return (
     <Select
       options={options}
@@ -201,14 +192,11 @@ export const TruncateMiddleText = () => {
       placeholder='Placeholder text'
       itemRenderer={(option) => (
         <MenuItem>
-          <MiddleTextTruncation
-            text={option.label}
-            textRenderer={textRenderer}
-          />
+          <MiddleTextTruncation text={option.label} />
         </MenuItem>
       )}
       selectedItemRenderer={(option) => (
-        <MiddleTextTruncation text={option.label} textRenderer={textRenderer} />
+        <MiddleTextTruncation text={option.label} />
       )}
     />
   );

--- a/examples/Select.truncate.jsx
+++ b/examples/Select.truncate.jsx
@@ -8,7 +8,6 @@ import {
   MiddleTextTruncation,
   LabeledSelect,
 } from '@itwin/itwinui-react';
-import { useCallback, useState } from 'react';
 
 export default () => {
   const options = [
@@ -27,7 +26,7 @@ export default () => {
       label: 'SomeOtherFile.dgn',
     },
   ];
-  const [selectedValue, setSelectedValue] = useState(options[0].value);
+  const [selectedValue, setSelectedValue] = React.useState(options[0].value);
 
   return (
     <LabeledSelect

--- a/examples/Select.truncate.jsx
+++ b/examples/Select.truncate.jsx
@@ -28,14 +28,7 @@ export default () => {
     },
   ];
   const [selectedValue, setSelectedValue] = useState(options[0].value);
-  const textRenderer = useCallback(
-    (truncatedText, originalText) => (
-      <span title={truncatedText !== originalText ? originalText : undefined}>
-        {truncatedText}
-      </span>
-    ),
-    [],
-  );
+
   return (
     <LabeledSelect
       label={'Choose file'}
@@ -45,14 +38,11 @@ export default () => {
       placeholder={'Placeholder text'}
       itemRenderer={(option) => (
         <MenuItem>
-          <MiddleTextTruncation
-            text={option.label}
-            textRenderer={textRenderer}
-          />
+          <MiddleTextTruncation text={option.label} />
         </MenuItem>
       )}
       selectedItemRenderer={(option) => (
-        <MiddleTextTruncation text={option.label} textRenderer={textRenderer} />
+        <MiddleTextTruncation text={option.label} />
       )}
     />
   );

--- a/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
+++ b/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
@@ -5,6 +5,8 @@
 import * as React from 'react';
 import type { PolymorphicForwardRefComponent } from '../props.js';
 import { OverflowContainer } from './OverflowContainer.js';
+import { VisuallyHidden } from '../../core/VisuallyHidden/VisuallyHidden.js';
+import { ShadowRoot } from './ShadowRoot.js';
 
 const ELLIPSIS_CHAR = '…';
 
@@ -60,6 +62,10 @@ export const MiddleTextTruncation = React.forwardRef((props, forwardedRef) => {
       {...rest}
       ref={forwardedRef}
     >
+      <ShadowRoot>
+        <VisuallyHidden>{text}</VisuallyHidden>
+        <slot aria-hidden />
+      </ShadowRoot>
       <MiddleTextTruncationContent
         text={text}
         endCharsCount={endCharsCount}

--- a/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
+++ b/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
@@ -3,12 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import type { CommonProps } from '../props.js';
+import type { PolymorphicForwardRefComponent } from '../props.js';
 import { OverflowContainer } from './OverflowContainer.js';
 
 const ELLIPSIS_CHAR = '…';
 
-export type MiddleTextTruncationProps = {
+type MiddleTextTruncationProps = {
   /**
    * Text to truncate.
    */
@@ -25,7 +25,7 @@ export type MiddleTextTruncationProps = {
     truncatedText: string,
     originalText: string,
   ) => React.ReactNode;
-} & CommonProps;
+};
 
 /**
  * Truncates text with the ellipsis in the middle,
@@ -43,8 +43,8 @@ export type MiddleTextTruncationProps = {
  *   )}
  * />
  */
-export const MiddleTextTruncation = (props: MiddleTextTruncationProps) => {
-  const { text, style, ...rest } = props;
+export const MiddleTextTruncation = React.forwardRef((props, forwardedRef) => {
+  const { text, endCharsCount, textRenderer, style, ...rest } = props;
 
   return (
     <OverflowContainer
@@ -58,11 +58,16 @@ export const MiddleTextTruncation = (props: MiddleTextTruncationProps) => {
       }}
       itemsCount={text.length}
       {...rest}
+      ref={forwardedRef}
     >
-      <MiddleTextTruncationContent {...props} />
+      <MiddleTextTruncationContent
+        text={text}
+        endCharsCount={endCharsCount}
+        textRenderer={textRenderer}
+      />
     </OverflowContainer>
   );
-};
+}) as PolymorphicForwardRefComponent<'span', MiddleTextTruncationProps>;
 if (process.env.NODE_ENV === 'development') {
   MiddleTextTruncation.displayName = 'MiddleTextTruncation';
 }
@@ -79,9 +84,9 @@ const MiddleTextTruncationContent = (props: MiddleTextTruncationProps) => {
         0,
         visibleCount - endCharsCount - ELLIPSIS_CHAR.length,
       )}${ELLIPSIS_CHAR}${text.substring(text.length - endCharsCount)}`;
-    } else {
-      return text;
     }
+
+    return text;
   }, [endCharsCount, text, visibleCount]);
 
   return textRenderer?.(truncatedText, text) ?? truncatedText;

--- a/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
+++ b/packages/itwinui-react/src/utils/components/MiddleTextTruncation.tsx
@@ -64,7 +64,12 @@ export const MiddleTextTruncation = React.forwardRef((props, forwardedRef) => {
     >
       <ShadowRoot>
         <VisuallyHidden>{text}</VisuallyHidden>
-        <slot aria-hidden />
+        <slot
+          aria-hidden
+          style={{
+            pointerEvents: 'none', // Shadow-tree should not affect handling of clicks
+          }}
+        />
       </ShadowRoot>
       <MiddleTextTruncationContent
         text={text}


### PR DESCRIPTION
## Changes

This PR improves the accessibility of the `MiddleTextTruncation` component. This component is meant for visual truncation and should not affect the accessibility tree because it would make the text confusing and nonsensical. While truncation in general should be avoided for even better accessibility, this is at least better than before.

The behavior of `MiddleTextTruncation` is now consistent with the browser's built-in `text-overflow: ellipsis` mechanism, so the same set of UX guidelines could be applied in both cases to tackle the truncation problem. Right now, there is no such UX pattern documented in the design system, but it's becoming clear that there needs to be one.

It might be easier to review the first three commits separately:
1. [`27d4deb`](https://github.com/iTwin/iTwinUI/pull/2339/commits/27d4deb34d3bd1ef6ebb4af659310183842888ef): Code reorganization only; no outward behavior changes.
2. [`399ed24`](https://github.com/iTwin/iTwinUI/pull/2339/commits/399ed24b32b4a165b0dbb50352b683c9bf24d474): This is the most interesting part. Uses shadow DOM to inject the untruncated text while keeping it visually hidden. The truncated text is removed from the accessibility tree using `aria-hidden`.
    - [`75b8148`](https://github.com/iTwin/iTwinUI/pull/2339/commits/75b8148b43c3167295cbda8acfd7ff9a0ed2e212): I needed to add `pointer-events: none`, because otherwise the shadow-tree was blocking clicks (problematic when `<MiddleTextTruncation>` is used inside an interactive element).
3. [`301885b`](https://github.com/iTwin/iTwinUI/pull/2339/commits/301885b1ab936dff752d9aeb0e505924da64f917): Removes `title` attribute from stories and examples. `title` is not a cure for bad design and should not be shown in any code examples.

## Testing

Updated e2e tests and added a new one to verify the new behavior.

Manually tested that the full text is part of the accessibility tree.

Before:

![Accessible name for combobox is MyFileWithAReallyLongName…2.html](https://github.com/user-attachments/assets/8868c040-1163-40c6-9af0-1c8c02376de5)

After:

![Accessible name for combobox is "MyFileWithAReallyLongNameThatWillBeTruncatedBecauseItIsReallyThatLongSoHardToBelieve_FinalVersion_V2.html"](https://github.com/user-attachments/assets/642ba897-666f-4718-a189-abf8989be073)

**Note**: With this change, the information in the accessibility tree can become very verbose, which could be potentially annoying for screen-reader users. But I think this is the safer default (and consistent with default overflow behavior), because otherwise there would be no way for the user to access the full text. "verbosity vs content loss" is a topic I would expect to be covered by any truncation UX pattern.

## Docs

Added `patch` changeset.

I also think we should mention this behavior on the documentation page (#2329).