### PR TITLE
Fixed broken site documentation layout

### DIFF
--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,7 +49,10 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: block !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
+        display: flex !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
+        justify-content: center;
+        align-items: center;
+        width: 650px;
       }
     </style>
     <style set:html={cssCode}></style>

--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,10 +49,9 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: flex !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
-        justify-content: center;
-        align-items: center;
+        display: block !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
         width: 650px;
+        text-align: center;
       }
     </style>
     <style set:html={cssCode}></style>

--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -49,9 +49,10 @@ const cssCode = await (async () => {
   <template shadowrootmode='open'>
     <style is:inline>
       astro-island {
-        display: block !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
+        display: flex !important; /* https://github.com/iTwin/iTwinUI/pull/2353 */
         width: 650px;
-        text-align: center;
+        justify-content: center;
+        align-items: center;
       }
     </style>
     <style set:html={cssCode}></style>

--- a/examples/Surface.elevation.jsx
+++ b/examples/Surface.elevation.jsx
@@ -7,7 +7,7 @@ import { Surface } from '@itwin/itwinui-react';
 
 export default () => {
   return (
-    <>
+    <div>
       <div className='demo-container'>
         <Surface elevation={0} className='demo-card'>
           <p>Elevation 0 (0dp)</p>
@@ -30,6 +30,6 @@ export default () => {
           <p>Elevation 5 (24dp)</p>
         </Surface>
       </div>
-    </>
+    </div>
   );
 };

--- a/examples/Tree.virtualization.css
+++ b/examples/Tree.virtualization.css
@@ -1,5 +1,5 @@
 .demo-tree {
   width: min(100%, 260px);
-  height: 100%;
+  height: 300px;
   overflow: auto;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

This PR addressed another workaround to temporarily fix the problem caused by VoiceOver not working in Safari. Currently, Safari 18.3 [beta version](https://developer.apple.com/documentation/safari-release-notes/safari-18_3-release-notes) has been released, while this bug was marked as major so hopefully, we can remove this workaround soon. 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that Safari VoiceOver is still working with this workaround.
![voiceover](https://github.com/user-attachments/assets/06786e99-e788-4625-bcae-80f624376f95)

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
