### PR TITLE
Prevented propagation when `DropdownMenu` is present in `Table`

### DIFF
--- a/apps/react-workshop/src/Table.stories.tsx
+++ b/apps/react-workshop/src/Table.stories.tsx
@@ -1280,7 +1280,10 @@ export const Full = () => {
       {
         ...ActionColumn({ columnManager: true }),
         Cell: () => (
-          <DropdownMenu menuItems={menuItems}>
+          <DropdownMenu
+            menuItems={menuItems}
+            onClick={(e) => e.stopPropagation()}
+          >
             <IconButton
               styleType='borderless'
               onClick={(e) => e.stopPropagation()}
@@ -1485,7 +1488,10 @@ export const Full2 = () => {
       {
         ...ActionColumn({ columnManager: true }),
         Cell: (props: CellProps<TableStoryDataType>) => (
-          <DropdownMenu menuItems={menuItems}>
+          <DropdownMenu
+            menuItems={menuItems}
+            onClick={(e) => e.stopPropagation()}
+          >
             <IconButton
               styleType='borderless'
               onClick={(e) => e.stopPropagation()}
@@ -3321,7 +3327,10 @@ export const StickyColumns = () => {
       {
         ...ActionColumn({ columnManager: true }),
         Cell: () => (
-          <DropdownMenu menuItems={menuItems}>
+          <DropdownMenu
+            menuItems={menuItems}
+            onClick={(e) => e.stopPropagation()}
+          >
             <IconButton
               styleType='borderless'
               onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

According to @r100-stack's [comment](https://github.com/iTwin/iTwinUI/pull/2337#discussion_r1841007999) in #2337, `DropdownMenu` might propagate up to the main row which toggles row selection state. Currently, the proposed solution in this PR is to temporarily prevent propagation in the `Table` stories by using `e.stopPropagation()` in the `onClick` event handlers. This approach is a temporary measure until a more permanent solution can be implemented within the internal component code.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that clicking row action items (such as "Edit" or "Delete") does not trigger single row selection.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/5cb8b5ad-e493-4462-b7be-d960f6d9286e" />|<video src="https://github.com/user-attachments/assets/57fccfb2-5260-4a99-ac3e-153eea35ff80" />|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
