### PR TITLE
fixed cursor bug when disabled

### DIFF
--- a/.changeset/olive-taxes-sniff.md
+++ b/.changeset/olive-taxes-sniff.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed bug in `ExpandableBlock` where cursor was `pointer` even when it was disabled.

--- a/.changeset/weak-impalas-own.md
+++ b/.changeset/weak-impalas-own.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Fixed bug in `.iui-button-base` where cursor was `pointer` even when it was disabled.

--- a/packages/itwinui-css/src/expandable-block/expandable-block.scss
+++ b/packages/itwinui-css/src/expandable-block/expandable-block.scss
@@ -100,7 +100,7 @@
     --_iui-expandable-block-header-caption-color: var(--iui-color-text-disabled);
     --_iui-expandable-block-header-label-color: var(--iui-color-text-disabled);
 
-    cursor: not-allowed;
+    pointer-events: none;
     background-color: var(--_iui-expandable-block-header-background-color-disabled);
     border-color: var(--iui-color-border-disabled);
 
@@ -141,6 +141,11 @@
   transition: color var(--iui-duration-1) ease;
   @media (forced-colors: active) {
     transition: none;
+  }
+
+  &:is([disabled], :disabled, [aria-disabled='true'], [data-iui-disabled='true']) {
+    cursor: not-allowed;
+    pointer-events: auto;
   }
 }
 

--- a/packages/itwinui-css/src/expandable-block/expandable-block.scss
+++ b/packages/itwinui-css/src/expandable-block/expandable-block.scss
@@ -142,10 +142,6 @@
   @media (forced-colors: active) {
     transition: none;
   }
-
-  &:is([disabled], :disabled, [aria-disabled='true'], [data-iui-disabled='true']) {
-    cursor: not-allowed;
-  }
 }
 
 .iui-expandable-block-caption {

--- a/packages/itwinui-css/src/expandable-block/expandable-block.scss
+++ b/packages/itwinui-css/src/expandable-block/expandable-block.scss
@@ -100,7 +100,7 @@
     --_iui-expandable-block-header-caption-color: var(--iui-color-text-disabled);
     --_iui-expandable-block-header-label-color: var(--iui-color-text-disabled);
 
-    pointer-events: none;
+    cursor: not-allowed;
     background-color: var(--_iui-expandable-block-header-background-color-disabled);
     border-color: var(--iui-color-border-disabled);
 
@@ -145,7 +145,6 @@
 
   &:is([disabled], :disabled, [aria-disabled='true'], [data-iui-disabled='true']) {
     cursor: not-allowed;
-    pointer-events: auto;
   }
 }
 

--- a/packages/itwinui-css/src/utils/button-base.scss
+++ b/packages/itwinui-css/src/utils/button-base.scss
@@ -8,4 +8,8 @@
   padding: 0;
   touch-action: manipulation;
   cursor: pointer;
+
+  &:is([disabled], :disabled, [aria-disabled='true'], [data-iui-disabled='true']) {
+    cursor: not-allowed;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes #2454.

A user reported a bug regarding the cursor behavior specifically for disabled expandable blocks. While the intended behavior of the cursor is `not allowed` when hovering over a disabled expandable block, it remained a `pointer`.

This PR addresses and fixes this bug.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

N/A

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A
