### PR TITLE
add `closeOnItemClick` prop to `DropdownMenu`

### DIFF
--- a/.changeset/fifty-monkeys-argue.md
+++ b/.changeset/fifty-monkeys-argue.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added a new `closeItemOnClick` prop to `<DropdownMenu>`. When set to `true`, the menu will automatically close when any menu-item is clicked, without having to explicitly call `close()`.

--- a/apps/react-workshop/src/DropdownMenu.stories.tsx
+++ b/apps/react-workshop/src/DropdownMenu.stories.tsx
@@ -26,23 +26,22 @@ export default {
 };
 
 export const Basic = () => {
-  const onClick = (index: number, close: () => void) => () => {
+  const handleItemClick = (index: number) => () => {
     console.log(`Item #${index} clicked!`);
-    close();
   };
-  const dropdownMenuItems = (close: () => void) => [
-    <MenuItem key={1} onClick={onClick(1, close)}>
-      Item #1
-    </MenuItem>,
-    <MenuItem key={2} onClick={onClick(2, close)}>
-      Item #2
-    </MenuItem>,
-    <MenuItem key={3} onClick={onClick(3, close)} disabled>
-      Item #3
-    </MenuItem>,
-  ];
   return (
-    <DropdownMenu menuItems={dropdownMenuItems}>
+    <DropdownMenu
+      closeOnItemClick
+      menuItems={
+        <>
+          <MenuItem onClick={handleItemClick(1)}>Item #1</MenuItem>
+          <MenuItem onClick={handleItemClick(2)}>Item #2</MenuItem>
+          <MenuItem onClick={handleItemClick(3)} disabled>
+            Item #3
+          </MenuItem>
+        </>
+      }
+    >
       <IconButton label='More options'>
         <SvgMore />
       </IconButton>

--- a/apps/website/src/content/docs/dropdownmenu.mdx
+++ b/apps/website/src/content/docs/dropdownmenu.mdx
@@ -26,6 +26,8 @@ The basic dropdown menu displays a list of clickable options when expanded. Addi
   <AllExamples.DropdownMenuBasicExample client:load />
 </LiveExample>
 
+The `closeOnItemClick` prop can be set to `true` if you want to automatically close the menu when an item is clicked.
+
 ### Start icon
 
 An icon may be display on the left side of option for better visualization of common menu items.

--- a/examples/DropdownMenu.basic.jsx
+++ b/examples/DropdownMenu.basic.jsx
@@ -7,22 +7,19 @@ import { MenuItem, DropdownMenu, IconButton } from '@itwin/itwinui-react';
 import { SvgMore } from '@itwin/itwinui-icons-react';
 
 export default () => {
-  const dropdownMenuItems = (close) => [
-    <MenuItem key={1} onClick={() => close()}>
-      Item #1
-    </MenuItem>,
-    <MenuItem key={2} onClick={() => close()}>
-      Item #2
-    </MenuItem>,
-    <MenuItem key={3} onClick={() => close()} disabled>
-      Item #3
-    </MenuItem>,
-  ];
-
   return (
     <>
-      <DropdownMenu menuItems={dropdownMenuItems}>
-        <IconButton aria-label='More options'>
+      <DropdownMenu
+        closeOnItemClick
+        menuItems={
+          <>
+            <MenuItem>Item #1</MenuItem>
+            <MenuItem>Item #2</MenuItem>
+            <MenuItem disabled>Item #3</MenuItem>
+          </>
+        }
+      >
+        <IconButton label='More options'>
           <SvgMore />
         </IconButton>
       </DropdownMenu>

--- a/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
+++ b/packages/itwinui-react/src/core/DropdownMenu/DropdownMenu.tsx
@@ -41,6 +41,11 @@ export type DropdownMenuProps = {
   middleware?: {
     hide?: boolean;
   };
+  /**
+   * If `true`, closes the `DropdownMenu` when any descendant `MenuItem` is clicked.
+   * @default false
+   */
+  closeOnItemClick?: boolean;
 } & Pick<
   Parameters<typeof usePopover>[0],
   'visible' | 'onVisibleChange' | 'placement' | 'matchWidth'
@@ -90,6 +95,7 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
     onVisibleChange,
     portal = true,
     middleware,
+    closeOnItemClick = false,
     ...rest
   } = props;
 
@@ -113,35 +119,37 @@ const DropdownMenuContent = React.forwardRef((props, forwardedRef) => {
   const dropdownMenuContextValue = React.useMemo(() => ({ close }), [close]);
 
   return (
-    <DropdownMenuContext.Provider value={dropdownMenuContextValue}>
-      <Menu
-        trigger={children}
-        onKeyDown={mergeEventHandlers(props.onKeyDown, (e) => {
-          if (e.defaultPrevented) {
-            return;
-          }
-          if (e.key === 'Tab') {
-            setVisible(false);
-          }
-        })}
-        role={role}
-        ref={forwardedRef}
-        portal={portal}
-        popoverProps={React.useMemo(
-          () => ({
-            placement,
-            matchWidth,
-            visible,
-            onVisibleChange: setVisible,
-            middleware,
-          }),
-          [matchWidth, middleware, placement, setVisible, visible],
-        )}
-        {...rest}
-      >
-        {menuContent}
-      </Menu>
-    </DropdownMenuContext.Provider>
+    <DropdownMenuCloseOnClickContext.Provider value={closeOnItemClick}>
+      <DropdownMenuContext.Provider value={dropdownMenuContextValue}>
+        <Menu
+          trigger={children}
+          onKeyDown={mergeEventHandlers(props.onKeyDown, (e) => {
+            if (e.defaultPrevented) {
+              return;
+            }
+            if (e.key === 'Tab') {
+              setVisible(false);
+            }
+          })}
+          role={role}
+          ref={forwardedRef}
+          portal={portal}
+          popoverProps={React.useMemo(
+            () => ({
+              placement,
+              matchWidth,
+              visible,
+              onVisibleChange: setVisible,
+              middleware,
+            }),
+            [matchWidth, middleware, placement, setVisible, visible],
+          )}
+          {...rest}
+        >
+          {menuContent}
+        </Menu>
+      </DropdownMenuContext.Provider>
+    </DropdownMenuCloseOnClickContext.Provider>
   );
 }) as PolymorphicForwardRefComponent<'div', DropdownMenuProps>;
 

--- a/packages/itwinui-react/src/core/Tile/Tile.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.tsx
@@ -15,10 +15,7 @@ import {
   Box,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
-import {
-  DropdownMenu,
-  DropdownMenuCloseOnClickContext,
-} from '../DropdownMenu/DropdownMenu.js';
+import { DropdownMenu } from '../DropdownMenu/DropdownMenu.js';
 import { IconButton } from '../Buttons/IconButton.js';
 import { ProgressRadial } from '../ProgressIndicators/ProgressRadial.js';
 import { LinkAction } from '../LinkAction/LinkAction.js';
@@ -387,33 +384,32 @@ const TileMoreOptions = React.forwardRef((props, forwardedRef) => {
   const [isMenuVisible, setIsMenuVisible] = React.useState(false);
 
   return (
-    <DropdownMenuCloseOnClickContext.Provider value={true}>
-      <Box
-        className={cx(
-          'iui-tile-more-options',
-          {
-            'iui-visible': isMenuVisible,
-          },
-          className,
-        )}
-        ref={forwardedRef}
-        {...rest}
+    <Box
+      className={cx(
+        'iui-tile-more-options',
+        {
+          'iui-visible': isMenuVisible,
+        },
+        className,
+      )}
+      ref={forwardedRef}
+      {...rest}
+    >
+      <DropdownMenu
+        onVisibleChange={setIsMenuVisible}
+        menuItems={children as React.ReactElement<any>[]}
+        closeOnItemClick
       >
-        <DropdownMenu
-          onVisibleChange={setIsMenuVisible}
-          menuItems={children as React.ReactElement<any>[]}
+        <IconButton
+          styleType='borderless'
+          size='small'
+          aria-label='More options'
+          {...buttonProps}
         >
-          <IconButton
-            styleType='borderless'
-            size='small'
-            aria-label='More options'
-            {...buttonProps}
-          >
-            <SvgMore />
-          </IconButton>
-        </DropdownMenu>
-      </Box>
-    </DropdownMenuCloseOnClickContext.Provider>
+          <SvgMore />
+        </IconButton>
+      </DropdownMenu>
+    </Box>
   );
 }) as PolymorphicForwardRefComponent<'div', TileMoreOptionsOwnProps>;
 if (process.env.NODE_ENV === 'development') {

--- a/testing/e2e/app/routes/DropdownMenu/route.tsx
+++ b/testing/e2e/app/routes/DropdownMenu/route.tsx
@@ -16,28 +16,47 @@ import { SvgMore } from '@itwin/itwinui-icons-react';
 export default () => {
   const [searchParams] = useSearchParams();
 
-  const menuType = (searchParams.get('menuType') || 'withSubmenu') as
+  const menuType = searchParams.get('menuType') as
     | 'withSubmenu'
     | 'withHideMiddleware'
-    | 'withExtraContent';
+    | 'withExtraContent'
+    | undefined;
   const hideMiddleware =
     searchParams.get('hideMiddleware') === 'false' ? false : undefined;
+  const closeOnItemClick = searchParams.get('closeOnItemClick') === 'true';
 
-  return (
-    <>
-      {menuType === 'withExtraContent' ? (
-        <DropdownMenuWithExtraContent />
-      ) : menuType === 'withHideMiddleware' ? (
-        <DropdownMenuHideMiddleware hideMiddleware={hideMiddleware} />
-      ) : (
-        <DropdownMenuWithSubmenus />
-      )}
-      <div data-testid='outside'>Outside</div>
-    </>
-  );
+  if (menuType === 'withSubmenu') {
+    return <DropdownMenuWithSubmenus />;
+  }
+  if (menuType === 'withHideMiddleware') {
+    return <DropdownMenuHideMiddleware hideMiddleware={hideMiddleware} />;
+  }
+  if (menuType === 'withExtraContent') {
+    return <DropdownMenuWithExtraContent />;
+  }
+  return <DropdownMenuBasic closeOnItemClick={closeOnItemClick} />;
 };
 
 // ----------------------------------------------------------------------------
+
+const DropdownMenuBasic = ({ closeOnItemClick = false }) => {
+  return (
+    <DropdownMenu
+      closeOnItemClick={closeOnItemClick}
+      menuItems={
+        <>
+          <MenuItem>Item #1</MenuItem>
+          <MenuItem>Item #2</MenuItem>
+          <MenuItem disabled>Item #3</MenuItem>
+        </>
+      }
+    >
+      <IconButton label='More'>
+        <SvgMore />
+      </IconButton>
+    </DropdownMenu>
+  );
+};
 
 const DropdownMenuWithSubmenus = () => {
   return (

--- a/testing/e2e/app/routes/DropdownMenu/spec.ts
+++ b/testing/e2e/app/routes/DropdownMenu/spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page } from '@playwright/test';
 
 test.describe('DropdownMenu', () => {
   test('should render menu items', async ({ page }) => {
-    await page.goto('/DropdownMenu');
+    await page.goto('/DropdownMenu?menuType=withSubmenu');
 
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
@@ -16,7 +16,7 @@ test.describe('DropdownMenu', () => {
   });
 
   test('should support deep level submenus', async ({ page }) => {
-    await page.goto('/DropdownMenu');
+    await page.goto('/DropdownMenu?menuType=withSubmenu');
 
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
@@ -161,7 +161,7 @@ test.describe('DropdownMenu', () => {
   });
 
   test('should respect the click trigger', async ({ page }) => {
-    await page.goto('/DropdownMenu');
+    await page.goto('/DropdownMenu?menuType=withSubmenu');
 
     // open the whole menu
     const trigger = page.getByTestId('trigger');
@@ -183,8 +183,7 @@ test.describe('DropdownMenu', () => {
     await expect(page.getByTestId('Item 2_1')).toBeVisible();
 
     // click outside to close
-    const outside = page.getByTestId('outside');
-    await outside.click();
+    await page.locator('body').click();
     await expect(page.getByTestId('Item 1_1')).toBeHidden();
 
     // click again to open whole menu
@@ -194,7 +193,7 @@ test.describe('DropdownMenu', () => {
   });
 
   test('should respect the keyboard enter/space triggers', async ({ page }) => {
-    await page.goto('/DropdownMenu');
+    await page.goto('/DropdownMenu?menuType=withSubmenu');
 
     // open the whole menu (using Enter)
     await page.keyboard.press('Tab');
@@ -234,7 +233,7 @@ test.describe('DropdownMenu', () => {
       await page.keyboard.press('ArrowRight', { delay: 30 });
     };
 
-    await page.goto('/DropdownMenu');
+    await page.goto('/DropdownMenu?menuType=withSubmenu');
 
     await page.keyboard.press('Tab');
     await page.keyboard.press('Enter');
@@ -310,6 +309,29 @@ test.describe('DropdownMenu', () => {
     await page.locator('button').nth(10).scrollIntoViewIfNeeded();
 
     await expect(page.getByRole('menu')).toHaveCount(1);
+  });
+
+  test('should support closeOnItemClick prop', async ({ page }) => {
+    await page.goto('/DropdownMenu?closeOnItemClick=true');
+
+    const trigger = page.getByRole('button', { name: 'More' });
+    const menu = page.getByRole('menu');
+
+    // open
+    await trigger.click();
+    await expect(menu).toBeVisible();
+
+    // click on item => close
+    await page.getByRole('menuitem', { name: 'Item #1' }).click();
+    await expect(menu).not.toBeVisible();
+
+    // click on disabled item => do not close
+    await trigger.click();
+    await expect(menu).toBeVisible();
+    await page
+      .getByRole('menuitem', { name: 'Item #3' })
+      .click({ force: true });
+    await expect(menu).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Changes

This builds upon #2452 to make the same functionality available as a new `closeOnItemClick` prop on `<DropdownMenu>`. The name is bikesheddable.

`<Tile.MoreOptions>` now directly sets this prop instead of using Context.

This prop currently defaults to `false` (to keep existing behavior) but should probably default to true in the future, because menus should almost always close when clicking an item. This also improves the DX slightly, as `menuItems` can now be a simple React fragment instead of a callback which accepts the `close()` function.

## Testing

Added e2e test for this prop and updated Basic story to use this prop.

## Docs

Updated Basic example to use this prop, and added a small note at the beginning of `/dropdownmenu` docs to mention this prop.

Added `minor` changeset.