### PR TITLE
Updated `Tree` JSDoc and website documentation

### DIFF
--- a/apps/website/src/content/docs/tree.mdx
+++ b/apps/website/src/content/docs/tree.mdx
@@ -18,7 +18,9 @@ To initialize the tree component, the following props are required:
 
 - `data`: An array of the custom data that represents a tree node.
 - `getNode`: A function that maps your `data` entry to `NodeData` that has all information about the node state. Here is where one can control the state of expanded, selected and disabled nodes. The function must be memoized.
-- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component. If `nodeRenderer` returns a wrapper component that in turn returns a `TreeNode`, the wrapper component must be wrapped with `React.forwardRef`. This ensures that the correct styling and logic are applied to the returned component, especially with virtualization. This function must be memoized.
+- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component.
+
+**Note**: When virtualization is enabled, the return value of `nodeRenderer()` is cloned and a `ref` is passed to it. Thus, you would need a `React.forwardRef` in the component returned by `nodeRenderer()`, except if you are returning `TreeNode` since that already forwards its ref.
 
 ### Subnode
 

--- a/apps/website/src/content/docs/tree.mdx
+++ b/apps/website/src/content/docs/tree.mdx
@@ -18,7 +18,7 @@ To initialize the tree component, the following props are required:
 
 - `data`: An array of the custom data that represents a tree node.
 - `getNode`: A function that maps your `data` entry to `NodeData` that has all information about the node state. Here is where one can control the state of expanded, selected and disabled nodes. The function must be memoized.
-- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component. This function must be memoized.
+- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component. If `nodeRenderer` returns a wrapper component that in turn returns a `TreeNode`, the wrapper component must be wrapped with `React.forwardRef`. This ensures that the correct styling and logic are applied to the returned component, especially with virtualization. This function must be memoized.
 
 ### Subnode
 

--- a/apps/website/src/content/docs/tree.mdx
+++ b/apps/website/src/content/docs/tree.mdx
@@ -18,7 +18,7 @@ To initialize the tree component, the following props are required:
 
 - `data`: An array of the custom data that represents a tree node.
 - `getNode`: A function that maps your `data` entry to `NodeData` that has all information about the node state. Here is where one can control the state of expanded, selected and disabled nodes. The function must be memoized.
-- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component.
+- `nodeRenderer`: A function to render the tree node using `NodeData`. We recommend this function to return the `TreeNode` component. This function must be memoized.
 
 **Note**: When virtualization is enabled, the return value of `nodeRenderer()` is cloned and a `ref` is passed to it. Thus, you would need a `React.forwardRef` in the component returned by `nodeRenderer()`, except if you are returning `TreeNode` since that already forwards its ref.
 

--- a/packages/itwinui-react/src/core/Tree/Tree.tsx
+++ b/packages/itwinui-react/src/core/Tree/Tree.tsx
@@ -68,8 +68,8 @@ export type TreeProps<T> = {
   /**
    * Render function that should return the node element.
    * Recommended to use `TreeNode` component.
-   * If `nodeRenderer` returns a wrapper component that returns `TreeNode`, the component must be wrapped with `React.forwardRef`.
-   * Must be memoized.
+   *
+   ***Note**: When virtualization is enabled, the return value of `nodeRenderer()` is cloned and a `ref` is passed to it. Thus, you would need a `React.forwardRef` in the component returned by `nodeRenderer()`, except if you are returning `TreeNode` since that already forwards its ref.
    * @example
    * const nodeRenderer = React.useCallback(({ node, ...rest }: NodeRenderProps<DataType>) => (
    *   <TreeNode

--- a/packages/itwinui-react/src/core/Tree/Tree.tsx
+++ b/packages/itwinui-react/src/core/Tree/Tree.tsx
@@ -68,6 +68,7 @@ export type TreeProps<T> = {
   /**
    * Render function that should return the node element.
    * Recommended to use `TreeNode` component.
+   * If `nodeRenderer` returns a wrapper component that returns `TreeNode`, the component must be wrapped with `React.forwardRef`.
    * Must be memoized.
    * @example
    * const nodeRenderer = React.useCallback(({ node, ...rest }: NodeRenderProps<DataType>) => (


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

This PR updated the `Tree` JSDoc and website documentation to mention the [issue](https://github.com/iTwin/iTwinUI/issues/2357) user reported. The issue discussed the requirement for the `Tree`'s `nodeRenderer` to return a component wrapped with `React.forwardRef`, ensuring proper application of styling and other props to virtualized small `Tree`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

All tests passed.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
