### PR TITLE
Bump `cross-spawn` to fix audit

### DIFF
--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -113,7 +113,7 @@
     "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
-    "@swc/cli": "^0.3.12",
+    "@swc/cli": "^0.5.1",
     "@swc/core": "^1.5.28",
     "@testing-library/jest-dom": "^6.3.0",
     "@testing-library/react": "^13.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@swc/cli':
-        specifier: ^0.3.12
-        version: 0.3.12(@swc/core@1.5.28(@swc/helpers@0.5.11))(chokidar@3.6.0)
+        specifier: ^0.5.1
+        version: 0.5.1(@swc/core@1.5.28(@swc/helpers@0.5.11))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.5.28
         version: 1.5.28(@swc/helpers@0.5.11)
@@ -2777,13 +2777,6 @@ packages:
         integrity: sha512-+z1c7HpC5ysdSVVyUVz67hctVLl337VlRJP/MBwpvXHkKJdlnSUVrBhlRzxgal7xpm1uDE2JeUhWbQh6wPRC4w==,
       }
 
-  '@mole-inc/bin-wrapper@8.0.1':
-    resolution:
-      {
-        integrity: sha512-sTGoeZnjI8N4KS+sW2AN95gDBErhAguvkw/tWdCjeM8bvxpz5lqrnd0vOJABA1A+Ic3zED7PYoLP/RANLgVotA==,
-      }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
   '@mswjs/interceptors@0.35.8':
     resolution:
       {
@@ -3433,6 +3426,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution:
+      {
+        integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==,
+      }
+
   '@shikijs/core@1.18.0':
     resolution:
       {
@@ -3499,12 +3498,12 @@ packages:
         integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==,
       }
 
-  '@sindresorhus/is@4.6.0':
+  '@sindresorhus/is@5.6.0':
     resolution:
       {
-        integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==,
+        integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==,
       }
-    engines: { node: '>=10' }
+    engines: { node: '>=14.16' }
 
   '@sindresorhus/merge-streams@2.3.0':
     resolution:
@@ -3513,10 +3512,10 @@ packages:
       }
     engines: { node: '>=18' }
 
-  '@swc/cli@0.3.12':
+  '@swc/cli@0.5.1':
     resolution:
       {
-        integrity: sha512-h7bvxT+4+UDrLWJLFHt6V+vNAcUNii2G4aGSSotKz1ECEk4MyEh5CWxmeSscwuz5K3i+4DWTgm4+4EyMCQKn+g==,
+        integrity: sha512-sxSXyjqFImYrqjhZSPymjmM/9V6auZG67UsDwbe7FZaBlyfW8ka3QG/zRjpJJ9+8Ahns/kKb8bXPKQq7V2MtBw==,
       }
     engines: { node: '>= 16.14.0' }
     hasBin: true
@@ -3653,12 +3652,12 @@ packages:
         integrity: sha512-RNFA3+7OJFNYY78x0FYwi1Ow+iF1eF5WvmfY1nXPOEH4R2p/D4Cr1vzje7dNAI2aLFqpv8Wyz4oKSWqIZArpQA==,
       }
 
-  '@szmarczak/http-timer@4.0.6':
+  '@szmarczak/http-timer@5.0.1':
     resolution:
       {
-        integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==,
+        integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==,
       }
-    engines: { node: '>=10' }
+    engines: { node: '>=14.16' }
 
   '@tanstack/react-virtual@3.8.2':
     resolution:
@@ -3788,12 +3787,6 @@ packages:
         integrity: sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==,
       }
 
-  '@types/cacheable-request@6.0.3':
-    resolution:
-      {
-        integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==,
-      }
-
   '@types/cookie@0.6.0':
     resolution:
       {
@@ -3830,10 +3823,10 @@ packages:
         integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
       }
 
-  '@types/http-cache-semantics@4.0.1':
+  '@types/http-cache-semantics@4.0.4':
     resolution:
       {
-        integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==,
+        integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==,
       }
 
   '@types/istanbul-lib-coverage@2.0.4':
@@ -3852,12 +3845,6 @@ packages:
     resolution:
       {
         integrity: sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==,
-      }
-
-  '@types/keyv@3.1.4':
-    resolution:
-      {
-        integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==,
       }
 
   '@types/mdast@3.0.15':
@@ -3966,12 +3953,6 @@ packages:
     resolution:
       {
         integrity: sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==,
-      }
-
-  '@types/responselike@1.0.0':
-    resolution:
-      {
-        integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==,
       }
 
   '@types/sax@1.2.7':
@@ -4213,6 +4194,76 @@ packages:
         integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==,
       }
 
+  '@xhmikosr/archive-type@7.0.0':
+    resolution:
+      {
+        integrity: sha512-sIm84ZneCOJuiy3PpWR5bxkx3HaNt1pqaN+vncUBZIlPZCq8ASZH+hBVdu5H8znR7qYC6sKwx+ie2Q7qztJTxA==,
+      }
+    engines: { node: ^14.14.0 || >=16.0.0 }
+
+  '@xhmikosr/bin-check@7.0.3':
+    resolution:
+      {
+        integrity: sha512-4UnCLCs8DB+itHJVkqFp9Zjg+w/205/J2j2wNBsCEAm/BuBmtua2hhUOdAMQE47b1c7P9Xmddj0p+X1XVsfHsA==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/bin-wrapper@13.0.5':
+    resolution:
+      {
+        integrity: sha512-DT2SAuHDeOw0G5bs7wZbQTbf4hd8pJ14tO0i4cWhRkIJfgRdKmMfkDilpaJ8uZyPA0NVRwasCNAmMJcWA67osw==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/decompress-tar@8.0.1':
+    resolution:
+      {
+        integrity: sha512-dpEgs0cQKJ2xpIaGSO0hrzz3Kt8TQHYdizHsgDtLorWajuHJqxzot9Hbi0huRxJuAGG2qiHSQkwyvHHQtlE+fg==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/decompress-tarbz2@8.0.1':
+    resolution:
+      {
+        integrity: sha512-OF+6DysDZP5YTDO8uHuGG6fMGZjc+HszFPBkVltjoje2Cf60hjBg/YP5OQndW1hfwVWOdP7f3CnJiPZHJUTtEg==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/decompress-targz@8.0.1':
+    resolution:
+      {
+        integrity: sha512-mvy5AIDIZjQ2IagMI/wvauEiSNHhu/g65qpdM4EVoYHUJBAmkQWqcPJa8Xzi1aKVTmOA5xLJeDk7dqSjlHq8Mg==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/decompress-unzip@7.0.0':
+    resolution:
+      {
+        integrity: sha512-GQMpzIpWTsNr6UZbISawsGI0hJ4KA/mz5nFq+cEoPs12UybAqZWKbyIaZZyLbJebKl5FkLpsGBkrplJdjvUoSQ==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/decompress@10.0.1':
+    resolution:
+      {
+        integrity: sha512-6uHnEEt5jv9ro0CDzqWlFgPycdE+H+kbJnwyxgZregIMLQ7unQSCNVsYG255FoqU8cP46DyggI7F7LohzEl8Ag==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/downloader@15.0.1':
+    resolution:
+      {
+        integrity: sha512-fiuFHf3Dt6pkX8HQrVBsK0uXtkgkVlhrZEh8b7VgoDqFf+zrgFBPyrwCqE/3nDwn3hLeNz+BsrS7q3mu13Lp1g==,
+      }
+    engines: { node: '>=18' }
+
+  '@xhmikosr/os-filter-obj@3.0.0':
+    resolution:
+      {
+        integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==,
+      }
+    engines: { node: ^14.14.0 || >=16.0.0 }
+
   '@zxing/text-encoding@0.9.0':
     resolution:
       {
@@ -4368,6 +4419,12 @@ packages:
     resolution:
       {
         integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==,
+      }
+
+  arch@3.0.0:
+    resolution:
+      {
+        integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==,
       }
 
   arg@4.1.3:
@@ -4607,6 +4664,12 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
+  b4a@1.6.7:
+    resolution:
+      {
+        integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==,
+      }
+
   backstopjs@6.2.2:
     resolution:
       {
@@ -4630,6 +4693,12 @@ packages:
     resolution:
       {
         integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==,
+      }
+
+  bare-events@2.5.0:
+    resolution:
+      {
+        integrity: sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==,
       }
 
   base-64@1.0.0:
@@ -4668,13 +4737,6 @@ packages:
       {
         integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==,
       }
-
-  bin-check@4.1.0:
-    resolution:
-      {
-        integrity: sha512-b6weQyEUKsDGFlACWSIOfveEnImkJyK/FGW6FAG42loyoquvjdtOIqO6yBFzHyqyVVhNgNkQxxx09SFLK28YnA==,
-      }
-    engines: { node: '>=4' }
 
   bin-version-check@5.1.0:
     resolution:
@@ -4888,19 +4950,19 @@ packages:
       }
     engines: { node: '>= 6.0.0' }
 
-  cacheable-lookup@5.0.4:
+  cacheable-lookup@7.0.0:
     resolution:
       {
-        integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==,
+        integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==,
       }
-    engines: { node: '>=10.6.0' }
+    engines: { node: '>=14.16' }
 
-  cacheable-request@7.0.4:
+  cacheable-request@10.2.14:
     resolution:
       {
-        integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==,
+        integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==,
       }
-    engines: { node: '>=8' }
+    engines: { node: '>=14.16' }
 
   cachedir@2.3.0:
     resolution:
@@ -5198,12 +5260,6 @@ packages:
       }
     engines: { node: '>=12' }
 
-  clone-response@1.0.3:
-    resolution:
-      {
-        integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==,
-      }
-
   clone@1.0.4:
     resolution:
       {
@@ -5440,23 +5496,17 @@ packages:
         integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==,
       }
 
-  cross-spawn@5.1.0:
+  cross-spawn@6.0.6:
     resolution:
       {
-        integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==,
-      }
-
-  cross-spawn@6.0.5:
-    resolution:
-      {
-        integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==,
+        integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==,
       }
     engines: { node: '>=4.8' }
 
-  cross-spawn@7.0.3:
+  cross-spawn@7.0.6:
     resolution:
       {
-        integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==,
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
       }
     engines: { node: '>= 8' }
 
@@ -5786,6 +5836,13 @@ packages:
       {
         integrity: sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==,
       }
+
+  defaults@3.0.0:
+    resolution:
+      {
+        integrity: sha512-RsqXDEAALjfRTro+IFNKpcPCt0/Cy2FqHSIlnomiJp9YGadpQnrtbRpSgN2+np21qHcIKiva4fiOQGjS9/qR/A==,
+      }
+    engines: { node: '>=18' }
 
   defer-to-connect@2.0.1:
     resolution:
@@ -6481,13 +6538,6 @@ packages:
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
 
-  execa@0.7.0:
-    resolution:
-      {
-        integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==,
-      }
-    engines: { node: '>=4' }
-
   execa@4.1.0:
     resolution:
       {
@@ -6591,6 +6641,12 @@ packages:
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
       }
 
+  fast-fifo@1.3.2:
+    resolution:
+      {
+        integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==,
+      }
+
   fast-glob@3.3.2:
     resolution:
       {
@@ -6656,12 +6712,12 @@ packages:
       }
     engines: { node: '>=12.0.0' }
 
-  file-type@17.1.6:
+  file-type@19.6.0:
     resolution:
       {
-        integrity: sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==,
+        integrity: sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==,
       }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    engines: { node: '>=18' }
 
   filename-reserved-regex@3.0.0:
     resolution:
@@ -6670,12 +6726,12 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
-  filenamify@5.1.1:
+  filenamify@6.0.0:
     resolution:
       {
-        integrity: sha512-M45CbrJLGACfrPOkrTp3j2EcO9OBkKUYME0eiqOCa7i2poaklU0jhlIaMlr8ijLorT0uLAzrn3qXOp5684CkfA==,
+        integrity: sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==,
       }
-    engines: { node: '>=12.20' }
+    engines: { node: '>=16' }
 
   fill-range@7.1.1:
     resolution:
@@ -6784,6 +6840,13 @@ packages:
       {
         integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==,
       }
+
+  form-data-encoder@2.1.4:
+    resolution:
+      {
+        integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==,
+      }
+    engines: { node: '>= 14.17' }
 
   form-data@2.3.3:
     resolution:
@@ -6955,13 +7018,6 @@ packages:
       }
     engines: { node: '>=16' }
 
-  get-stream@3.0.0:
-    resolution:
-      {
-        integrity: sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==,
-      }
-    engines: { node: '>=4' }
-
   get-stream@5.2.0:
     resolution:
       {
@@ -6982,6 +7038,13 @@ packages:
         integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==,
       }
     engines: { node: '>=16' }
+
+  get-stream@9.0.1:
+    resolution:
+      {
+        integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==,
+      }
+    engines: { node: '>=18' }
 
   get-symbol-description@1.0.2:
     resolution:
@@ -7104,12 +7167,12 @@ packages:
         integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==,
       }
 
-  got@11.8.6:
+  got@13.0.0:
     resolution:
       {
-        integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==,
+        integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==,
       }
-    engines: { node: '>=10.19.0' }
+    engines: { node: '>=16' }
 
   graceful-fs@4.2.11:
     resolution:
@@ -7487,10 +7550,10 @@ packages:
       }
     engines: { node: '>=0.10' }
 
-  http2-wrapper@1.0.3:
+  http2-wrapper@2.2.1:
     resolution:
       {
-        integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==,
+        integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==,
       }
     engines: { node: '>=10.19.0' }
 
@@ -7662,6 +7725,12 @@ packages:
     resolution:
       {
         integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==,
+      }
+
+  inspect-with-kind@1.0.5:
+    resolution:
+      {
+        integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==,
       }
 
   internal-slot@1.0.7:
@@ -8008,13 +8077,6 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  is-stream@1.1.0:
-    resolution:
-      {
-        integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==,
-      }
-    engines: { node: '>=0.10.0' }
-
   is-stream@2.0.1:
     resolution:
       {
@@ -8028,6 +8090,13 @@ packages:
         integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  is-stream@4.0.1:
+    resolution:
+      {
+        integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==,
+      }
+    engines: { node: '>=18' }
 
   is-string@1.0.7:
     resolution:
@@ -8765,12 +8834,12 @@ packages:
         integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==,
       }
 
-  lowercase-keys@2.0.0:
+  lowercase-keys@3.0.0:
     resolution:
       {
-        integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==,
+        integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==,
       }
-    engines: { node: '>=8' }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   lru-cache@10.2.0:
     resolution:
@@ -8778,12 +8847,6 @@ packages:
         integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==,
       }
     engines: { node: 14 || >=16.14 }
-
-  lru-cache@4.1.5:
-    resolution:
-      {
-        integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==,
-      }
 
   lru-cache@5.1.1:
     resolution:
@@ -9539,19 +9602,19 @@ packages:
       }
     engines: { node: '>=18' }
 
-  mimic-response@1.0.1:
-    resolution:
-      {
-        integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==,
-      }
-    engines: { node: '>=4' }
-
   mimic-response@3.1.0:
     resolution:
       {
         integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
       }
     engines: { node: '>=10' }
+
+  mimic-response@4.0.0:
+    resolution:
+      {
+        integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   min-indent@1.0.1:
     resolution:
@@ -9900,12 +9963,12 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
-  normalize-url@6.1.0:
+  normalize-url@8.0.1:
     resolution:
       {
-        integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==,
+        integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==,
       }
-    engines: { node: '>=10' }
+    engines: { node: '>=14.16' }
 
   not@0.1.0:
     resolution:
@@ -9948,13 +10011,6 @@ packages:
       }
     engines: { node: '>= 4' }
     hasBin: true
-
-  npm-run-path@2.0.2:
-    resolution:
-      {
-        integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==,
-      }
-    engines: { node: '>=4' }
 
   npm-run-path@4.0.1:
     resolution:
@@ -10145,13 +10201,6 @@ packages:
       }
     engines: { node: '>=18' }
 
-  os-filter-obj@2.0.0:
-    resolution:
-      {
-        integrity: sha512-uksVLsqG3pVdzzPvmAHpBK0wKxYItuzZr7SziusRPoz67tGV8rL1szZ6IdeUrbqLjGDwApBtN29eEE3IqGHOjg==,
-      }
-    engines: { node: '>=4' }
-
   os@0.1.2:
     resolution:
       {
@@ -10176,19 +10225,12 @@ packages:
         integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==,
       }
 
-  p-cancelable@2.1.1:
+  p-cancelable@3.0.0:
     resolution:
       {
-        integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==,
+        integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==,
       }
-    engines: { node: '>=8' }
-
-  p-finally@1.0.0:
-    resolution:
-      {
-        integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==,
-      }
-    engines: { node: '>=4' }
+    engines: { node: '>=12.20' }
 
   p-limit@2.3.0:
     resolution:
@@ -10444,10 +10486,10 @@ packages:
         integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==,
       }
 
-  peek-readable@5.0.0:
+  peek-readable@5.3.1:
     resolution:
       {
-        integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==,
+        integrity: sha512-GVlENSDW6KHaXcd9zkZltB7tCLosKB/4Hg0fqBJkAoBgYG2Tn1xtMgXtSUuMU9AK/gCm/tTdT8mgAeF4YNeeqw==,
       }
     engines: { node: '>=14.16' }
 
@@ -11121,12 +11163,6 @@ packages:
         integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==,
       }
 
-  pseudomap@1.0.2:
-    resolution:
-      {
-        integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==,
-      }
-
   psl@1.8.0:
     resolution:
       {
@@ -11209,6 +11245,12 @@ packages:
     resolution:
       {
         integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
+
+  queue-tick@1.0.1:
+    resolution:
+      {
+        integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==,
       }
 
   quick-lru@5.1.1:
@@ -11374,13 +11416,6 @@ packages:
         integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==,
       }
     engines: { node: '>= 6' }
-
-  readable-web-to-node-stream@3.0.2:
-    resolution:
-      {
-        integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==,
-      }
-    engines: { node: '>=8' }
 
   readdirp@3.6.0:
     resolution:
@@ -11643,11 +11678,12 @@ packages:
       }
     hasBin: true
 
-  responselike@2.0.1:
+  responselike@3.0.0:
     resolution:
       {
-        integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==,
+        integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==,
       }
+    engines: { node: '>=14.16' }
 
   restore-cursor@3.1.0:
     resolution:
@@ -11965,6 +12001,13 @@ packages:
         integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==,
       }
     engines: { node: '>=4' }
+
+  seek-bzip@2.0.0:
+    resolution:
+      {
+        integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==,
+      }
+    hasBin: true
 
   semver-regex@4.0.5:
     resolution:
@@ -12338,6 +12381,12 @@ packages:
       }
     engines: { node: '>=10.0.0' }
 
+  streamx@2.20.2:
+    resolution:
+      {
+        integrity: sha512-aDGDLU+j9tJcUdPGOaHmVF1u/hhI+CsGkT02V3OKlHDV7IukOI+nTWAGkiZEKCO35rWN1wIr4tS7YFr1f4qSvA==,
+      }
+
   strict-event-emitter@0.5.1:
     resolution:
       {
@@ -12456,12 +12505,11 @@ packages:
       }
     engines: { node: '>=4' }
 
-  strip-eof@1.0.0:
+  strip-dirs@3.0.0:
     resolution:
       {
-        integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==,
+        integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==,
       }
-    engines: { node: '>=0.10.0' }
 
   strip-final-newline@2.0.0:
     resolution:
@@ -12504,19 +12552,12 @@ packages:
         integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==,
       }
 
-  strip-outer@2.0.0:
+  strtok3@9.0.1:
     resolution:
       {
-        integrity: sha512-A21Xsm1XzUkK0qK1ZrytDUvqsQWict2Cykhvi0fBQntGG5JSprESasEyV1EZ/4CiR5WB5KjzLTrP/bO37B0wPg==,
+        integrity: sha512-ERPW+XkvX9W2A+ov07iy+ZFJpVdik04GhDA4eVogiG9hpC97Kem2iucyzhFxbFRvQ5o2UckFtKZdp1hkGvnrEw==,
       }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-  strtok3@7.0.0:
-    resolution:
-      {
-        integrity: sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==,
-      }
-    engines: { node: '>=14.16' }
+    engines: { node: '>=16' }
 
   style-search@0.1.0:
     resolution:
@@ -12700,6 +12741,12 @@ packages:
       }
     engines: { node: '>=6' }
 
+  tar-stream@3.1.7:
+    resolution:
+      {
+        integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==,
+      }
+
   tar@6.2.1:
     resolution:
       {
@@ -12720,6 +12767,12 @@ packages:
         integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==,
       }
     engines: { node: '>=8' }
+
+  text-decoder@1.2.1:
+    resolution:
+      {
+        integrity: sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==,
+      }
 
   text-table@0.2.0:
     resolution:
@@ -12805,10 +12858,10 @@ packages:
       }
     engines: { node: '>=0.6' }
 
-  token-types@5.0.1:
+  token-types@6.0.0:
     resolution:
       {
-        integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==,
+        integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==,
       }
     engines: { node: '>=14.16' }
 
@@ -12855,13 +12908,6 @@ packages:
     resolution:
       {
         integrity: sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==,
-      }
-    engines: { node: '>=12' }
-
-  trim-repeated@2.0.0:
-    resolution:
-      {
-        integrity: sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==,
       }
     engines: { node: '>=12' }
 
@@ -13098,6 +13144,13 @@ packages:
       }
     engines: { node: '>=0.8.0' }
     hasBin: true
+
+  uint8array-extras@1.4.0:
+    resolution:
+      {
+        integrity: sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==,
+      }
+    engines: { node: '>=18' }
 
   ultrahtml@1.5.3:
     resolution:
@@ -13915,12 +13968,6 @@ packages:
       }
     engines: { node: '>=10' }
 
-  yallist@2.1.2:
-    resolution:
-      {
-        integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==,
-      }
-
   yallist@3.1.1:
     resolution:
       {
@@ -13993,6 +14040,13 @@ packages:
       {
         integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
       }
+
+  yauzl@3.2.0:
+    resolution:
+      {
+        integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==,
+      }
+    engines: { node: '>=12' }
 
   ylru@1.3.2:
     resolution:
@@ -15394,7 +15448,7 @@ snapshots:
       chokidar: 3.6.0
       classnames: 2.5.1
       commander: 12.1.0
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       debug: 4.3.7(supports-color@8.1.1)
       get-port: 7.1.0
       globby: 14.0.2
@@ -15492,17 +15546,6 @@ snapshots:
     dependencies:
       jpeg-js: 0.4.4
       pngjs: 6.0.0
-
-  '@mole-inc/bin-wrapper@8.0.1':
-    dependencies:
-      bin-check: 4.1.0
-      bin-version-check: 5.1.0
-      content-disposition: 0.5.4
-      ext-name: 5.0.0
-      file-type: 17.1.6
-      filenamify: 5.1.1
-      got: 11.8.6
-      os-filter-obj: 2.0.0
 
   '@mswjs/interceptors@0.35.8':
     dependencies:
@@ -15797,7 +15840,7 @@ snapshots:
       cacache: 17.1.4
       chalk: 4.1.2
       chokidar: 3.6.0
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       dotenv: 16.4.5
       es-module-lexer: 1.5.4
       esbuild: 0.17.6
@@ -15993,6 +16036,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.22.4':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/core@1.18.0':
     dependencies:
       '@shikijs/engine-javascript': 1.18.0
@@ -16049,15 +16094,15 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@sindresorhus/is@4.6.0': {}
+  '@sindresorhus/is@5.6.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@swc/cli@0.3.12(@swc/core@1.5.28(@swc/helpers@0.5.11))(chokidar@3.6.0)':
+  '@swc/cli@0.5.1(@swc/core@1.5.28(@swc/helpers@0.5.11))(chokidar@3.6.0)':
     dependencies:
-      '@mole-inc/bin-wrapper': 8.0.1
       '@swc/core': 1.5.28(@swc/helpers@0.5.11)
       '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 13.0.5
       commander: 8.3.0
       fast-glob: 3.3.2
       minimatch: 9.0.3
@@ -16130,7 +16175,7 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@szmarczak/http-timer@4.0.6':
+  '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
 
@@ -16217,13 +16262,6 @@ snapshots:
 
   '@types/btoa-lite@1.0.2': {}
 
-  '@types/cacheable-request@6.0.3':
-    dependencies:
-      '@types/http-cache-semantics': 4.0.1
-      '@types/keyv': 3.1.4
-      '@types/node': 22.5.5
-      '@types/responselike': 1.0.0
-
   '@types/cookie@0.6.0': {}
 
   '@types/debug@4.1.10':
@@ -16244,17 +16282,13 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.2
 
-  '@types/http-cache-semantics@4.0.1': {}
+  '@types/http-cache-semantics@4.0.4': {}
 
   '@types/istanbul-lib-coverage@2.0.4': {}
 
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonwebtoken@9.0.6':
-    dependencies:
-      '@types/node': 22.5.5
-
-  '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 22.5.5
 
@@ -16315,10 +16349,6 @@ snapshots:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
       csstype: 3.1.3
-
-  '@types/responselike@1.0.0':
-    dependencies:
-      '@types/node': 22.5.5
 
   '@types/sax@1.2.7':
     dependencies:
@@ -16570,6 +16600,74 @@ snapshots:
 
   '@web3-storage/multipart-parser@1.0.0': {}
 
+  '@xhmikosr/archive-type@7.0.0':
+    dependencies:
+      file-type: 19.6.0
+
+  '@xhmikosr/bin-check@7.0.3':
+    dependencies:
+      execa: 5.1.1
+      isexe: 2.0.0
+
+  '@xhmikosr/bin-wrapper@13.0.5':
+    dependencies:
+      '@xhmikosr/bin-check': 7.0.3
+      '@xhmikosr/downloader': 15.0.1
+      '@xhmikosr/os-filter-obj': 3.0.0
+      bin-version-check: 5.1.0
+
+  '@xhmikosr/decompress-tar@8.0.1':
+    dependencies:
+      file-type: 19.6.0
+      is-stream: 2.0.1
+      tar-stream: 3.1.7
+
+  '@xhmikosr/decompress-tarbz2@8.0.1':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.0.1
+      file-type: 19.6.0
+      is-stream: 2.0.1
+      seek-bzip: 2.0.0
+      unbzip2-stream: 1.4.3
+
+  '@xhmikosr/decompress-targz@8.0.1':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.0.1
+      file-type: 19.6.0
+      is-stream: 2.0.1
+
+  '@xhmikosr/decompress-unzip@7.0.0':
+    dependencies:
+      file-type: 19.6.0
+      get-stream: 6.0.1
+      yauzl: 3.2.0
+
+  '@xhmikosr/decompress@10.0.1':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.0.1
+      '@xhmikosr/decompress-tarbz2': 8.0.1
+      '@xhmikosr/decompress-targz': 8.0.1
+      '@xhmikosr/decompress-unzip': 7.0.0
+      graceful-fs: 4.2.11
+      make-dir: 4.0.0
+      strip-dirs: 3.0.0
+
+  '@xhmikosr/downloader@15.0.1':
+    dependencies:
+      '@xhmikosr/archive-type': 7.0.0
+      '@xhmikosr/decompress': 10.0.1
+      content-disposition: 0.5.4
+      defaults: 3.0.0
+      ext-name: 5.0.0
+      file-type: 19.6.0
+      filenamify: 6.0.0
+      get-stream: 6.0.1
+      got: 13.0.0
+
+  '@xhmikosr/os-filter-obj@3.0.0':
+    dependencies:
+      arch: 3.0.0
+
   '@zxing/text-encoding@0.9.0':
     optional: true
 
@@ -16672,6 +16770,8 @@ snapshots:
       picomatch: 2.3.1
 
   arch@2.2.0: {}
+
+  arch@3.0.0: {}
 
   arg@4.1.3: {}
 
@@ -16892,6 +16992,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.6.7: {}
+
   backstopjs@6.2.2(typescript@5.5.2):
     dependencies:
       os: 0.1.2
@@ -16925,6 +17027,9 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  bare-events@2.5.0:
+    optional: true
+
   base-64@1.0.0: {}
 
   base64-js@1.5.1: {}
@@ -16940,11 +17045,6 @@ snapshots:
       tweetnacl: 0.14.5
 
   before-after-hook@2.2.3: {}
-
-  bin-check@4.1.0:
-    dependencies:
-      execa: 0.7.0
-      executable: 4.1.1
 
   bin-version-check@5.1.0:
     dependencies:
@@ -17111,17 +17211,17 @@ snapshots:
       mime-types: 2.1.35
       ylru: 1.3.2
 
-  cacheable-lookup@5.0.4: {}
+  cacheable-lookup@7.0.0: {}
 
-  cacheable-request@7.0.4:
+  cacheable-request@10.2.14:
     dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
+      '@types/http-cache-semantics': 4.0.4
+      get-stream: 6.0.1
       http-cache-semantics: 4.1.1
       keyv: 4.5.4
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
+      mimic-response: 4.0.0
+      normalize-url: 8.0.1
+      responselike: 3.0.0
 
   cachedir@2.3.0: {}
 
@@ -17286,10 +17386,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  clone-response@1.0.3:
-    dependencies:
-      mimic-response: 1.0.1
-
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
@@ -17417,13 +17513,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  cross-spawn@5.1.0:
-    dependencies:
-      lru-cache: 4.1.5
-      shebang-command: 1.2.0
-      which: 1.3.1
-
-  cross-spawn@6.0.5:
+  cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
@@ -17431,7 +17521,7 @@ snapshots:
       shebang-command: 1.2.0
       which: 1.3.1
 
-  cross-spawn@7.0.3:
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -17641,6 +17731,8 @@ snapshots:
   defaults@1.0.3:
     dependencies:
       clone: 1.0.4
+
+  defaults@3.0.0: {}
 
   defer-to-connect@2.0.1: {}
 
@@ -18031,7 +18123,7 @@ snapshots:
       '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       debug: 4.3.7(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
@@ -18164,19 +18256,9 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
-  execa@0.7.0:
-    dependencies:
-      cross-spawn: 5.1.0
-      get-stream: 3.0.0
-      is-stream: 1.1.0
-      npm-run-path: 2.0.2
-      p-finally: 1.0.0
-      signal-exit: 3.0.7
-      strip-eof: 1.0.0
-
   execa@4.1.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 5.2.0
       human-signals: 1.1.1
       is-stream: 2.0.1
@@ -18188,7 +18270,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -18200,7 +18282,7 @@ snapshots:
 
   execa@8.0.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 8.0.1
       human-signals: 5.0.0
       is-stream: 3.0.0
@@ -18290,6 +18372,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -18328,19 +18412,18 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
-  file-type@17.1.6:
+  file-type@19.6.0:
     dependencies:
-      readable-web-to-node-stream: 3.0.2
-      strtok3: 7.0.0
-      token-types: 5.0.1
+      get-stream: 9.0.1
+      strtok3: 9.0.1
+      token-types: 6.0.0
+      uint8array-extras: 1.4.0
 
   filename-reserved-regex@3.0.0: {}
 
-  filenamify@5.1.1:
+  filenamify@6.0.0:
     dependencies:
       filename-reserved-regex: 3.0.0
-      strip-outer: 2.0.0
-      trim-repeated: 2.0.0
 
   fill-range@7.1.1:
     dependencies:
@@ -18401,15 +18484,17 @@ snapshots:
 
   foreground-child@2.0.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 3.0.7
 
   foreground-child@3.1.1:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
+
+  form-data-encoder@2.1.4: {}
 
   form-data@2.3.3:
     dependencies:
@@ -18497,8 +18582,6 @@ snapshots:
 
   get-port@7.1.0: {}
 
-  get-stream@3.0.0: {}
-
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.0
@@ -18506,6 +18589,11 @@ snapshots:
   get-stream@6.0.1: {}
 
   get-stream@8.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.0.2:
     dependencies:
@@ -18594,19 +18682,19 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
-  got@11.8.6:
+  got@13.0.0:
     dependencies:
-      '@sindresorhus/is': 4.6.0
-      '@szmarczak/http-timer': 4.0.6
-      '@types/cacheable-request': 6.0.3
-      '@types/responselike': 1.0.0
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
       decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
 
   graceful-fs@4.2.11: {}
 
@@ -18987,7 +19075,7 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.17.0
 
-  http2-wrapper@1.0.3:
+  http2-wrapper@2.2.1:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
@@ -19063,6 +19151,10 @@ snapshots:
   inline-style-parser@0.1.1: {}
 
   inline-style-parser@0.2.2: {}
+
+  inspect-with-kind@1.0.5:
+    dependencies:
+      kind-of: 6.0.3
 
   internal-slot@1.0.7:
     dependencies:
@@ -19219,11 +19311,11 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
 
-  is-stream@1.1.0: {}
-
   is-stream@2.0.1: {}
 
   is-stream@3.0.0: {}
+
+  is-stream@4.0.1: {}
 
   is-string@1.0.7:
     dependencies:
@@ -19671,14 +19763,9 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  lowercase-keys@2.0.0: {}
+  lowercase-keys@3.0.0: {}
 
   lru-cache@10.2.0: {}
-
-  lru-cache@4.1.5:
-    dependencies:
-      pseudomap: 1.0.2
-      yallist: 2.1.2
 
   lru-cache@5.1.1:
     dependencies:
@@ -20527,9 +20614,9 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@1.0.1: {}
-
   mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
 
   min-indent@1.0.1: {}
 
@@ -20725,7 +20812,7 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  normalize-url@6.1.0: {}
+  normalize-url@8.0.1: {}
 
   not@0.1.0: {}
 
@@ -20753,17 +20840,13 @@ snapshots:
     dependencies:
       ansi-styles: 3.2.1
       chalk: 2.4.2
-      cross-spawn: 6.0.5
+      cross-spawn: 6.0.6
       memorystream: 0.3.1
       minimatch: 3.1.2
       pidtree: 0.3.1
       read-pkg: 3.0.0
       shell-quote: 1.8.1
       string.prototype.padend: 3.1.5
-
-  npm-run-path@2.0.2:
-    dependencies:
-      path-key: 2.0.1
 
   npm-run-path@4.0.1:
     dependencies:
@@ -20906,10 +20989,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 6.0.1
 
-  os-filter-obj@2.0.0:
-    dependencies:
-      arch: 2.2.0
-
   os@0.1.2: {}
 
   ospath@1.2.2: {}
@@ -20918,9 +20997,7 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  p-cancelable@2.1.1: {}
-
-  p-finally@1.0.0: {}
+  p-cancelable@3.0.0: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -21057,7 +21134,7 @@ snapshots:
 
   pathval@1.1.1: {}
 
-  peek-readable@5.0.0: {}
+  peek-readable@5.3.1: {}
 
   peek-stream@1.1.3:
     dependencies:
@@ -21497,8 +21574,6 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  pseudomap@1.0.2: {}
-
   psl@1.8.0: {}
 
   pump@2.0.1:
@@ -21572,6 +21647,8 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
+
+  queue-tick@1.0.1: {}
 
   quick-lru@5.1.1: {}
 
@@ -21689,10 +21766,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readable-web-to-node-stream@3.0.2:
-    dependencies:
-      readable-stream: 3.6.0
 
   readdirp@3.6.0:
     dependencies:
@@ -21922,9 +21995,9 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  responselike@2.0.1:
+  responselike@3.0.0:
     dependencies:
-      lowercase-keys: 2.0.0
+      lowercase-keys: 3.0.0
 
   restore-cursor@3.1.0:
     dependencies:
@@ -22133,6 +22206,10 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
 
   semver-regex@4.0.5: {}
 
@@ -22380,6 +22457,14 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  streamx@2.20.2:
+    dependencies:
+      fast-fifo: 1.3.2
+      queue-tick: 1.0.1
+      text-decoder: 1.2.1
+    optionalDependencies:
+      bare-events: 2.5.0
+
   strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
@@ -22467,7 +22552,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-eof@1.0.0: {}
+  strip-dirs@3.0.0:
+    dependencies:
+      inspect-with-kind: 1.0.5
+      is-plain-obj: 1.1.0
 
   strip-final-newline@2.0.0: {}
 
@@ -22487,12 +22575,10 @@ snapshots:
     dependencies:
       acorn: 8.12.1
 
-  strip-outer@2.0.0: {}
-
-  strtok3@7.0.0:
+  strtok3@9.0.1:
     dependencies:
       '@tokenizer/token': 0.3.0
-      peek-readable: 5.0.0
+      peek-readable: 5.3.1
 
   style-search@0.1.0: {}
 
@@ -22650,6 +22736,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.0
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.6.7
+      fast-fifo: 1.3.2
+      streamx: 2.20.2
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -22669,6 +22761,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  text-decoder@1.2.1: {}
 
   text-table@0.2.0: {}
 
@@ -22705,7 +22799,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  token-types@5.0.1:
+  token-types@6.0.0:
     dependencies:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
@@ -22730,10 +22824,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trim-newlines@4.1.1: {}
-
-  trim-repeated@2.0.0:
-    dependencies:
-      escape-string-regexp: 5.0.0
 
   trough@2.1.0: {}
 
@@ -22852,6 +22942,8 @@ snapshots:
 
   uglify-js@3.17.4:
     optional: true
+
+  uint8array-extras@1.4.0: {}
 
   ultrahtml@1.5.3: {}
 
@@ -23387,8 +23479,6 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yallist@2.1.2: {}
-
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
@@ -23451,6 +23541,11 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yauzl@3.2.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   ylru@1.3.2: {}
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes https://github.com/advisories/GHSA-3xgq-45jj-v275.

Ran [`pnpm audit --fix`](https://pnpm.io/cli/audit#--fix), then ran `pnpm i` to update the lockfile, and then manually deleted the `package.json` overrides.

However, the audit was still failing. Upon investigating, it was coming from one of the nested dependencies of `@itwin/itwinui-react`'s `@swc/cli` dependency. So, I bumped `@swc/cli` too since I didn't find any big changes in their [changelog](https://github.com/swc-project/pkgs/blob/main/packages/cli/CHANGELOG.md). I then confirmed that it fixed the audit.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

- [x] Confirm `pnpm audit` passes ([run](https://github.com/iTwin/iTwinUI/actions/runs/11920407390/job/33222316667?pr=2349))
- ~[ ]~ Confirm build passes
  - Noticed that build for `website` is failing, even in the current `main`. So deemed it unrelated and added it as an after PR TODO.
- [x] Confirm CI passes
- [x] Confirm that esm and cjs build outputs are the same. E.g. tested for `Table.js`

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Didn't add a changeset since I didn't think a bump in `cross-spawn` was important enough to warrant a changeset. Can add one if reviewers feel otherwise.

## After PR TODOs:

* [ ] See why `build` of website is failing
  <details><summary>Error</summary>

  ```
  website:build:  generating static routes 
  website:build: λ /_astro/ec.dy9ns.js
  website:build:   └─ /_astro/ec.dy9ns.js (+3ms)
  website:build: λ /_astro/ec.ulvux.css
  website:build:   └─ /_astro/ec.ulvux.css (+1ms)
  website:build: ▶ src/pages/docs/components.astro
  website:build:   └─ /docs/components/index.html (+43ms)
  website:build: ▶ src/pages/docs/[...slug].astro
  website:build:   ├─ /docs/alert/index.htmlCannot find package '/iTwinUI/apps/website/node_modules/outdent/package.json' imported from /iTwinUI/apps/website/dist/chunks/UnstableApiCard_DAd-Wouo.mjs
  website:build: Did you mean to import outdent/lib/index.js?
  website:build:   Stack trace:
  website:build:     at legacyMainResolve (node:internal/modules/esm/resolve:214:26)
  website:build:     at moduleResolve (node:internal/modules/esm/resolve:910:20)
  website:build:     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
  website:build:     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
  website:build:     at link (node:internal/modules/esm/module_job:84:36)
  website:build:  ELIFECYCLE  Command failed with exit code 1.
  website:build: ERROR: command finished with error: command (/iTwinUI/apps/website) /usr/local/bin/pnpm run build exited (1)
  website#build: command (/iTwinUI/apps/website) /usr/local/bin/pnpm run build exited (1)
  ```

  </details>