### PR TITLE
Fix missing useId import

### DIFF
--- a/.changeset/cool-pants-greet.md
+++ b/.changeset/cool-pants-greet.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed `Panels.Trigger` not working in older React versions where `useId` is not available.

--- a/packages/itwinui-react/src/core/Panels/Panels.tsx
+++ b/packages/itwinui-react/src/core/Panels/Panels.tsx
@@ -16,6 +16,7 @@ import {
   useWarningLogger,
   useLayoutEffect,
   useLatestRef,
+  useId,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import { IconButton } from '../Buttons/IconButton.js';
@@ -269,7 +270,7 @@ const PanelTrigger = (props: PanelTriggerProps) => {
   } = useSafeContext(PanelsWrapperContext);
   const { id: panelId } = useSafeContext(PanelContext);
 
-  const fallbackId = React.useId();
+  const fallbackId = useId();
   const triggerId = children.props.id || fallbackId;
 
   const onClick = React.useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

`useId` hook from React is not available in react 17, for that purpose a custom hook exists, however; for some reason it is not used in Panels component (likely a typo). Fixes #2410 

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".

-->
Ensure Panels component works with react 17 app

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
N/A