### PR TITLE
make `SideNavigation` render a `<nav>` landmark

### DIFF
--- a/.changeset/plain-grapes-say.md
+++ b/.changeset/plain-grapes-say.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`<SideNavigation>` now renders a `<nav>` as the topmost element. This creates a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html) for assistive technology.

--- a/apps/css-workshop/src/pages/side-navigation.astro
+++ b/apps/css-workshop/src/pages/side-navigation.astro
@@ -50,7 +50,7 @@ import IconButton_ from '../components/IconButton.astro';
 
   <h2>Default</h2>
   <section id='demo-side-navigation'>
-    <div class='iui-side-navigation iui-collapsed' id='demo-sidenav-container'>
+    <nav class='iui-side-navigation iui-collapsed' id='demo-sidenav-container'>
       <!-- Expand arrow -->
       <IconButton_
         class='iui-sidenav-button iui-expand'
@@ -166,14 +166,14 @@ import IconButton_ from '../components/IconButton.astro';
           <span class='iui-tooltip' style='margin-bottom: 10px;'>Administration</span>
         </div>
       </div>
-    </div>
+    </nav>
   </section>
 
   <br /><br />
 
   <h3>With submenu open</h3>
   <section id='demo-side-navigation-submenu'>
-    <div class='iui-side-navigation-wrapper'>
+    <nav class='iui-side-navigation-wrapper'>
       <div class='iui-side-navigation iui-collapsed' id='demo-sidenav-container'>
         <!-- Rest of the tabs -->
         <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
@@ -323,14 +323,14 @@ import IconButton_ from '../components/IconButton.astro';
           </ul>
         </div>
       </div>
-    </div>
+    </nav>
   </section>
 
   <br /><br />
 
   <h3>With submenu open & active</h3>
   <section id='demo-side-navigation-submenu-active'>
-    <div class='iui-side-navigation-wrapper'>
+    <nav class='iui-side-navigation-wrapper'>
       <div class='iui-side-navigation iui-collapsed' id='demo-sidenav-container'>
         <!-- Rest of the tabs -->
         <div class='iui-sidenav-content' role='tablist' aria-label='Applications'>
@@ -480,7 +480,7 @@ import IconButton_ from '../components/IconButton.astro';
           </ul>
         </div>
       </div>
-    </div>
+    </nav>
   </section>
 
   <script is:inline>

--- a/apps/website/src/content/docs/sidenavigation.mdx
+++ b/apps/website/src/content/docs/sidenavigation.mdx
@@ -40,7 +40,9 @@ The submenu is the menu that expands when one of the menu items is clicked. It c
 
 ## Accessibility
 
-`<SideNavigation>` is rendered as a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html) (using the `<nav>` HTML element). It can be optionally labelled using `wrapperProps['aria-labelledby']` or `wrapperProps['aria-label']`.
+`<SideNavigation>` is rendered as a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html) (using the `<nav>` HTML element). In conjunction with other landmarks, this helps assistive technology users to quickly navigate between different parts of the page.
+
+This can be optionally labelled using `wrapperProps['aria-labelledby']` or `wrapperProps['aria-label']` to help distinguish it from other navigation landmarks on the page.
 
 ## Props
 

--- a/apps/website/src/content/docs/sidenavigation.mdx
+++ b/apps/website/src/content/docs/sidenavigation.mdx
@@ -38,6 +38,10 @@ The submenu is the menu that expands when one of the menu items is clicked. It c
   <AllExamples.SideNavigationSubmenuExample client:load />
 </LiveExample>
 
+## Accessibility
+
+`<SideNavigation>` is rendered as a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html) (using the `<nav>` HTML element). It can be optionally labelled using `wrapperProps['aria-labelledby']` or `wrapperProps['aria-label']`.
+
 ## Props
 
 <PropsTable path='@itwin/itwinui-react/esm/core/SideNavigation/SideNavigation.d.ts' />

--- a/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
+++ b/packages/itwinui-react/src/core/SideNavigation/SideNavigation.tsx
@@ -69,7 +69,7 @@ type SideNavigationProps = {
   /**
    * Passes props for SideNav wrapper.
    */
-  wrapperProps?: React.ComponentProps<'div'>;
+  wrapperProps?: React.ComponentProps<'nav'>;
   /**
    * Passes props for SideNav content.
    */
@@ -86,6 +86,10 @@ type SideNavigationProps = {
 
 /**
  * Left side navigation menu component.
+ *
+ * Renders a `<nav>` landmark, which can be labelled using `wrapperProps['aria-labelledby']`
+ * or `wrapperProps['aria-label']`.
+ *
  * @example
  * <SideNavigation
  *   items={[
@@ -135,13 +139,13 @@ export const SideNavigation = React.forwardRef((props, forwardedRef) => {
   return (
     <SidenavExpandedContext.Provider value={isExpanded}>
       <Box
+        as='nav'
         {...wrapperProps}
         className={cx('iui-side-navigation-wrapper', wrapperProps?.className)}
         ref={forwardedRef}
       >
         <FloatingDelayGroup delay={defaultTooltipDelay}>
           <Box
-            as='div'
             className={cx(
               'iui-side-navigation',
               {


### PR DESCRIPTION
## Changes

This changes the `<SideNavigation>` component to render a `<nav>` element (instead of `<div>`), which creates a [navigation landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/navigation.html).

## Testing

All existing tests pass.

Manually verified that `<nav>` is being rendered in stories and examples.

## Docs

Added `minor` changeset.

Updated JSDocs and `/sidenavigation` docs page to mention the landmark. Since navigation landmarks should be uniquely labelled, I added a mention of how to do that.