### PR TITLE
Disabled `InputWithDecorations.Input` gets `cursor: not-allowed`

### DIFF
--- a/.changeset/red-singers-juggle.md
+++ b/.changeset/red-singers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+`input` and `textarea` inside `.iui-input-flex-container` now properly get `cursor: not-allowed` when disabled.

--- a/.changeset/shiny-glasses-look.md
+++ b/.changeset/shiny-glasses-look.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`InputWithDecorations.Input` now properly gets `cursor: not-allowed` when disabled.

--- a/packages/itwinui-css/src/input-container/input-container.scss
+++ b/packages/itwinui-css/src/input-container/input-container.scss
@@ -196,6 +196,7 @@
 
     &:disabled {
       color: var(--iui-color-text-disabled);
+      cursor: not-allowed;
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes #2313.

This PR does a quick fix by applying `cursor: not-allowed` to `input` and `textarea` inside `.iui-input-flex-container` when the `input`/`textarea` is disabled.

A better solution (e.g. abstraction of common code) can come later.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the `not-allowed` cursor comes up in the user's sandbox code.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changesets.