### PR TITLE
don't flush shadow-roots in `Table`

### DIFF
--- a/.changeset/tender-women-train.md
+++ b/.changeset/tender-women-train.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed a "Maximum update depth exceeded" error in `Table`.

--- a/packages/itwinui-css/src/utils/line-clamp.scss
+++ b/packages/itwinui-css/src/utils/line-clamp.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+// See LICENSE.md in the project root for license terms and full copyright notice.
+@use '../mixins';
+
+:where(.iui-line-clamp) {
+  @include mixins.iui-line-clamp(var(--_iui-line-clamp, 3));
+}

--- a/packages/itwinui-css/src/utils/utils.scss
+++ b/packages/itwinui-css/src/utils/utils.scss
@@ -7,3 +7,4 @@
 @forward 'flex';
 @forward 'visually-hidden';
 @forward 'link-action';
+@forward 'line-clamp';

--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -134,18 +134,16 @@ export const ColumnHeader = React.forwardRef((props, forwardedRef) => {
       }}
     >
       <>
-        <ShadowRoot>
-          {typeof column.Header === 'string' ? (
+        {typeof column.Header === 'string' ? (
+          <ShadowRoot>
             <LineClamp>
               <slot />
             </LineClamp>
-          ) : (
-            <slot />
-          )}
-          <slot name='actions' />
-          <slot name='resizers' />
-          <slot name='shadows' />
-        </ShadowRoot>
+            <slot name='actions' />
+            <slot name='resizers' />
+            <slot name='shadows' />
+          </ShadowRoot>
+        ) : null}
 
         {column.render('Header')}
         {(showFilterButton(column) || showSortButton(column)) && (

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -4086,7 +4086,5 @@ it('should not apply clamp, if custom Cell is used', () => {
     data,
   });
   const host = container.querySelector('.test-cell');
-  expect(host?.shadowRoot).toBeTruthy();
-  const lineClamp = host?.shadowRoot?.querySelector('div');
-  expect(lineClamp).toBeNull();
+  expect(host?.shadowRoot).toBeFalsy();
 });

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -1085,7 +1085,7 @@ export const Table = <
             (isSelectable && selectionMode === 'multi') || undefined
           }
         >
-          <ShadowRoot css={virtualizerCss}>
+          <ShadowRoot css={virtualizerCss} flush={false}>
             {enableVirtualization && data.length !== 0 ? (
               <div
                 data-iui-virtualizer='root'

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -84,7 +84,7 @@ export const DefaultCell = <T extends Record<string, unknown>>(
       data-iui-status={status}
       style={{ ...cellElementStyle, ...style }}
     >
-      <ShadowRoot key={`${cellElementKey}-shadow-root`}>
+      <ShadowRoot key={`${cellElementKey}-shadow-root`} flush={false}>
         <slot name='start' key={`${cellElementKey}-shadow-root-start`} />
         {clamp ? (
           <LineClamp key={`${cellElementKey}-shadow-root-slot`}>

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -84,18 +84,16 @@ export const DefaultCell = <T extends Record<string, unknown>>(
       data-iui-status={status}
       style={{ ...cellElementStyle, ...style }}
     >
-      <ShadowRoot key={`${cellElementKey}-shadow-root`} flush={false}>
-        <slot name='start' key={`${cellElementKey}-shadow-root-start`} />
-        {clamp ? (
-          <LineClamp key={`${cellElementKey}-shadow-root-slot`}>
+      {clamp ? (
+        <ShadowRoot key={`${cellElementKey}-shadow-root`} flush={false}>
+          <slot name='start' />
+          <LineClamp>
             <slot />
           </LineClamp>
-        ) : (
-          <slot key={`${cellElementKey}-shadow-root-slot`} />
-        )}
-        <slot name='end' key={`${cellElementKey}-shadow-root-end`} />
-        <slot name='shadows' key={`${cellElementKey}-shadow-root-shadows`} />
-      </ShadowRoot>
+          <slot name='end' />
+          <slot name='shadows' />
+        </ShadowRoot>
+      ) : null}
 
       {startIcon && (
         <Box

--- a/packages/itwinui-react/src/utils/components/LineClamp.tsx
+++ b/packages/itwinui-react/src/utils/components/LineClamp.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import cx from 'classnames';
 import type { PolymorphicForwardRefComponent } from '../props.js';
 import { Box } from './Box.js';
 import { ShadowRoot } from './ShadowRoot.js';
@@ -14,11 +15,12 @@ export const LineClamp = React.forwardRef((props, forwardedRef) => {
     <Box
       ref={forwardedRef}
       {...rest}
+      className={cx('iui-line-clamp', props.className)}
       style={
         { '--_iui-line-clamp': lines, ...props.style } as React.CSSProperties
       }
     >
-      <ShadowRoot css={css}>
+      <ShadowRoot css={css} flush={false}>
         <slot />
       </ShadowRoot>
       {children}


### PR DESCRIPTION
## Changes

This PR started as an attempt to address #2444. After some investigation, I found that the one of issues was the use of [`flushSync`](https://react.dev/reference/react-dom/flushSync) in `ShadowRoot` (which gets rendered by every `DefaultCell`). Since a Table can have many cells, this ends up blocking the main thread for a long period, eventually leading to React throwing a "max depth" error. Removing the `flushSync` call allows React to yield to the browser in between rendering different components.

`flushSync` was previously added as a default to ensure that the content gets rendered as soon as the shadow-root is attached. This PR makes this behavior configurable so that it can be turned off for special cases like the `DefaultCell` where the performance cost outweighs the benefits of synchronous layout.

## Testing

Recreated the sandbox from #2444 in vite playground and manually tested using Chrome Dev Tools. I noticed improved INP using Chrome's profiler, though the experience was still not great (i.e. main thread still blocked https://github.com/iTwin/iTwinUI/pull/2462#discussion_r1985767321). It did fix the "max depth" error.

## Docs

Added `patch` changeset.