### PR TITLE
Fix menu background color in theme bridge

### DIFF
--- a/.changeset/eager-numbers-return.md
+++ b/.changeset/eager-numbers-return.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed background color in menus when the [theme bridge](https://github.com/iTwin/iTwinUI/wiki/iTwinUI-v5-theme-bridge) is enabled.

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -205,7 +205,7 @@
 
   .iui-menu {
     // v5 uses different surface colors for the dropdowns
-    background-color: var(--ids-color-bg-elevation-elevation-level-1);
+    background-color: var(--ids-color-bg-elevation-level-1);
 
     // v5 uses box shadow only
     border: none;


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes a typo (https://github.com/iTwin/iTwinUI/pull/2436#discussion_r1962123797) in one of the variable names in the theme bridge's `bridge.scss`:

```diff
- --ids-color-bg-elevation-elevation-level-1
+ --ids-color-bg-elevation-level-1
```

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that the background color no longer gives a the following error: "--ids-color-bg-elevation-elevation-level-1 is not defined".

Also confirmed visually that the variable is applied:

|Before|After|
|-|-|
|<img width="101" alt="image" src="https://github.com/user-attachments/assets/0dfc701d-6e07-4ea1-853c-fb20e2dadb51" />|<img width="101" alt="image" src="https://github.com/user-attachments/assets/a13985b0-2dd6-42d2-866c-4eae665606ad" />|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added a changeset