### PR TITLE
remove `display:contents` to fix live demos in Safari

### DIFF
--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,7 +49,7 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: block !important; // https://github.com/iTwin/iTwinUI/pull/2353
+        display: block !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
       }
     </style>
     <style set:html={cssCode}></style>

--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,7 +49,7 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: contents;
+        display: block !important;
       }
     </style>
     <style set:html={cssCode}></style>

--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,7 +49,7 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: block !important;
+        display: block !important; // https://github.com/iTwin/iTwinUI/pull/2353
       }
     </style>
     <style set:html={cssCode}></style>


### PR DESCRIPTION
## Changes

This PR fixes a Safari-specific accessibility issue, where the content inside nested `display: contents` elements within shadow DOM is completely unreachable when navigating using VoiceOver. I noticed this in the live demos on every page.

Forcing `display: block` on the astro-island fixes (or rather, avoids) the issue.

(Worth emphasizing: This is a [bug in Safari](https://bugs.webkit.org/show_bug.cgi?id=283511). We shouldn't have to do this workaround, and yet here we are. Thankfully the bug has already been fixed, hopefully to be released in the next stable version of Safari.)

## Testing

Tested on VoiceOver + Safari 18.1.1 (macOS 15.1).

| Before | After |
| --- | --- |
| The live demo is skipped entirely. | The live demo is accessible. |
| <video src="https://github.com/user-attachments/assets/bb6afee5-438e-4259-abc0-22b9aa0e67f1"> | <video src="https://github.com/user-attachments/assets/3ad6b7f2-cf2e-413f-ac65-b953e7ef9c1a"> |

## Docs

N/A
