### PR TITLE
set `type=button` on disabled buttons

### DIFF
--- a/.changeset/four-bananas-appear.md
+++ b/.changeset/four-bananas-appear.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue where disabled buttons were still causing form submissions. Affects `Button`, `IconButton`, and all other button components.

--- a/packages/itwinui-react/src/utils/components/ButtonBase.test.tsx
+++ b/packages/itwinui-react/src/utils/components/ButtonBase.test.tsx
@@ -84,3 +84,19 @@ it('should allow `htmlDisabled` prop to override `disabled`', () => {
   expect(button).toBeDisabled();
   expect(button).not.toHaveAttribute('aria-disabled');
 });
+
+it('should not allow submitting form when disabled', async () => {
+  const formAction = vi.fn();
+
+  render(
+    <form action={formAction}>
+      <ButtonBase type='submit' disabled>
+        hi
+      </ButtonBase>
+    </form>,
+  );
+  await userEvent.tab();
+  await userEvent.keyboard('{Enter}');
+
+  expect(formAction).not.toHaveBeenCalled();
+});

--- a/packages/itwinui-react/src/utils/components/ButtonBase.tsx
+++ b/packages/itwinui-react/src/utils/components/ButtonBase.tsx
@@ -13,6 +13,7 @@ export const ButtonBase = React.forwardRef((props, forwardedRef) => {
     as: asProp = 'button',
     disabled: disabledProp,
     htmlDisabled,
+    type: typeProp = asProp === 'button' ? 'button' : undefined,
     ...rest
   } = props;
 
@@ -33,10 +34,13 @@ export const ButtonBase = React.forwardRef((props, forwardedRef) => {
       handler?.(e);
     };
 
+  // Set the type to 'button' for disabled button, to prevent form submission
+  const type = asProp === 'button' && disabledProp ? 'button' : typeProp;
+
   return (
     <Box
       as={asProp}
-      type={asProp === 'button' ? 'button' : undefined}
+      type={type}
       ref={forwardedRef}
       aria-disabled={ariaDisabled ? 'true' : undefined}
       data-iui-disabled={disabledProp ? 'true' : undefined}


### PR DESCRIPTION
## Changes

Fixes #2398. Form submissions are prevented by overriding `<Button type="submit" disabled>` to use `type="button"`.

(This is a workaround that allows us to keep using `aria-disabled` for more accessible disabled buttons.)

## Testing

Added unit test + manually verified that the linked sandbox is fixed.

## Docs

Added `patch` changeset.