### PR TITLE
Fixed doc links to `Text` and `Label`

### DIFF
--- a/apps/website/src/content/docs/anchor.mdx
+++ b/apps/website/src/content/docs/anchor.mdx
@@ -61,7 +61,7 @@ If you do ultimately decide based on your research that it is beneficial to open
 
 By default, an anchor is only underlined when hovered, with a few exceptions:
 
-1. Anchors inside a [`Text`](https://itwinui.bentley.com/docs/typography#text) component are underlined by default.
+1. Anchors inside a [`Text`](/docs/text) component are underlined by default.
 2. All anchors are underlined by default when using a high-contrast theme.
 
 For [better accessibility](https://adrianroselli.com/2016/06/on-link-underlines.html#recommendation), it is recommended to explicitly make the anchor underlined in all themes, even when used outside `Text`. This can be achieved using the `underline` prop.

--- a/apps/website/src/content/docs/combobox.mdx
+++ b/apps/website/src/content/docs/combobox.mdx
@@ -81,7 +81,7 @@ If you expect the combobox to have a very long list of items, you can set `enabl
 
 ### Labels
 
-You can use a [Label](typography#label) component alongside the combobox to add a label. Note that passing the same id to the label as `htmlFor` and to the combobox as `id` in `inputProps` will allow users to open the combobox by clicking on the label.
+You can use a [Label](/docs/label) component alongside the combobox to add a label. Note that passing the same id to the label as `htmlFor` and to the combobox as `id` in `inputProps` will allow users to open the combobox by clicking on the label.
 
 <LiveExample src='ComboBox.label.jsx'>
   <AllExamples.ComboBoxLabelExample client:load />

--- a/apps/website/src/content/docs/inputgrid.mdx
+++ b/apps/website/src/content/docs/inputgrid.mdx
@@ -15,7 +15,7 @@ InputGrid is a layout component that allows to group label, form field and statu
 
 You can add any form field (eg. Select, ComboBox or InputWithDecorations).
 
-We recommend [Label](typography#label) and [StatusMessage](statusmessage) components with this layout.
+We recommend [Label](/docs/label) and [StatusMessage](statusmessage) components with this layout.
 
 <LiveExample src='InputGrid.select.jsx'>
   <AllExamples.InputGridSelectExample client:load />


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Since the `Typography` doc page has been split into to `Text` and `Label` separate docs (https://github.com/iTwin/iTwinUI/pull/2393), there were links to these docs that were still under `typography.mdx` page (`/docs/typography/#text` or `/docs/typography/#label`). This PR replaced those links with the direct doc links to the components (`/docs/text` and `/docs/label`).

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A