### PR TITLE
Use an inline-size container for `<demo-box>`

### DIFF
--- a/apps/website/src/components/LiveExample.astro
+++ b/apps/website/src/components/LiveExample.astro
@@ -112,6 +112,7 @@ const cssCode = await (async () => {
 <style lang='scss'>
   @layer components {
     demo-box {
+      container-type: inline-size;
       position: relative;
       min-height: 300px;
       max-height: 500px;

--- a/examples/TagContainer.scroll.css
+++ b/examples/TagContainer.scroll.css
@@ -1,3 +1,3 @@
 .demo-container {
-  max-width: 70%;
+  max-width: 70cqi;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

For the docs site, this resolves the issues of the main content breaking out of its grid column on the page for the `Tag` component. Given that a demo’s content should be isolated from the page, it makes sense to make it a container. Then in the specific example that was causing the breaking out, I’ve swap percentages for content query units.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->
