### PR TITLE
fix `Dialog` portaling

### DIFF
--- a/.changeset/breezy-falcons-sleep.md
+++ b/.changeset/breezy-falcons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed an issue in `Dialog`/`Modal` where nested floating elements (e.g. `Select` dropdown) were not interactable because they were being portaled incorrectly.

--- a/packages/itwinui-react/src/core/Dialog/Dialog.tsx
+++ b/packages/itwinui-react/src/core/Dialog/Dialog.tsx
@@ -26,7 +26,7 @@ type DialogProps = {
   children: React.ReactNode;
 } & DialogContextProps;
 
-const DialogComponent = React.forwardRef((props, ref) => {
+const DialogComponent = React.forwardRef((props, forwardedRef) => {
   const {
     trapFocus = false,
     setFocus = trapFocus,
@@ -45,11 +45,11 @@ const DialogComponent = React.forwardRef((props, ref) => {
     ...rest
   } = props;
 
-  const dialogRootRef = React.useRef<HTMLDivElement>(null);
+  const dialogRootRef = React.useRef<HTMLDivElement | null>(null);
   const [dialogElement, setDialogElement] = React.useState<HTMLElement | null>(
     null,
   );
-  const mergedRefs = useMergedRefs(ref, dialogRootRef, setDialogElement);
+  const mergedRefs = useMergedRefs(forwardedRef, dialogRootRef);
 
   return isOpen ? (
     <DialogContext.Provider
@@ -66,6 +66,8 @@ const DialogComponent = React.forwardRef((props, ref) => {
         isResizable,
         relativeTo,
         placement,
+        dialogRootRef,
+        setDialogElement,
       }}
     >
       <Portal portal={portal}>

--- a/packages/itwinui-react/src/core/Dialog/DialogBackdrop.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogBackdrop.tsx
@@ -28,11 +28,11 @@ export const DialogBackdrop = React.forwardRef((props, ref) => {
   const dialogMainContext = useDialogMainContext();
 
   const {
-    isVisible = dialogContext.isOpen,
-    isDismissible = dialogContext.isDismissible,
-    onClose = dialogContext.onClose,
-    closeOnExternalClick = dialogContext.closeOnExternalClick,
-    relativeTo = dialogContext.relativeTo,
+    isVisible = dialogContext?.isOpen,
+    isDismissible = dialogContext?.isDismissible,
+    onClose = dialogContext?.onClose,
+    closeOnExternalClick = dialogContext?.closeOnExternalClick,
+    relativeTo = dialogContext?.relativeTo,
     onMouseDown,
     className,
     style,

--- a/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogContext.tsx
@@ -86,19 +86,20 @@ export type DialogContextProps = {
    */
   portal?: PortalProps['portal'];
   /**
-   * Dialog root ref. For internal use.
-   */
-  dialogRootRef?: React.RefObject<HTMLDivElement | null>;
-  /**
    * Determines the positioning of Dialog on page.
    */
   placement?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 };
 
+type DialogContextInternalProps = {
+  dialogRootRef: React.RefObject<HTMLDivElement | null>;
+  setDialogElement: (dialogElement: HTMLElement | null) => void;
+};
+
 export const DialogContext = React.createContext<
-  DialogContextProps | undefined
+  (DialogContextProps & DialogContextInternalProps) | undefined
 >(undefined);
 
 export const useDialogContext = () => {
-  return React.useContext(DialogContext) || {};
+  return React.useContext(DialogContext);
 };

--- a/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogMain.tsx
@@ -30,7 +30,7 @@ export type DialogMainProps = {
    * Content of the dialog.
    */
   children: React.ReactNode;
-} & Omit<DialogContextProps, 'closeOnExternalClick' | 'dialogRootRef'>;
+} & Omit<DialogContextProps, 'closeOnExternalClick'>;
 
 /**
  * Dialog component which can wrap any content.
@@ -52,28 +52,28 @@ export type DialogMainProps = {
  *   </Dialog.ButtonBar>
  * </Dialog.Main>
  */
-export const DialogMain = React.forwardRef((props, ref) => {
+export const DialogMain = React.forwardRef((props, forwardedRef) => {
   const dialogContext = useDialogContext();
   const {
     className,
     children,
     styleType = 'default',
-    isOpen = dialogContext.isOpen,
-    isDismissible = dialogContext.isDismissible,
-    onClose = dialogContext.onClose,
-    closeOnEsc = dialogContext.closeOnEsc,
-    trapFocus = dialogContext.trapFocus,
-    setFocus = dialogContext.setFocus,
-    preventDocumentScroll = dialogContext.preventDocumentScroll,
+    isOpen = dialogContext?.isOpen,
+    isDismissible = dialogContext?.isDismissible,
+    onClose = dialogContext?.onClose,
+    closeOnEsc = dialogContext?.closeOnEsc,
+    trapFocus = dialogContext?.trapFocus,
+    setFocus = dialogContext?.setFocus,
+    preventDocumentScroll = dialogContext?.preventDocumentScroll,
     onKeyDown,
-    isDraggable = dialogContext.isDraggable,
-    isResizable = dialogContext.isResizable,
+    isDraggable = dialogContext?.isDraggable,
+    isResizable = dialogContext?.isResizable,
     style: propStyle,
-    placement = dialogContext.placement,
+    placement = dialogContext?.placement,
     ...rest
   } = props;
 
-  const { dialogRootRef } = dialogContext;
+  const { dialogRootRef, setDialogElement } = dialogContext || {};
 
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const previousFocusedElement = React.useRef<HTMLElement | null>(null);
@@ -203,7 +203,7 @@ export const DialogMain = React.forwardRef((props, ref) => {
         className,
       )}
       role='dialog'
-      ref={useMergedRefs(dialogRef, mountRef, ref)}
+      ref={useMergedRefs(dialogRef, mountRef, setDialogElement, forwardedRef)}
       onKeyDown={handleKeyDown}
       tabIndex={-1}
       data-iui-placement={placement}

--- a/packages/itwinui-react/src/core/Dialog/DialogTitleBar.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogTitleBar.tsx
@@ -49,9 +49,9 @@ export const DialogTitleBar = Object.assign(
     const {
       children,
       titleText,
-      isDismissible = dialogContext.isDismissible,
-      onClose = dialogContext.onClose,
-      isDraggable = dialogContext.isDraggable,
+      isDismissible = dialogContext?.isDismissible,
+      onClose = dialogContext?.onClose,
+      isDraggable = dialogContext?.isDraggable,
       className,
       onPointerDown: onPointerDownProp,
       ...rest


### PR DESCRIPTION
## Changes

Fixes #2522 by changing the portal element to `DialogMain` instead of `DialogRoot`. (This was a mistake from #2490).

`DialogContextProps` is being used in multiple places to create the public API, so I added `setDialogElement` in a separate internal type. After doing this, I was seeing some typescript issues in the return type of `useDialogContext`. Removing `|| {}` from the return value fixed the type errors but required using optional chaining (`?.`) in a few places.

## Testing

Verified that a `Select` inside a `Modal` is interactable with mouse.

## Docs

Added `patch` changeset.