### PR TITLE
Fix visibility of table columns when resizing sticky columns

### DIFF
--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -79,6 +79,42 @@ export const ColumnHeader = React.forwardRef((props, forwardedRef) => {
     }
   }
 
+  // track if the maxWidth for the column was initially set
+  const currCol = instance?.columns.find((c) => c.id === column.id);
+  if (currCol && column.maxWidth === 0) {
+    currCol.maxWidthDefault = true;
+  }
+
+  // calculate maxWidth for sticky columns if not manually defined before
+  // ensure total width of sticky columns does not exceed 75% of table width
+
+  // do not calculate maxWidth for action column since it is fixed
+  if (
+    currCol?.maxWidthDefault &&
+    column.id !== 'iui-table-action' &&
+    column.sticky &&
+    instance
+  ) {
+    const stickyCols = instance.columns.filter((c) => c.sticky);
+    // get sum of widths of sticky columns besides current sticky column
+    const stickyColsRest = stickyCols.filter((c) => column.id !== c.id);
+    const stickyColsWidthRest = stickyColsRest.reduce(
+      // handle for when width is not number?
+      (sum, c) => sum + (Number(c.width) || 0),
+      0,
+    );
+    // calculate total remaining width to set as maxWidth
+    if (instance.tableWidth && stickyColsWidthRest) {
+      const remainingWidth = Math.floor(
+        instance.tableWidth * 0.75 - stickyColsWidthRest,
+      );
+      // update maxWidth for the current column
+      if (currCol) {
+        currCol.maxWidth = remainingWidth;
+      }
+    }
+  }
+
   const columnProps = column.getHeaderProps({
     ...restSortProps,
     className: cx(

--- a/packages/itwinui-react/src/react-table/react-table.ts
+++ b/packages/itwinui-react/src/react-table/react-table.ts
@@ -228,6 +228,10 @@ export interface ColumnInterface<D extends Record<string, unknown> = {}>
    * Side on which column should be sticked to.
    */
   sticky?: 'left' | 'right';
+  /**
+   * If maxWidth was initially not defined.
+   */
+  maxWidthDefault?: boolean;
 }
 
 export interface ColumnInterfaceBasedOnValue<


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes #2518.

As demonstrated in the bug above, when resizing a left sticky column all the way to the right of the table, the visibility of the remaining columns disappears even though the horizontal scrollbar still exists.

This PR addresses this bug by adding JS logic to ensure that the total width of the sticky columns does not exceed the table width (specifically, 75% of the table width to be safe) in order to maintain visibility of the remaining table columns.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Manually tested using Chrome Dev Tools and vite playground.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

WIP
