### PR TITLE
Set `color` property to match `fill` of an icon

### DIFF
--- a/.changeset/smart-pots-film.md
+++ b/.changeset/smart-pots-film.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': minor
+---
+
+Set `color` property to match the existing `fill` property value of icons when they are used inside a menu item or field components. This ensures consistent icon colors, i.e. when a font icon is used. Additionally, it enables referencing the icon's color value using the `currentColor` keyword.

--- a/.changeset/twelve-hands-guess.md
+++ b/.changeset/twelve-hands-guess.md
@@ -1,5 +1,5 @@
 ---
-'@itwin/itwinui-react': minor
+'@itwin/itwinui-react': patch
 ---
 
-Added support for font icons to the `IconButton` and `MenuItem` components by using the `color` property instead of the `fill` property.
+Fixed color mismatch between font icons and svg icons in `IconButton` and `MenuItem`. (NOTE: Despite this fix, use of font icons is still discouraged).

--- a/.changeset/twelve-hands-guess.md
+++ b/.changeset/twelve-hands-guess.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added support for font icons to the `IconButton` and `MenuItem` components by using the `color` property instead of the `fill` property.

--- a/packages/itwinui-css/src/button/base.scss
+++ b/packages/itwinui-css/src/button/base.scss
@@ -41,7 +41,7 @@ $disabledButtonSelectors: '[disabled], :disabled, [aria-disabled="true"], [data-
 @mixin iui-button-icon {
   display: inline-flex;
   flex-shrink: 0;
-  color: var(--_iui-button-icon-color, currentColor);
+  color: var(--_iui-field-icon-color, currentColor);
 
   svg {
     @include mixins.iui-icon-style('m');

--- a/packages/itwinui-css/src/button/base.scss
+++ b/packages/itwinui-css/src/button/base.scss
@@ -46,7 +46,7 @@ $disabledButtonSelectors: '[disabled], :disabled, [aria-disabled="true"], [data-
   svg {
     @include mixins.iui-icon-style('m');
     transition: fill var(--iui-duration-1) ease-out;
-    fill: inherit;
+    fill: currentColor;
   }
 }
 

--- a/packages/itwinui-css/src/button/base.scss
+++ b/packages/itwinui-css/src/button/base.scss
@@ -41,6 +41,7 @@ $disabledButtonSelectors: '[disabled], :disabled, [aria-disabled="true"], [data-
 @mixin iui-button-icon {
   display: inline-flex;
   flex-shrink: 0;
+  color: var(--_iui-button-icon-color, currentColor);
 
   svg {
     @include mixins.iui-icon-style('m');

--- a/packages/itwinui-css/src/field.scss
+++ b/packages/itwinui-css/src/field.scss
@@ -28,6 +28,11 @@
   --_iui-field-state--disabled: var(--_iui-field-state,);
   --_iui-field-state--disabled-hover: var(--_iui-field-state,);
 
+  --_iui-button-icon-color: var(--_iui-field-state--default, var(--_iui-field-color-icon))
+    var(--_iui-field-state--hover, var(--_iui-field-color-icon-hover))
+    var(--_iui-field-state--disabled, var(--_iui-field-color-icon-disabled))
+    var(--_iui-field-state--disabled-hover, var(--_iui-field-color-icon-disabled-hover));
+
   background-color: var(--_iui-field-state--default, var(--_iui-field-color-background))
     var(--_iui-field-state--hover, var(--_iui-field-color-background-hover))
     var(--_iui-field-state--disabled, var(--_iui-field-color-background-disabled))
@@ -42,10 +47,7 @@
     var(--_iui-field-state--hover, var(--_iui-field-color-text-hover))
     var(--_iui-field-state--disabled, var(--_iui-field-color-text-disabled))
     var(--_iui-field-state--disabled-hover, var(--_iui-field-color-text-disabled-hover));
-  fill: var(--_iui-field-state--default, var(--_iui-field-color-icon))
-    var(--_iui-field-state--hover, var(--_iui-field-color-icon-hover))
-    var(--_iui-field-state--disabled, var(--_iui-field-color-icon-disabled))
-    var(--_iui-field-state--disabled-hover, var(--_iui-field-color-icon-disabled-hover));
+  fill: var(--_iui-button-icon-color);
   font: inherit;
   font-size: var(--_iui-field-font-size);
   font-weight: var(--iui-font-weight-normal);

--- a/packages/itwinui-css/src/field.scss
+++ b/packages/itwinui-css/src/field.scss
@@ -28,7 +28,7 @@
   --_iui-field-state--disabled: var(--_iui-field-state,);
   --_iui-field-state--disabled-hover: var(--_iui-field-state,);
 
-  --_iui-button-icon-color: var(--_iui-field-state--default, var(--_iui-field-color-icon))
+  --_iui-field-icon-color: var(--_iui-field-state--default, var(--_iui-field-color-icon))
     var(--_iui-field-state--hover, var(--_iui-field-color-icon-hover))
     var(--_iui-field-state--disabled, var(--_iui-field-color-icon-disabled))
     var(--_iui-field-state--disabled-hover, var(--_iui-field-color-icon-disabled-hover));
@@ -47,7 +47,7 @@
     var(--_iui-field-state--hover, var(--_iui-field-color-text-hover))
     var(--_iui-field-state--disabled, var(--_iui-field-color-text-disabled))
     var(--_iui-field-state--disabled-hover, var(--_iui-field-color-text-disabled-hover));
-  fill: var(--_iui-button-icon-color);
+  fill: var(--_iui-field-icon-color);
   font: inherit;
   font-size: var(--_iui-field-font-size);
   font-weight: var(--iui-font-weight-normal);

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -129,6 +129,7 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
 
 :is(.iui-menu-item-skeleton > .iui-icon, .iui-list-item-icon) {
   flex: 0 0 auto;
+  color: var(--_iui-list-item-icon-fill, var(--iui-color-icon));
 
   &,
   svg {

--- a/packages/itwinui-css/src/menu/menu.scss
+++ b/packages/itwinui-css/src/menu/menu.scss
@@ -134,7 +134,7 @@ $iui-active-outline: 1px solid var(--iui-color-border-accent);
   &,
   svg {
     @include mixins.iui-icon-style('m');
-    fill: var(--_iui-list-item-icon-fill, var(--iui-color-icon));
+    fill: currentColor;
   }
 }
 


### PR DESCRIPTION
## Changes

Set `color` property to match the existing `fill` property value of icons when they are used inside a menu item or field components. This ensures consistent icon colors, i.e. when a font icon is used. Additionally, it enables referencing the icon's color value using the `currentColor` keyword.

## Testing

Tested by using the `WithIcons` story of `ButtonGroup.stories.tsx` and `WithStartIcons` of `DropdownMenu.stories.tsx`. I have added a text node together with an SVG icon. Since text and color values are similar, it is best to set/override the underlying icon color variable to notice that both the color and SVG fill values are referencing the same value.

New tests/stories could be added if deemed necessary i.e. `WithFontIcons`.

## Docs

N/A

## After PR TODOs

- [ ] All svg implementations should use `fill: currentColor` ([#2554 (comment)](https://github.com/iTwin/iTwinUI/pull/2554#discussion_r2112181595), [#2554 (review)](https://github.com/iTwin/iTwinUI/pull/2554#pullrequestreview-2878974573))