### PR TITLE
Tabs: recalculate stripe position when `value` changes

### DIFF
--- a/.changeset/many-eggs-chew.md
+++ b/.changeset/many-eggs-chew.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Tabs` where it wasn't recalculating the active stripe position when a new tab was asynchronously added to the tablist.

--- a/packages/itwinui-react/src/core/Tabs/Tabs.tsx
+++ b/packages/itwinui-react/src/core/Tabs/Tabs.tsx
@@ -286,6 +286,7 @@ const Tab = React.forwardRef((props, forwardedRef) => {
     tabsWidth, // to fix visual artifact on initial render
     setStripeProperties,
     tablistRef,
+    value, // since Tab with a different value might be later added to the same position
   ]);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Changes

Fixes #2400 by adding `value` to the dependency array of the Effect that recalculates the stripe position.

**Explanation**: The `value` is automatically calculated (in `LegacyTabsComponent`) based on the tab's index in the tablist. So when a new tab is added to an existing position, the existing tab gets shifted and gets a new `value` which forces a recalculation. The `isActive` state stays unchanged, which is why previously it wasn't recalculating.

I still think that consumers should probably remount the tabs when the tablist changes, but this fixes the bug on our end.

## Testing

Confirmed that the issue is no longer reproducible by recreating the linked sandbox in local vite playground.

## Docs

N/A