### PR TITLE
fix codepen demos

### DIFF
--- a/apps/website/src/components/OpenInCodePen.astro
+++ b/apps/website/src/components/OpenInCodePen.astro
@@ -29,8 +29,8 @@ const js = outdent`
     `@itwin/itwinui-illustrations-react`,
     `https://esm.sh/@itwin/itwinui-illustrations-react@2`,
   )
-  .replaceAll(`'react'`, `'https://esm.sh/react@18'`)
-  .replaceAll(`react-dom`, `https://esm.sh/react-dom@18`);
+  .replaceAll(`'react'`, `'https://esm.sh/react@19'`)
+  .replaceAll(`react-dom`, `https://esm.sh/react-dom@19`);
 const html = '<body style="margin: 0"></body>';
 ---
 


### PR DESCRIPTION
## Changes

This fixes the broken CodePen demos by updating the React version to 19. This was made possible by the recent release (#2417).

**Explanation**: After some investigation, I found that the issue was that CodePen was somehow loading two different versions of React. This might have been caused by the https://esm.sh CDN using the latest compatible React version for dependencies, or due to CodePen (being a browser-based tool) not correctly resolving "peer dependencies", or a combination of both. Either way, switching to React 19 makes it work correctly.

## Testing

Verified that the CodePen demos render correctly, both locally and in the deploy preview. No more console errors.

## Docs

N/A
