### PR TITLE
remove legacy v1 layer

### DIFF
--- a/.changeset/young-hornets-end.md
+++ b/.changeset/young-hornets-end.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Removed a leftover `@layer` name, which was originally intended to support _very_ old versions of iTwinUI.

--- a/packages/itwinui-react/src/styles.js/styles.module.css
+++ b/packages/itwinui-react/src/styles.js/styles.module.css
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@layer reset, itwinui-v1, itwinui.v1, itwinui.v2;
+@layer reset, itwinui.v1, itwinui.v2;
 
 @import '@itwin/itwinui-variables' layer(itwinui.foundations.v3);
 @import '@itwin/itwinui-css';


### PR DESCRIPTION
## Changes

This is a follow-up to #2438. After testing the latest release of theme bridge, I found an issue if the consuming application sets up their own layer order (as [documented](https://github.com/iTwin/iTwinUI/wiki/Styling)). The `itwinui-v1` layer gets added _after_ the `itwinui` layer (because the `itwinui` layer was already defined by the application). This defeats the whole purpose of including it in our layer order, so this PR removes the `itwinui-v1` layer.

### Context

Originally, this legacy layer name was included to [support older codebases](https://github.com/iTwin/iTwinUI/pull/1412#discussion_r1263716496). The last v1 patch version renames `itwinui-v1` to `itwinui.v1` (see https://github.com/iTwin/iTwinUI/pull/1423), so everything should work correctly if applications are on the last patch.  Beyond that, there is not much point going out of our way to support older v1 patches, because v2 and v3 have been available for a very long time.

## Testing

N/A.

## Docs

Added `patch` changeset.