### PR TITLE
Added buffer to all sides of `Tooltip`'s floating content

### DIFF
--- a/.changeset/clean-worms-destroy.md
+++ b/.changeset/clean-worms-destroy.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': major
+---
+
+The `Tooltip` now remains visible when hovered up to `4px` outside its border.

--- a/.changeset/clean-worms-destroy.md
+++ b/.changeset/clean-worms-destroy.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-css': major
+'@itwin/itwinui-css': patch
 ---
 
 The `Tooltip` now remains visible when hovered up to `4px` outside its border.

--- a/packages/itwinui-css/src/tooltip/tooltip.scss
+++ b/packages/itwinui-css/src/tooltip/tooltip.scss
@@ -9,7 +9,7 @@
   text-align: center;
   border-radius: var(--iui-border-radius-1);
   font-size: var(--iui-font-size-0);
-  overflow: hidden;
+  overflow: visible;
   max-inline-size: 400px;
   inline-size: max-content;
   overflow-wrap: break-word;
@@ -20,6 +20,12 @@
   box-shadow: var(--iui-shadow-3);
   color: var(--iui-color-white);
   border: 1px solid rgba(255, 255, 255, var(--iui-opacity-4));
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+  }
 
   @include mixins.iui-blur($hsl: 0 0% 0%, $opacity: 3);
 


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

This PR added a buffer of 4px to all sides of the `Tooltip`'s floating content so that when users slightly move their mouse outside of the content box, the tooltip is still visible.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the tooltip is still visible when the mouse moves outside of the border.

https://github.com/user-attachments/assets/718f75fd-a63f-451c-89bf-3962cb7cbb52


## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
