### PR TITLE
Fix `HeaderButton`'s `startIcon` & `endIcon` fill color

### DIFF
--- a/.changeset/shiny-waves-judge.md
+++ b/.changeset/shiny-waves-judge.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fix `HeaderButton`'s `startIcon` and `endIcon` fill color.

--- a/.changeset/smart-penguins-greet.md
+++ b/.changeset/smart-penguins-greet.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fix fill of svgs in `iui-header-breadcrumb-button`.

--- a/packages/itwinui-css/src/header/header-buttons.scss
+++ b/packages/itwinui-css/src/header/header-buttons.scss
@@ -160,6 +160,17 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   &[aria-disabled='true'] {
     cursor: not-allowed;
   }
+
+  svg {
+    fill: currentColor;
+
+    :disabled &,
+    [aria-disabled='true'] & {
+      @media (forced-colors: active) {
+        fill: GrayText;
+      }
+    }
+  }
 }
 
 @mixin iui-header-breadcrumb-button-split {
@@ -190,20 +201,8 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
   flex-shrink: 0;
   margin-inline-end: calc(0px - var(--iui-size-2xs));
 
-  &,
-  > svg {
-    fill: currentColor;
-  }
-
   .iui-header-breadcrumb-button-split & {
     margin-inline-end: 0;
-  }
-
-  :disabled &,
-  [aria-disabled='true'] & {
-    @media (forced-colors: active) {
-      fill: GrayText;
-    }
   }
 }
 
@@ -277,7 +276,7 @@ $iui-side-navigation-icon-margins: calc(1.5 * var(--iui-size-m));
 
     :is(:disabled, [aria-disabled='true']) & {
       background-color: var(--iui-color-background-backdrop);
-      fill: var(--iui-color-icon-disabled);
+      fill: currentColor;
 
       @media (forced-colors: active) {
         fill: GrayText;

--- a/packages/itwinui-react/src/core/Header/HeaderDropdownButton.tsx
+++ b/packages/itwinui-react/src/core/Header/HeaderDropdownButton.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import cx from 'classnames';
 import * as React from 'react';
 import { DropdownMenu } from '../DropdownMenu/DropdownMenu.js';
 import {
@@ -15,7 +14,7 @@ import { HeaderBasicButton } from './HeaderBasicButton.js';
 import type { DropdownButtonProps } from '../Buttons/DropdownButton.js';
 
 export const HeaderDropdownButton = React.forwardRef((props, ref) => {
-  const { menuItems, className, children, ...rest } = props;
+  const { menuItems, children, ...rest } = props;
 
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
@@ -36,7 +35,6 @@ export const HeaderDropdownButton = React.forwardRef((props, ref) => {
       onVisibleChange={(open) => setIsMenuOpen(open)}
     >
       <HeaderBasicButton
-        className={cx('iui-header-breadcrumb-button', className)}
         ref={refs}
         aria-label='Dropdown'
         endIcon={


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Originated from https://github.com/iTwin/iTwinUI/pull/2369#issuecomment-2539884925.

This PR fixes the `fill` color of `HeaderButton`'s `startIcon` and `endIcon`. More specifically:
* all svgs inside the `HeaderButton` now have `fill: currentColor`. This fix applies to end icon since start icon has its own styling from `iui-header-breadcrumb-button-icon` that takes priority.
* Disabled fill with and without `forced-colors` now properly applied to start and end icon.

Unrelated: Removed the duplicate `iui-header-breadcrumb-button` class in `HeaderDropdownButton`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

[Playground](https://stackblitz.com/edit/github-d992wxck?file=src%2FApp.tsx)

|Before|After|Diff
|-|-|-|
|![image](https://github.com/user-attachments/assets/9c1d1466-74e2-415c-bf67-285049f1dab3)|![image](https://github.com/user-attachments/assets/eadbb00d-03b8-40b0-b823-774ff0c1d6e1)|![image](https://github.com/user-attachments/assets/6e442b1d-4a0e-48e3-9d67-fe1f51af74e1)|


Forced colors:

|Before|After|Diff|
|-|-|-|
|![image](https://github.com/user-attachments/assets/346210f7-c081-45f0-8630-e8780a827ea0)|![image](https://github.com/user-attachments/assets/e50165ce-5ee3-40a2-967c-cb5ba25e8838)|<img width="952" alt="image" src="https://github.com/user-attachments/assets/73d03bb2-ea8b-440f-bbad-e91b2b36caec" />|

Disabled fill in start icon:

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/2724d975-7fc9-415e-ade4-98b1df077200)|![image](https://github.com/user-attachments/assets/343a83d1-3f5e-4743-9db2-2332faaf7d7e)|


<!-- ![image](https://github.com/user-attachments/assets/a3ea1b95-6ec8-40e1-9f6e-abb53459672a) -->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added css and react changesets.

## After PR TODOs:

* [ ] Maybe consider better ways to target svgs inside of components since the `svg` selector is too general. ([#2374 (comment)](https://github.com/iTwin/iTwinUI/pull/2374#discussion_r1887301379)). This applies to other components too that follow this pattern.