### PR TITLE
create `unstable_TabsPresentation` component

### DIFF
--- a/.changeset/fluffy-oranges-cough.md
+++ b/.changeset/fluffy-oranges-cough.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': major
+---
+
+`iui-tabs` no longer requires a `iui-not-animated` class. When `iui-animated` is not present, the "not animated" behavior will be automatically used.

--- a/.changeset/short-knives-find.md
+++ b/.changeset/short-knives-find.md
@@ -1,0 +1,6 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added a new `unstable_TabsPresentation` component. This can be used in cases where the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) is not desirable.
+- Includes the following subcomponents: `Wrapper`, `TabList`, and `Tab`.

--- a/.changeset/slimy-grapes-occur.md
+++ b/.changeset/slimy-grapes-occur.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': minor
+---
+
+`iui-tab` now supports `aria-current` (as an alternative to `aria-selected`) for indicating selected state.

--- a/apps/css-workshop/src/pages/information-panel.astro
+++ b/apps/css-workshop/src/pages/information-panel.astro
@@ -889,7 +889,7 @@ import Icon_ from '../components/Icon.astro';
         <div class='iui-information-body'>
           <div class='iui-tabs-wrapper iui-horizontal' id='demo-pill-2'>
             <div
-              class='iui-tabs iui-pill iui-not-animated'
+              class='iui-tabs iui-pill'
               data-iui-orientation='horizontal'
               role='tablist'
               aria-label='Tab group name'

--- a/apps/css-workshop/src/pages/tabs.astro
+++ b/apps/css-workshop/src/pages/tabs.astro
@@ -791,7 +791,7 @@ import IconButton_ from '../components/IconButton.astro';
 
     <div class='iui-tabs-wrapper iui-horizontal'>
       <div
-        class='iui-tabs iui-borderless iui-green iui-not-animated'
+        class='iui-tabs iui-borderless iui-green'
         data-iui-orientation='horizontal'
         role='tablist'
         aria-label='Tab group name'
@@ -1239,7 +1239,7 @@ import IconButton_ from '../components/IconButton.astro';
 
     <div class='iui-tabs-wrapper iui-horizontal'>
       <div
-        class='iui-tabs iui-pill iui-green iui-not-animated'
+        class='iui-tabs iui-pill iui-green'
         data-iui-orientation='horizontal'
         role='tablist'
         aria-label='Tab group name'
@@ -1304,7 +1304,7 @@ import IconButton_ from '../components/IconButton.astro';
 
     <div class='iui-tabs-wrapper iui-horizontal'>
       <div
-        class='iui-tabs iui-pill iui-green iui-not-animated'
+        class='iui-tabs iui-pill iui-green'
         data-iui-orientation='horizontal'
         role='tablist'
         aria-label='Tab group name'

--- a/apps/website/src/content/docs/tabs.mdx
+++ b/apps/website/src/content/docs/tabs.mdx
@@ -144,6 +144,30 @@ The `Tabs.Action` subcomponent can be used to add action buttons to the end of t
   <AllExamples.TabsActionsExample client:load />
 </LiveExample>
 
+## Presentational
+
+In cases where the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) is not desirable, the `unstable_TabsPresentation` component can be used.
+
+This may be imported as an alias:
+
+```js
+import { unstable_TabsPresentation as TabsPresentation } from '@itwin/itwinui-react';
+```
+
+Usage:
+
+```jsx
+<TabsPresentation.Wrapper>
+  <TabsPresentation.TabList color='green'>
+    <TabsPresentation.Tab aria-current='true'>…</TabsPresentation.Tab>
+    <TabsPresentation.Tab>…</TabsPresentation.Tab>
+    <TabsPresentation.Tab>…</TabsPresentation.Tab>
+  </TabsPresentation.TabList>
+</TabsPresentation.Wrapper>
+```
+
+**Important**: When using the presentational version of Tabs, it is your responsibility to ensure that the resulting pattern is still accessible.
+
 ## Props
 
 Unfinished

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -63,7 +63,7 @@ $borderless-horizontal-tab-min-height: calc(
       background-color: var(--_iui-tab-color-stripe);
     }
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], [aria-current]) {
       --_iui-tab-color: var(--_iui-tab-color-selected);
 
       .iui-tab-icon svg {
@@ -118,7 +118,7 @@ $borderless-horizontal-tab-min-height: calc(
       outline-color: var(--iui-color-text-positive);
     }
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], [aria-current]) {
       --_iui-tab-color: var(--_iui-tab-color-green-selected);
 
       .iui-tab-icon svg {
@@ -187,7 +187,7 @@ $borderless-horizontal-tab-min-height: calc(
         block-size: 0;
       }
 
-      &[aria-selected='true']::after {
+      &:is([aria-selected='true'], [aria-current])::after {
         block-size: var(--iui-size-3xs);
       }
     }
@@ -238,7 +238,7 @@ $borderless-horizontal-tab-min-height: calc(
         block-size: 100%;
       }
 
-      &[aria-selected='true']::after {
+      &:is([aria-selected='true'], [aria-current])::after {
         inline-size: var(--iui-size-3xs);
       }
     }
@@ -253,7 +253,7 @@ $borderless-horizontal-tab-min-height: calc(
     --_iui-tab-color-stripe: var(--_iui-tab-color-stripe-blue);
   }
 
-  [aria-selected='true']::after {
+  :is([aria-selected='true'], [aria-current])::after {
     @media (prefers-reduced-motion: no-preference) {
       transition:
         width var(--iui-duration-1) ease,

--- a/packages/itwinui-css/src/tabs/borderless.scss
+++ b/packages/itwinui-css/src/tabs/borderless.scss
@@ -17,7 +17,7 @@
       background-color: var(--iui-color-background-transparent-hover);
     }
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], [aria-current]) {
       background-color: var(--iui-color-background-accent-muted);
     }
   }
@@ -35,7 +35,7 @@
   }
 
   &.iui-green {
-    [aria-selected='true'] {
+    :is([aria-selected='true'], [aria-current]) {
       background-color: var(--iui-color-background-positive-muted);
     }
   }

--- a/packages/itwinui-css/src/tabs/default.scss
+++ b/packages/itwinui-css/src/tabs/default.scss
@@ -3,8 +3,6 @@
 @use 'base';
 
 @mixin iui-tabs-default {
-  @include base.iui-tab-not-animated;
-
   .iui-tab {
     padding-block: var(--iui-size-2xs);
     padding-inline: var(--iui-size-m);

--- a/packages/itwinui-css/src/tabs/default.scss
+++ b/packages/itwinui-css/src/tabs/default.scss
@@ -18,7 +18,7 @@
       background-color: var(--iui-color-background-backdrop-hover);
     }
 
-    &[aria-selected='true'] {
+    &:is([aria-selected='true'], [aria-current]) {
       background-color: var(--iui-color-background);
     }
 
@@ -33,7 +33,7 @@
   }
 
   .iui-horizontal &[data-iui-orientation='horizontal'] {
-    .iui-tab[aria-selected='true'] {
+    .iui-tab:is([aria-selected='true'], [aria-current]) {
       border-block-end-color: transparent;
     }
 
@@ -51,7 +51,7 @@
   }
 
   .iui-vertical &[data-iui-orientation='vertical'] {
-    .iui-tab[aria-selected='true'] {
+    .iui-tab:is([aria-selected='true'], [aria-current]) {
       border-inline-end-color: transparent;
     }
 

--- a/packages/itwinui-css/src/tabs/pill.scss
+++ b/packages/itwinui-css/src/tabs/pill.scss
@@ -15,7 +15,7 @@
       background-color: var(--iui-color-background-transparent-hover);
     }
 
-    &[aria-selected='true']:hover {
+    &:is([aria-selected='true'], [aria-current]):hover {
       background-color: var(--iui-color-background-positive-muted);
     }
   }
@@ -37,7 +37,7 @@
       background-color: var(--iui-color-background-transparent-hover);
     }
 
-    &[aria-selected='true']:hover {
+    &:is([aria-selected='true'], [aria-current]):hover {
       background-color: var(--iui-color-background-accent-muted);
     }
 

--- a/packages/itwinui-css/src/tabs/tabs.scss
+++ b/packages/itwinui-css/src/tabs/tabs.scss
@@ -48,7 +48,7 @@
     @include base.iui-tab-animated;
   }
 
-  &.iui-not-animated {
+  &:not(.iui-animated) {
     @include base.iui-tab-not-animated;
   }
 }

--- a/packages/itwinui-react/src/index.ts
+++ b/packages/itwinui-react/src/index.ts
@@ -74,7 +74,7 @@ export { ListItem } from './core/List/ListItem.js';
 
 export { TransferList } from './core/TransferList/TransferList.js';
 
-export { Tabs, Tab } from './core/Tabs/Tabs.js';
+export { Tabs, Tab, unstable_TabsPresentation } from './core/Tabs/Tabs.js';
 
 export { InformationPanel } from './core/InformationPanel/InformationPanel.js';
 export { InformationPanelWrapper } from './core/InformationPanel/InformationPanelWrapper.js';


### PR DESCRIPTION
This PR extracts out all the presentational/visual aspects of `Tabs.Wrapper` `Tabs.TabList` and `Tabs.Tab` into new components, which are exported as subcomponents of `unstable_TabsPresentation`. This makes it  possible to use Tabs in cases where the [ARIA Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/) is not desirable.

**Use cases**

- A navigation list of anchors (see github's fake "tabs" on this very page).
- Tabs with close button (see https://github.com/iTwin/appui/pull/1190#issuecomment-2725326603)

## Changes

The [four commits](https://github.com/iTwin/iTwinUI/pull/2493/commits) are isolated and can be reviewed individually.

### CSS

- In the [first commit](https://github.com/iTwin/iTwinUI/pull/2493/commits/08b705de196b6c8fbeb720d4a428d5618b3ab972), the `iui-not-animated` class is removed from the CSS.
- In the [second commit](https://github.com/iTwin/iTwinUI/pull/2493/commits/022413edefdac20e81e360391df121f77f44bd0a), [`aria-current`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) has been added to the CSS selectors to support active tabs that do not have `role="tab"`.

### React

The [third commit](https://github.com/iTwin/iTwinUI/pull/2493/commits/991a49a4083b30c57fe6bc94d829995890cfd12a) includes _all_ React-related changes related to `unstable_TabsPresentation`.
  - The newly added components are both used internally by the existing components, and also exported publicly.
  - CI was passing before and after this commit, proving that the existing pattern is intact.

## Testing

Tested that it's appearing correctly using this code:

```jsx
import { unstable_TabsPresentation as TabsPresentation } from '@itwin/itwinui-react';

export default function App() {
  return (
    <TabsPresentation.Wrapper>
      <TabsPresentation.TabList color='green'>
        <TabsPresentation.Tab aria-current='true'>A</TabsPresentation.Tab>
        <TabsPresentation.Tab>B</TabsPresentation.Tab>
        <TabsPresentation.Tab>C</TabsPresentation.Tab>
      </TabsPresentation.TabList>
    </TabsPresentation.Wrapper>
  );
}
```

![Screenshot of three tabs, the first one has a green stripe](https://github.com/user-attachments/assets/9d4393f3-d6a1-4896-90b6-2231a174bf48)

`TabsPresentation.Tab` can be used together with other components to handle advanced cases, such as a "close button" inside a Tab.

```jsx
<TabsPresentation.Tab as={LinkBox} role='listitem' aria-current='true'>
  <LinkAction>…</LinkAction>
  <IconButton styleType='borderless' size='small' label='Close tab'>
    <SvgCloseSmall />
  </IconButton>
</TabsPresentation.Tab>
```


## Docs

Added two changesets for the CSS changes (`iui-not-animated` and `aria-current`) and one for the changeset for the React change (`unstable_TabsPresentation`).

There are some basic docs on the `/tabs` page. The `unstable_TabsPresentation.Tab` component also has some inline JSDocs.
