### PR TITLE
`Table`: Fix bug of props being passed to DOM

### DIFF
--- a/packages/itwinui-react/src/core/Table/Table.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.tsx
@@ -447,6 +447,41 @@ export const Table = <
     caption = 'Table',
     role,
     scrollToRow,
+
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    useControlledState,
+    autoResetExpanded,
+    autoResetFilters,
+    autoResetGlobalFilter,
+    autoResetHiddenColumns,
+    autoResetPage,
+    autoResetResize,
+    autoResetSelectedRows,
+    autoResetSortBy,
+    defaultCanFilter,
+    defaultCanSort,
+    disableFilters,
+    disableGlobalFilter,
+    disableMultiSort,
+    disableSortRemove,
+    disabledMultiRemove,
+    expandSubRows,
+    globalFilter,
+    initialState,
+    isMultiSortEvent,
+    manualExpandedKey,
+    manualFilters,
+    manualGlobalFilter,
+    manualPagination,
+    manualRowSelectedKey,
+    manualSortBy,
+    maxMultiSortColCount,
+    orderByFn,
+    pageCount,
+    paginateExpandedRows,
+    sortTypes,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+
     ..._rest
   } = props;
 
@@ -702,7 +737,38 @@ export const Table = <
     {
       manualPagination: !paginatorRenderer, // Prevents from paginating rows in regular table without pagination
       paginateExpandedRows: false, // When false, it shows sub-rows in the current page instead of splitting them
-      ...props,
+
+      // --- START --- Unused props from TableOptions<T> ------
+      useControlledState,
+      autoResetExpanded,
+      autoResetFilters,
+      autoResetGlobalFilter,
+      autoResetHiddenColumns,
+      autoResetPage,
+      autoResetResize,
+      autoResetSelectedRows,
+      autoResetSortBy,
+      defaultCanFilter,
+      defaultCanSort,
+      disableFilters,
+      disableGlobalFilter,
+      disableMultiSort,
+      disableSortRemove,
+      disabledMultiRemove,
+      expandSubRows,
+      globalFilter,
+      isMultiSortEvent,
+      manualExpandedKey,
+      manualFilters,
+      manualGlobalFilter,
+      manualRowSelectedKey,
+      manualSortBy,
+      maxMultiSortColCount,
+      orderByFn,
+      pageCount,
+      sortTypes,
+      // --- END --- Unused props from TableOptions<T> ------
+
       columns,
       defaultColumn,
       disableSortBy: !isSortable,


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixes https://github.com/iTwin/iTwinUI/issues/2553.

This PR addresses an issue where `Table` props (e.g. `useControlledState` and `autoResetResize`) are passed to the DOM element which is not intended.

To fix this, all `Table` props are destructed from `props` and defined as `options`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Tested manually to ensure there is no console warning.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

WIP
