### PR TITLE
force wrap long lines in `Tile.Name`

### DIFF
--- a/.changeset/modern-pigs-mix-1.md
+++ b/.changeset/modern-pigs-mix-1.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed an issue in `iui-tile-name` where a long string without spaces wasn't wrapping properly.

--- a/.changeset/modern-pigs-mix-2.md
+++ b/.changeset/modern-pigs-mix-2.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Tile.Name` where a long string without spaces wasn't wrapping properly.

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -227,6 +227,7 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   font-size: var(--iui-font-size-2);
   color: var(--_iui-tile-title-text-color);
   padding-inline: var(--iui-size-s);
+  overflow-wrap: anywhere;
 }
 
 @mixin iui-tile-status-icon {


### PR DESCRIPTION
## Changes

Fixes https://github.com/iTwin/iTwinUI/issues/2383 using `overflow-wrap: anywhere`.

## Testing

Tested by recreating the sandbox from linked issue.

| Before | After |
| --- | --- |
| ![No wrapping; the tile name overflows out of the tile](https://github.com/user-attachments/assets/cbd14642-1c31-4027-be67-5514bd3b93c3) | ![Wrapping properly](https://github.com/user-attachments/assets/5d3f0a0e-7d7a-44a9-8d1c-e2c464d6dd25) |

## Docs

N/A