### PR TITLE
Fix `Table` bug of trying to add `scrollToRow` to DOM

### DIFF
--- a/.changeset/nine-monkeys-lay.md
+++ b/.changeset/nine-monkeys-lay.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed `Table` bug where it unintentionally tried to add `scrollToRow` to the DOM and thus led to a console error.

--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -446,6 +446,7 @@ export const Table = <
     getRowId,
     caption = 'Table',
     role,
+    scrollToRow,
     ..._rest
   } = props;
 
@@ -875,7 +876,11 @@ export const Table = <
 
   const tableRef = React.useRef<HTMLDivElement>(null);
 
-  const { scrollToIndex, tableRowRef } = useScrollToRow<T>({ ...props, page });
+  const { scrollToIndex, tableRowRef } = useScrollToRow<T>({
+    ...props,
+    scrollToRow,
+    page,
+  });
   const columnRefs = React.useRef<Record<string, HTMLDivElement>>({});
   const previousTableWidth = React.useRef(0);
   const onTableResize = React.useCallback(


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes #2513.

Destructs `scrollToRow` from `props` and uses it somewhere in the code to make use of that variable.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed manually that that console error no longer shows.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added `patch` changeset.