### PR TITLE
Remove leading spaces in peer-deps for react deps

### DIFF
--- a/.changeset/large-poets-begin.md
+++ b/.changeset/large-poets-begin.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed the syntax for `react` version range declared in `peerDependencies`.

--- a/packages/itwinui-react/package.json
+++ b/packages/itwinui-react/package.json
@@ -134,8 +134,8 @@
     "vitest": "^1.2.1"
   },
   "peerDependencies": {
-    "react": ">= 17.0.0 < 19.0.0",
-    "react-dom": ">=17.0.0 < 19.0.0"
+    "react": ">=17.0.0 <19.0.0",
+    "react-dom": ">=17.0.0 <19.0.0"
   },
   "lint-staged": {
     "*.{tsx,ts,jsx,js}": [


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

Hi all, with Module Federation coming into use more and more we have fallen quite a few times into this pitfall of declaring peerDep version ranges with extra spaces.

The version resolution logic is quite complex inside MF sources and it does not seem to handle having extra spaces in the version range. We want MF to include shared bundle of react and react-dom as the peerDep for iTwinUI and would mean the peerDep has to be resolved with a "correct" version range.

## NPM Docs

Set of primitive operators are all declared without spaces: https://docs.npmjs.com/cli/v6/using-npm/semver#ranges

## Testing

I am using a private repository to test this but the results are quite appearant:
![image](https://github.com/user-attachments/assets/177996ac-ead2-4277-ae02-a91902ac74ee)
![image](https://github.com/user-attachments/assets/aa256253-cd55-42cf-8879-1993826359d7)

Without spaces in the version range:
![image](https://github.com/user-attachments/assets/633777f6-c412-48a1-b14a-2adeb3895578)
![image](https://github.com/user-attachments/assets/3cffeb31-c932-407f-88c3-d86bd3646b14)

Bundles are shared like:
![image](https://github.com/user-attachments/assets/a6adc7c4-32e1-4f6f-81f6-2971e6f1e743)


## Docs

N/A
