### PR TITLE
adjust `Tooltip` delays

### DIFF
--- a/.changeset/bright-trains-jam.md
+++ b/.changeset/bright-trains-jam.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': patch
 ---
 
-`Tooltip` delays have been adjusted to use the same values for open and close.
+`Tooltip`'s entry delay has been increased to match the exit delay. This change will help reduce the chances of a user accidentally triggering the tooltip, while also preventing multiple tooltips from showing at the same time.

--- a/.changeset/bright-trains-jam.md
+++ b/.changeset/bright-trains-jam.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+`Tooltip` delays have been adjusted to use the same values for open and close.

--- a/apps/react-workshop/src/AvatarGroup.test.ts
+++ b/apps/react-workshop/src/AvatarGroup.test.ts
@@ -20,7 +20,7 @@ describe('AvatarGroup', () => {
 
       if (testName.includes('Tooltip')) {
         cy.get('div').contains('3').trigger('mouseenter');
-        cy.wait(100);
+        cy.wait(200);
       }
 
       cy.compareSnapshot(testName);

--- a/apps/react-workshop/src/Breadcrumbs.test.ts
+++ b/apps/react-workshop/src/Breadcrumbs.test.ts
@@ -28,7 +28,7 @@ describe('Breadcrumbs', () => {
         cy.get('button').eq(1).click();
       } else if (testName === 'Custom Overflow Back Button') {
         cy.get('button').eq(1).trigger('mouseenter');
-        cy.wait(100);
+        cy.wait(200);
       }
 
       cy.compareSnapshot(testName);

--- a/apps/react-workshop/src/Stepper.test.ts
+++ b/apps/react-workshop/src/Stepper.test.ts
@@ -15,7 +15,7 @@ describe('Stepper', () => {
       if (testName.includes('Tooltip')) {
         cy.get('#ladle-root').within(() => {
           cy.get('li').first().trigger('mouseenter'); // trigger tooltip
-          cy.wait(100);
+          cy.wait(200);
         });
       }
 

--- a/apps/react-workshop/src/Tooltip.test.ts
+++ b/apps/react-workshop/src/Tooltip.test.ts
@@ -12,7 +12,7 @@ describe('Tooltip', () => {
       cy.visit('/', { qs: { mode: 'preview', story: id } });
 
       cy.get('#tooltip-target').trigger('mouseenter');
-      cy.wait(100);
+      cy.wait(200);
       cy.compareSnapshot(testName);
     });
   });

--- a/apps/react-workshop/src/WorkflowDiagram.test.ts
+++ b/apps/react-workshop/src/WorkflowDiagram.test.ts
@@ -15,7 +15,7 @@ describe('WorkflowDiagram', () => {
       if (testName.includes('Tooltip')) {
         cy.get('#ladle-root').within(() => {
           cy.get('li').first().trigger('mouseenter'); // trigger tooltip
-          cy.wait(100);
+          cy.wait(200);
         });
       }
 

--- a/packages/itwinui-react/src/core/Stepper/Stepper.test.tsx
+++ b/packages/itwinui-react/src/core/Stepper/Stepper.test.tsx
@@ -273,7 +273,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
   fireEvent.mouseEnter(screen.getByText('Step One'), { bubbles: true });
-  act(() => void vi.advanceTimersByTime(100));
+  act(() => void vi.advanceTimersByTime(200));
   const tooltip = document.querySelector('.iui-tooltip') as HTMLElement;
   expect(tooltip).toBeVisible();
   expect(tooltip).toHaveTextContent('Step one tooltip');

--- a/packages/itwinui-react/src/core/Stepper/WorkflowDiagram.test.tsx
+++ b/packages/itwinui-react/src/core/Stepper/WorkflowDiagram.test.tsx
@@ -81,7 +81,7 @@ it('should display tooltip upon hovering step if description provided', async ()
 
   expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
   fireEvent.mouseEnter(screen.getByText('Step One'), { bubbles: true });
-  act(() => void vi.advanceTimersByTime(100));
+  act(() => void vi.advanceTimersByTime(200));
   const tooltip = document.querySelector('.iui-tooltip') as HTMLElement;
   expect(tooltip).toBeVisible();
   expect(tooltip).toHaveTextContent('Step one tooltip');
@@ -90,7 +90,7 @@ it('should display tooltip upon hovering step if description provided', async ()
   act(() => void vi.advanceTimersByTime(250));
 
   fireEvent.mouseEnter(screen.getByText('Step Three'), { bubbles: true });
-  act(() => void vi.advanceTimersByTime(100));
+  act(() => void vi.advanceTimersByTime(200));
   expect(document.querySelector('.iui-tooltip')).not.toBeVisible();
 
   vi.useRealTimers();

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.test.tsx
@@ -49,7 +49,7 @@ it('should toggle the visibility of tooltip on focus', async () => {
   expect(tooltip).toHaveAttribute('popover', 'manual');
 
   fireEvent.focus(trigger);
-  act(() => void vi.advanceTimersByTime(50));
+  act(() => void vi.advanceTimersByTime(200));
   expect(tooltip).toBeVisible();
   expect(onVisibleChange).toBeCalledWith(true);
 

--- a/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
+++ b/packages/itwinui-react/src/core/Tooltip/Tooltip.tsx
@@ -40,7 +40,7 @@ import type {
 export const defaultTooltipDelay: React.ComponentPropsWithoutRef<
   typeof FloatingDelayGroup
 >['delay'] = {
-  open: 100,
+  open: 200,
   close: 200,
 };
 


### PR DESCRIPTION
## Changes

The entry delay for `Tooltip` has been increased from 100ms to 200ms, matching the exit delay. The increased value should avoid more instances of accidental activation, and matching the exit value should avoid situations where multiple tooltips can appear at the same time and overlap.

Closes #2508

## Testing

Needed to adjust the delays used in tests to make them pass.

Other than that, I did some rough manual testing in the vite playground to verify that tooltips don't appear simultaneously and don't overlap when moving the mouse from tooltip trigger to another.

**Note:** For the best experience, `ButtonGroup` should be used instead of manually grouping buttons, to take advantage of the delay group feature.

## Docs

Added `patch` changeset.