### PR TITLE
Bump `tar-fs`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11176,10 +11176,10 @@ packages:
       }
     engines: { node: '>=10.0.0' }
 
-  tar-fs@3.0.8:
+  tar-fs@3.0.9:
     resolution:
       {
-        integrity: sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==,
+        integrity: sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==,
       }
 
   tar-stream@3.1.7:
@@ -13896,7 +13896,7 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.5.0
       semver: 7.6.0
-      tar-fs: 3.0.8
+      tar-fs: 3.0.9
       unbzip2-stream: 1.4.3
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -19865,7 +19865,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tar-fs@3.0.8:
+  tar-fs@3.0.9:
     dependencies:
       pump: 3.0.0
       tar-stream: 3.1.7


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Bumps `tar-fs` to fix https://github.com/advisories/GHSA-8cj5-5rvv-wf4v.

The audit still fails because of https://github.com/advisories/GHSA-v6h2-p8h4-qcjw. ~Since there is no patched version for that (`brace-expansion`) yet, this PR doesn't fix that at the moment.~ Although there is no mentioned patch fixed version for `brace-expansion` (**EDIT**: They added the patched versions), the very recently released `v4.0.1` seems like a fix. Upgrading to it was not very straightforward. Thus, will be handling it in another PR.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

https://github.com/advisories/GHSA-8cj5-5rvv-wf4v no longer appearing in the failing audit.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A since `tar-fs` was used in internal workspaces (`apps/css-workshop`).