### PR TITLE
Fix `Table` not working in old React versions

### DIFF
--- a/.changeset/grumpy-crabs-type.md
+++ b/.changeset/grumpy-crabs-type.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed `Table` not working in older React versions where `useId` is not available.

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -37,6 +37,7 @@ import {
   useMergedRefs,
   useLatestRef,
   useVirtualScroll,
+  useId,
 } from '../../utils/index.js';
 import type { CommonProps } from '../../utils/index.js';
 import { TableInstanceContext } from './utils.js';
@@ -1043,7 +1044,7 @@ export const Table = <
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const captionId = React.useId();
+  const captionId = useId();
 
   return (
     <TableInstanceContext.Provider


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes #2519. Similar to #2411.

Replaced the `React.useId()` with the `useId()` from utils. This utils version works even with old React versions (e.g. 17 and below) where `useId()` is not available.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that `Table` does not give an error in React 17.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added changeset.