### PR TITLE
improve `Table` row selection

### DIFF
--- a/.changeset/curvy-jeans-shine.md
+++ b/.changeset/curvy-jeans-shine.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Table` where `onSelect` was being incorrectly called when selecting text inside cells.

--- a/.changeset/ninety-buttons-pull.md
+++ b/.changeset/ninety-buttons-pull.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Table: Increased the hit target size of checkboxes and text inside cells to prevent accidental row clicks when clicking the checkbox or selecting the text.

--- a/packages/itwinui-css/src/table/base.scss
+++ b/packages/itwinui-css/src/table/base.scss
@@ -425,8 +425,8 @@
     align-items: center;
     flex-basis: calc(var(--iui-size-l) * 2);
 
-    // make the checkbox bigger (32x32) to prevent accidentally clicking on the row
-    --iui-checkbox-target-size: 32px;
+    // make the checkbox bigger to prevent accidentally clicking on the row
+    --iui-checkbox-target-size: var(--_iui-table-row-size);
   }
 
   &.iui-table-cell-sticky {

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -4086,5 +4086,7 @@ it('should not apply clamp, if custom Cell is used', () => {
     data,
   });
   const host = container.querySelector('.test-cell');
-  expect(host?.shadowRoot).toBeFalsy();
+  expect(host?.shadowRoot).toBeTruthy();
+  const lineClamp = host?.shadowRoot?.querySelector('.iui-line-clamp');
+  expect(lineClamp).toBeNull();
 });

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -84,16 +84,23 @@ export const DefaultCell = <T extends Record<string, unknown>>(
       data-iui-status={status}
       style={{ ...cellElementStyle, ...style }}
     >
-      {clamp ? (
-        <ShadowRoot key={`${cellElementKey}-shadow-root`} flush={false}>
-          <slot name='start' />
-          <LineClamp>
+      <ShadowRoot key={`${cellElementKey}-shadow-root`} flush={false} css={css}>
+        <slot name='start' />
+        <div
+          className='_iui-table-cell-main-content'
+          onClick={(e) => e.stopPropagation()}
+        >
+          {clamp ? (
+            <LineClamp>
+              <slot />
+            </LineClamp>
+          ) : (
             <slot />
-          </LineClamp>
-          <slot name='end' />
-          <slot name='shadows' />
-        </ShadowRoot>
-      ) : null}
+          )}
+        </div>
+        <slot name='end' />
+        <slot name='shadows' />
+      </ShadowRoot>
 
       {startIcon && (
         <Box
@@ -120,3 +127,21 @@ export const DefaultCell = <T extends Record<string, unknown>>(
 if (process.env.NODE_ENV === 'development') {
   DefaultCell.displayName = 'DefaultCell';
 }
+
+/**
+ * Increase hit target size of the cell content.
+ * This helps prevent accidental row selection when selecting text.
+ */
+const css = /* css */ `
+._iui-table-cell-main-content {
+  position: relative;
+  isolation: isolate;
+}
+._iui-table-cell-main-content::before {
+  content: '';
+  display: block;
+  position: absolute;
+  inset: -6px;
+  z-index: -1;
+}
+`;

--- a/testing/e2e/app/routes/Table/route.tsx
+++ b/testing/e2e/app/routes/Table/route.tsx
@@ -209,6 +209,7 @@ const Default = ({
         selectSubRows={selectSubRows}
         enableVirtualization={enableVirtualization}
         style={{ maxHeight: '90vh' }}
+        onSelect={() => console.log('onSelect')}
         scrollToRow={
           scroll
             ? (rows, data) =>

--- a/testing/e2e/app/routes/Table/route.tsx
+++ b/testing/e2e/app/routes/Table/route.tsx
@@ -86,6 +86,7 @@ const getConfigFromSearchParams = (searchParams: URLSearchParams) => {
   const stateReducer = searchParams.get('stateReducer') === 'true';
   const scrollRow = Number(searchParams.get('scrollRow'));
   const hasSubComponent = searchParams.get('hasSubComponent') === 'true';
+  const onSelect = searchParams.get('onSelect') === 'true';
 
   return {
     exampleType,
@@ -105,6 +106,7 @@ const getConfigFromSearchParams = (searchParams: URLSearchParams) => {
     stateReducer,
     scrollRow,
     hasSubComponent,
+    onSelect,
   };
 };
 
@@ -130,6 +132,7 @@ const Default = ({
     stateReducer,
     rows,
     hasSubComponent,
+    onSelect,
   } = config;
 
   const virtualizedData = React.useMemo(() => {
@@ -209,7 +212,7 @@ const Default = ({
         selectSubRows={selectSubRows}
         enableVirtualization={enableVirtualization}
         style={{ maxHeight: '90vh' }}
-        onSelect={() => console.log('onSelect')}
+        onSelect={onSelect ? () => console.log('onSelect') : undefined}
         scrollToRow={
           scroll
             ? (rows, data) =>

--- a/testing/e2e/app/routes/Table/route.tsx
+++ b/testing/e2e/app/routes/Table/route.tsx
@@ -228,12 +228,6 @@ const Default = ({
             accessor: 'id',
             width: '8rem',
           },
-          {
-            Header: 'Custom',
-            accessor: 'custom',
-            cellClassName: 'custom-cell',
-            Cell: () => 'my custom content',
-          },
         ]}
         data={enableVirtualization ? virtualizedData : data}
         emptyTableContent='No data.'

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -440,7 +440,7 @@ test.describe('Table row selection', () => {
     });
 
     const row1CellBox = (await row1Cell.boundingBox())!;
-    // Approximate the positionn of the text
+    // Approximate the position of the text
     await page.mouse.click(
       row1CellBox.x + 24, // A few pixels from the left edge
       row1CellBox.y + row1CellBox.height / 2, // Vertically middle of the cell

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -38,28 +38,6 @@ test.describe('Conditional ARIA attributes', () => {
   });
 });
 
-test.describe('Clamping', () => {
-  test('should apply clamp, if cell is string value and no custom Cell is rendered', async ({
-    page,
-  }) => {
-    await page.goto('/Table');
-
-    const host = page.locator('.name-cell').first();
-    await expect(await host.evaluate((el) => el.shadowRoot)).not.toBeNull();
-    const lineClamp = await host.evaluate(
-      (el) => el.shadowRoot?.querySelector('div'),
-    );
-    await expect(lineClamp).not.toBeNull();
-  });
-
-  test('should not apply clamp, if custom Cell is used', async ({ page }) => {
-    await page.goto('/Table');
-
-    const host = page.locator('.custom-cell').first();
-    await expect(await host.evaluate((el) => el.shadowRoot)).toBeNull();
-  });
-});
-
 test.describe('Table sorting', () => {
   test('should work with keyboard', async ({ page }) => {
     await page.goto('/Table');

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -427,7 +427,7 @@ test.describe('Table row selection', () => {
   });
 
   test('should not call onSelect when clicking on text', async ({ page }) => {
-    await page.goto('/Table?isSelectable=true');
+    await page.goto('/Table?isSelectable=true&onSelect=true');
 
     const row1 = page.getByText('1Name1Description1');
     const row1Cell = row1.getByText('Name1');

--- a/testing/e2e/app/routes/Table/spec.ts
+++ b/testing/e2e/app/routes/Table/spec.ts
@@ -426,6 +426,31 @@ test.describe('Table row selection', () => {
     expect((await secondParentRowMessage).text()).toBe('false');
   });
 
+  test('should not call onSelect when clicking on text', async ({ page }) => {
+    await page.goto('/Table?isSelectable=true');
+
+    const row1 = page.getByText('1Name1Description1');
+    const row1Cell = row1.getByText('Name1');
+
+    let consoleText = '';
+    page.on('console', (msg) => {
+      if (msg.type() === 'log') {
+        consoleText = msg.text();
+      }
+    });
+
+    const row1CellBox = (await row1Cell.boundingBox())!;
+    // Approximate the positionn of the text
+    await page.mouse.click(
+      row1CellBox.x + 24, // A few pixels from the left edge
+      row1CellBox.y + row1CellBox.height / 2, // Vertically middle of the cell
+    );
+    expect(consoleText).not.toContain('onSelect');
+
+    await row1.click();
+    expect(consoleText).toContain('onSelect');
+  });
+
   //#region Helpers for row selection tests
   const filter = async (page: Page) => {
     const filterButton = page.getByLabel('Filter');


### PR DESCRIPTION
## Changes

This PR makes three changes to `Table` to improve the `selectRowOnClick` functionality.

- Increased hit target size of checkbox to cover the entire cell. This will prevent user frustration (they could lose their entire selection if the row is clicked instead of checkbox).
- Added wrapper element around cell text
  - Increased hit target size by a few pixels to prevent accidental row click when selecting text.
  - Stopped propagation of click events when this wrapper element is clicked, so that `onSelect` is not called when selecting text. (#2475)

Additionally, ShadowRoot is now always added to DefaultCell to preserve slotting behavior (see https://github.com/iTwin/iTwinUI/pull/2462#discussion_r2035844529).

Note: `onSelect` will still be called twice when clicking on the row (outside of text). This is _working as intended_ because of StrictMode.

## Testing

Added e2e test to ensure `onSelect` is not called when clicking on the text.

Re-added unit tests that were removed in https://github.com/iTwin/iTwinUI/pull/2487#discussion_r2036189481.

The other improvements were tested manually.

## Docs

Added changesets.