### PR TITLE
override portal container in `Dialog` and `Popover`

### DIFF
--- a/.changeset/better-ears-accept.md
+++ b/.changeset/better-ears-accept.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `toaster` where toasts was portaling into a new container when used inside `<Popover>`. With this change, the global toaster container will be correctly reused.

--- a/.changeset/free-lemons-laugh.md
+++ b/.changeset/free-lemons-laugh.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`Dialog`, `Modal` and `Popover` will now correctly handle portaling of nested floating elements.

--- a/packages/itwinui-react/src/core/Dialog/Dialog.tsx
+++ b/packages/itwinui-react/src/core/Dialog/Dialog.tsx
@@ -11,7 +11,12 @@ import { DialogContext } from './DialogContext.js';
 import type { DialogContextProps } from './DialogContext.js';
 import { DialogButtonBar } from './DialogButtonBar.js';
 import { DialogMain } from './DialogMain.js';
-import { useMergedRefs, Box, Portal } from '../../utils/index.js';
+import {
+  useMergedRefs,
+  Box,
+  Portal,
+  PortalContainerContext,
+} from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 
 type DialogProps = {
@@ -41,7 +46,10 @@ const DialogComponent = React.forwardRef((props, ref) => {
   } = props;
 
   const dialogRootRef = React.useRef<HTMLDivElement>(null);
-  const mergedRefs = useMergedRefs(ref, dialogRootRef);
+  const [dialogElement, setDialogElement] = React.useState<HTMLElement | null>(
+    null,
+  );
+  const mergedRefs = useMergedRefs(ref, dialogRootRef, setDialogElement);
 
   return isOpen ? (
     <DialogContext.Provider
@@ -61,12 +69,14 @@ const DialogComponent = React.forwardRef((props, ref) => {
       }}
     >
       <Portal portal={portal}>
-        <Box
-          className={cx('iui-dialog-wrapper', className)}
-          data-iui-relative={relativeTo === 'container'}
-          ref={mergedRefs}
-          {...rest}
-        />
+        <PortalContainerContext.Provider value={dialogElement}>
+          <Box
+            className={cx('iui-dialog-wrapper', className)}
+            data-iui-relative={relativeTo === 'container'}
+            ref={mergedRefs}
+            {...rest}
+          />
+        </PortalContainerContext.Provider>
       </Portal>
     </DialogContext.Provider>
   ) : null;

--- a/packages/itwinui-react/src/core/Popover/Popover.tsx
+++ b/packages/itwinui-react/src/core/Popover/Popover.tsx
@@ -47,7 +47,10 @@ import {
   useMergedRefs,
 } from '../../utils/index.js';
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
-import { usePortalTo } from '../../utils/components/Portal.js';
+import {
+  PortalContainerContext,
+  usePortalTo,
+} from '../../utils/components/Portal.js';
 import type { PortalProps } from '../../utils/components/Portal.js';
 import { ThemeProvider } from '../ThemeProvider/ThemeProvider.js';
 
@@ -431,7 +434,8 @@ export const Popover = React.forwardRef((props, forwardedRef) => {
     middleware,
   });
 
-  const [popoverElement, setPopoverElement] = React.useState<HTMLElement>();
+  const [popoverElement, setPopoverElement] =
+    React.useState<HTMLElement | null>(null);
 
   const popoverRef = useMergedRefs(
     popover.refs.setFloating,
@@ -469,31 +473,31 @@ export const Popover = React.forwardRef((props, forwardedRef) => {
       {popover.open ? (
         <PopoverInitialFocusContext.Provider value={initialFocusContextValue}>
           <PopoverPortal portal={portal}>
-            <ThemeProvider
-              portalContainer={popoverElement} // portal nested popovers into this one
-            >
-              <DisplayContents />
-              <FloatingFocusManager
-                context={popover.context}
-                modal={false}
-                initialFocus={initialFocus}
-              >
-                <Box
-                  className={cx(
-                    { 'iui-popover-surface': applyBackground },
-                    className,
-                  )}
-                  aria-labelledby={
-                    !hasAriaLabel
-                      ? popover.refs.domReference.current?.id
-                      : undefined
-                  }
-                  {...popover.getFloatingProps(rest)}
-                  ref={popoverRef}
+            <ThemeProvider>
+              <PortalContainerContext.Provider value={popoverElement}>
+                <DisplayContents />
+                <FloatingFocusManager
+                  context={popover.context}
+                  modal={false}
+                  initialFocus={initialFocus}
                 >
-                  {content}
-                </Box>
-              </FloatingFocusManager>
+                  <Box
+                    className={cx(
+                      { 'iui-popover-surface': applyBackground },
+                      className,
+                    )}
+                    aria-labelledby={
+                      !hasAriaLabel
+                        ? popover.refs.domReference.current?.id
+                        : undefined
+                    }
+                    {...popover.getFloatingProps(rest)}
+                    ref={popoverRef}
+                  >
+                    {content}
+                  </Box>
+                </FloatingFocusManager>
+              </PortalContainerContext.Provider>
             </ThemeProvider>
           </PopoverPortal>
         </PopoverInitialFocusContext.Provider>

--- a/testing/e2e/app/routes/Toaster/route.tsx
+++ b/testing/e2e/app/routes/Toaster/route.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useSearchParams } from '@remix-run/react';
-import { ThemeProvider, useToaster } from '@itwin/itwinui-react';
+import { Popover, ThemeProvider, useToaster } from '@itwin/itwinui-react';
 
 export default function Page() {
   const [searchParams] = useSearchParams();
@@ -10,6 +10,10 @@ export default function Page() {
   return (
     <>
       <Toast text='Toast (root)' />
+
+      <Popover content={<PopoverContent toastText='Toast (popover)' />}>
+        <button>Show popover</button>
+      </Popover>
 
       <ThemeProvider data-container='nested'>
         <Toast text='Toast (nested)' />
@@ -32,6 +36,22 @@ function Toast({ text = 'Toast' }) {
   }, [toaster]);
 
   return null;
+}
+
+function PopoverContent({ toastText = 'Toast' }) {
+  const toaster = useToaster();
+
+  return (
+    <>
+      <button
+        onClick={() => {
+          toaster.informational(toastText, { type: 'persisting' });
+        }}
+      >
+        Show toast
+      </button>
+    </>
+  );
 }
 
 function useIsClient() {

--- a/testing/e2e/app/routes/Toaster/spec.ts
+++ b/testing/e2e/app/routes/Toaster/spec.ts
@@ -1,18 +1,39 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Toaster', () => {
-  test('should not create nested toast containers', async ({ page }) => {
-    await page.goto('/Toaster');
+  test.describe('should not create nested toast containers', () => {
+    test('inside ThemeProvider', async ({ page }) => {
+      await page.goto('/Toaster');
+      const rootToast = page.getByText('Toast (root)');
+      await expect(rootToast).toBeVisible();
 
-    const rootToast = page.getByText('Toast (root)');
-    await expect(rootToast).toBeVisible();
+      const nestedToast = page.getByText('Toast (nested)');
+      await expect(nestedToast).toBeVisible();
 
-    const nestedToast = page.getByText('Toast (nested)');
-    await expect(nestedToast).toBeVisible();
+      await expect(page.locator('[data-container="nested"]')).not.toContainText(
+        'Toast',
+      );
+    });
 
-    await expect(page.locator('[data-container="nested"]')).not.toContainText(
-      'Toast',
-    );
+    test('inside Popover', async ({ page }) => {
+      await page.goto('/Toaster');
+
+      // Open popover
+      const popoverButton = page.getByRole('button', { name: 'Show popover' });
+      await popoverButton.click();
+
+      // Show toast
+      const showToastButton = page.getByRole('button', { name: 'Show toast' });
+      await showToastButton.click();
+
+      const popoverToast = page.getByText('Toast (popover)');
+      await expect(popoverToast).toBeVisible();
+
+      // Toast should not be inside the popover
+      const popover = page.getByRole('dialog');
+      await expect(popover).toBeVisible();
+      await expect(popover).not.toContainText('Toast');
+    });
   });
 
   test('should work when using portalContainer prop', async ({ page }) => {


### PR DESCRIPTION
### Changes

This PR implements the approach outlined in https://github.com/iTwin/iTwinUI/pull/2450#issuecomment-2762461133. Instead of using the `portalContainer` prop (which is meant for consumers), `<Popover>` will now use `PortalContainerContext` to ensure all nested floating elements remain inside it.

This fixes #2449 because toaster only respects `portalContainer` (which is no longer set internally) and does not use the `PortalContainerContext`/`usePortalTo` helpers.

---

The same approach has also been used in `Dialog`. Previously, `Dialog` wasn't even changing the portal container. It was partially working because:
- it was relying on other floating elements using a higher `z-index` value.
- it was blocking clicks using a backdrop element.

However, this is not enough because: A modal dialog makes the rest of the page inert, which means that nested popovers, dropdowns, etc should be inside the dialog otherwise they will not be part of the accessibility tree. Therefore, `Dialog` now sets the `PortalContainerContext` value to the dialog element.

**Future**: There is some more work to do with regards to handling nesting of popovers and dialogs. See #2491.

---

For better reviewing experience, turn off whitespace diff.

### Testing

Added e2e test to verify toasts triggered from inside `<Popover>` don't end up inside it.

Also manually verified using the code from linked issue. Toasts are added in the global toast container and appear in the correct position.

| Before | After |
| --- | --- |
| ![Screenshot showing a toast obscuring a popover in the middle of the screen](https://github.com/user-attachments/assets/55594e04-d934-485f-b5e7-a809de0ac7d5) | ![Screenshot showing a toast at the top of the screen, and an open popover further down the page.](https://github.com/user-attachments/assets/e1c6581b-c9a8-48d7-adb2-995566fb09b4) |


### Docs

Added two changesets.

We will also need docs to properly show how the nested approach should work, but that will come in #2491.