### PR TITLE
Add missing react imports in examples

### DIFF
--- a/examples/InputGroup.radioGroup.jsx
+++ b/examples/InputGroup.radioGroup.jsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import { InputGroup, Radio } from '@itwin/itwinui-react';
 
 export default () => {

--- a/examples/Panels.main.jsx
+++ b/examples/Panels.main.jsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import {
   unstable_Panels as Panels,
   List,

--- a/examples/Panels.multiPanelInformationPanel.jsx
+++ b/examples/Panels.multiPanelInformationPanel.jsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import {
   unstable_Panels as Panels,
   List,

--- a/examples/Panels.nestedPanels.jsx
+++ b/examples/Panels.nestedPanels.jsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import {
   unstable_Panels as Panels,
   Flex,

--- a/examples/SkipToContentLink.main.jsx
+++ b/examples/SkipToContentLink.main.jsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
 import { SkipToContentLink } from '@itwin/itwinui-react';
 
 export default () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

@mayank99 noticed that when some examples (e.g. [`Panels`](https://itwinui.bentley.com/docs/panels)'s examples) were opened in CodePen from the docs site, the following error is encountered: `ReferenceError: React is not defined`.

To avoid this error in those examples, React imports are added to the examples that were missing it.

In the future, as @mayank99 suggested, we could even have a lint rule to easily ensure this react import is there.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

* Confirmed that no example is missing a react import.
* Confirmed that the `Panels` examples and the other examples that were missing the react import now open properly in CodePen.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A

## After PR TODOs

* [ ] Try having lint rules to make sure react imports are there in all examples