### PR TITLE
create internal `FutureFlagsProvider`

### DIFF
--- a/.changeset/cute-tires-sniff.md
+++ b/.changeset/cute-tires-sniff.md
@@ -2,4 +2,4 @@
 '@itwin/itwinui-react': minor
 ---
 
-Added the ability pass `future={true}` to `ThemeProvider` to enable _all_ future options.
+Added the ability to pass `future={true}` to `ThemeProvider` to enable _all_ future options.

--- a/.changeset/cute-tires-sniff.md
+++ b/.changeset/cute-tires-sniff.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Added the ability pass `future={true}` to `ThemeProvider` to enable _all_ future options.

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeContext.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeContext.tsx
@@ -3,18 +3,13 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import type {
-  FutureOptions,
-  ThemeOptions,
-  ThemeType,
-} from './ThemeProvider.js';
+import type { ThemeOptions, ThemeType } from './ThemeProvider.js';
 
 export const ThemeContext = React.createContext<
   | {
       theme?: ThemeType;
       themeOptions?: ThemeOptions;
       portalContainer?: HTMLElement | null;
-      future?: FutureOptions;
     }
   | undefined
 >(undefined);

--- a/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/itwinui-react/src/core/ThemeProvider/ThemeProvider.tsx
@@ -17,8 +17,13 @@ import {
   useHydration,
   PortalContainerContext,
   useId,
+  FutureFlagsProvider,
+  useFutureFlag,
 } from '../../utils/index.js';
-import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
+import type {
+  FutureOptions,
+  PolymorphicForwardRefComponent,
+} from '../../utils/index.js';
 import { ThemeContext } from './ThemeContext.js';
 import { ToastProvider, Toaster } from '../Toast/Toaster.js';
 import { meta } from '../../utils/meta.js';
@@ -39,19 +44,6 @@ export type ThemeOptions = {
    * Will default to user preference if browser supports it.
    */
   highContrast?: boolean;
-};
-
-export type FutureOptions = {
-  /**
-   * @alpha
-   *
-   * If enabled, the theme resembles the future iTwinUI version's theme (including alphas) *whenever possible*.
-   *
-   * This is useful in making apps looks like future versions of iTwinUI to help with incremental adoption.
-   *
-   * **NOTE**: Since this is a theme bridge to *future* versions, the theme could have breaking changes.
-   */
-  themeBridge?: boolean;
 };
 
 export type ThemeType = 'light' | 'dark' | 'os';
@@ -89,13 +81,9 @@ type RootProps = {
      */
     applyBackground?: boolean;
   };
-  /**
-   * Options to help with early adoption of features from future versions.
-   */
-  future?: FutureOptions;
 };
 
-type ThemeProviderOwnProps = Pick<RootProps, 'theme' | 'future'> & {
+type ThemeProviderOwnProps = Pick<RootProps, 'theme'> & {
   themeOptions?: RootProps['themeOptions'];
   children: Required<React.ReactNode>;
   /**
@@ -126,6 +114,12 @@ type ThemeProviderOwnProps = Pick<RootProps, 'theme' | 'future'> & {
    * If true or false is passed, it will override the default behavior.
    */
   includeCss?: boolean;
+  /**
+   * Options to help with early adoption of features from future versions.
+   *
+   * All future options will be automatically inherited across nested ThemeProviders, unless explicitly overridden.
+   */
+  future?: true | FutureOptions;
 };
 
 // ----------------------------------------------------------------------------
@@ -165,7 +159,7 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
     themeOptions = {},
     portalContainer: portalContainerProp,
     includeCss = themeProp === 'inherit',
-    future = {},
+    future: futureProp = {},
     ...rest
   } = props;
 
@@ -184,54 +178,56 @@ export const ThemeProvider = React.forwardRef((props, forwardedRef) => {
   themeOptions.highContrast ??=
     themeProp === 'inherit' ? parent.highContrast : undefined;
 
-  future.themeBridge ??= parent.context?.future?.themeBridge;
-
   const portalContainerFromParent = React.useContext(PortalContainerContext);
 
-  const contextValue = React.useMemo(
-    () => ({ theme, themeOptions, future }),
+  const themeContextValue = React.useMemo(
+    () => ({ theme, themeOptions }),
     // we do include all dependencies below, but we want to stringify the objects as they could be different on each render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [theme, JSON.stringify(themeOptions), JSON.stringify(future)],
+    [theme, JSON.stringify(themeOptions)],
   );
 
   const [portalContainer, setPortalContainer] =
     React.useState<HTMLElement | null>(portalContainerProp || null);
 
   return (
-    <PortalContainerContext.Provider value={portalContainer}>
-      <HydrationProvider>
-        <ThemeContext.Provider value={contextValue}>
-          <ToastProvider
-            inherit={themeProp === 'inherit' && !portalContainerProp}
-          >
-            {includeCss && rootElement ? (
-              <FallbackStyles root={rootElement} />
-            ) : null}
-
-            <MainRoot
-              theme={theme}
-              themeOptions={themeOptions}
-              future={future}
-              ref={useMergedRefs(forwardedRef, setRootElement, useIuiDebugRef)}
-              {...rest}
+    <FutureFlagsProvider value={futureProp}>
+      <PortalContainerContext.Provider value={portalContainer}>
+        <HydrationProvider>
+          <ThemeContext.Provider value={themeContextValue}>
+            <ToastProvider
+              inherit={themeProp === 'inherit' && !portalContainerProp}
             >
-              {children}
+              {includeCss && rootElement ? (
+                <FallbackStyles root={rootElement} />
+              ) : null}
 
-              <PortalContainer
+              <MainRoot
                 theme={theme}
                 themeOptions={themeOptions}
-                future={future}
-                portalContainerProp={portalContainerProp}
-                portalContainerFromParent={portalContainerFromParent}
-                setPortalContainer={setPortalContainer}
-                isInheritingTheme={themeProp === 'inherit'}
-              />
-            </MainRoot>
-          </ToastProvider>
-        </ThemeContext.Provider>
-      </HydrationProvider>
-    </PortalContainerContext.Provider>
+                ref={useMergedRefs(
+                  forwardedRef,
+                  setRootElement,
+                  useIuiDebugRef,
+                )}
+                {...rest}
+              >
+                {children}
+
+                <PortalContainer
+                  theme={theme}
+                  themeOptions={themeOptions}
+                  portalContainerProp={portalContainerProp}
+                  portalContainerFromParent={portalContainerFromParent}
+                  setPortalContainer={setPortalContainer}
+                  isInheritingTheme={themeProp === 'inherit'}
+                />
+              </MainRoot>
+            </ToastProvider>
+          </ThemeContext.Provider>
+        </HydrationProvider>
+      </PortalContainerContext.Provider>
+    </FutureFlagsProvider>
   );
 }) as PolymorphicForwardRefComponent<'div', ThemeProviderOwnProps>;
 if (process.env.NODE_ENV === 'development') {
@@ -266,13 +262,15 @@ const MainRoot = React.forwardRef((props, forwardedRef) => {
 // ----------------------------------------------------------------------------
 
 const Root = React.forwardRef((props, forwardedRef) => {
-  const { theme, children, themeOptions, className, future, ...rest } = props;
+  const { theme, children, themeOptions, className, ...rest } = props;
 
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
   const prefersHighContrast = useMediaQuery('(prefers-contrast: more)');
   const shouldApplyDark = theme === 'dark' || (theme === 'os' && prefersDark);
   const shouldApplyHC = themeOptions?.highContrast ?? prefersHighContrast;
   const shouldApplyBackground = themeOptions?.applyBackground;
+
+  const themeBridge = useFutureFlag('themeBridge');
 
   return (
     <Box
@@ -283,7 +281,7 @@ const Root = React.forwardRef((props, forwardedRef) => {
       )}
       data-iui-theme={shouldApplyDark ? 'dark' : 'light'}
       data-iui-contrast={shouldApplyHC ? 'high' : 'default'}
-      data-iui-bridge={!!future?.themeBridge ? true : undefined}
+      data-iui-bridge={themeBridge ? 'true' : undefined}
       ref={forwardedRef}
       {...rest}
     >
@@ -370,7 +368,6 @@ const PortalContainer = React.memo(
     isInheritingTheme,
     theme,
     themeOptions,
-    future,
   }: {
     portalContainerProp: HTMLElement | undefined;
     portalContainerFromParent: HTMLElement | null;
@@ -422,7 +419,6 @@ const PortalContainer = React.memo(
         <Root
           theme={theme}
           themeOptions={{ ...themeOptions, applyBackground: false }}
-          future={future}
           data-iui-portal
           style={{ display: 'contents' }}
           ref={setPortalContainer}

--- a/packages/itwinui-react/src/utils/providers/FutureFlagsProvider.tsx
+++ b/packages/itwinui-react/src/utils/providers/FutureFlagsProvider.tsx
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from 'react';
+import { useSafeContext } from '../hooks/useSafeContext.js';
+
+export type FutureOptions = {
+  /**
+   * @alpha
+   *
+   * If enabled, the theme resembles the future iTwinUI version's theme (including alphas) *whenever possible*.
+   *
+   * This is useful in making apps looks like future versions of iTwinUI to help with incremental adoption.
+   *
+   * **NOTE**: Since this is a theme bridge to *future* versions, the theme could have breaking changes.
+   */
+  themeBridge?: boolean;
+};
+
+const FutureFlagsContext = React.createContext<FutureOptions>({});
+
+/**
+ * Hook to access future flags.
+ * @private
+ *
+ * @example
+ * ```jsx
+ * const themeBridge = useFutureFlag('themeBridge');
+ * ```
+ */
+export function useFutureFlag<K extends keyof FutureOptions>(key: K) {
+  const context = useSafeContext(FutureFlagsContext);
+  return (context[key] ?? {}) as NonNullable<FutureOptions[K]>;
+}
+
+/** @private */
+export const FutureFlagsProvider = ({
+  children,
+  value,
+}: React.PropsWithChildren<{ value: true | FutureOptions }>) => {
+  if (typeof value === 'boolean') {
+    value = {
+      themeBridge: value,
+    };
+  }
+
+  const context = React.useContext(FutureFlagsContext);
+  const combinedValue = { ...context, ...value };
+
+  return (
+    <FutureFlagsContext.Provider
+      value={React.useMemo(
+        () => combinedValue,
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- stringify the value to avoid unnecessary re-renders
+        [JSON.stringify(combinedValue)],
+      )}
+    >
+      {children}
+    </FutureFlagsContext.Provider>
+  );
+};

--- a/packages/itwinui-react/src/utils/providers/FutureFlagsProvider.tsx
+++ b/packages/itwinui-react/src/utils/providers/FutureFlagsProvider.tsx
@@ -31,7 +31,7 @@ const FutureFlagsContext = React.createContext<FutureOptions>({});
  */
 export function useFutureFlag<K extends keyof FutureOptions>(key: K) {
   const context = useSafeContext(FutureFlagsContext);
-  return (context[key] ?? {}) as NonNullable<FutureOptions[K]>;
+  return context[key];
 }
 
 /** @private */
@@ -39,9 +39,9 @@ export const FutureFlagsProvider = ({
   children,
   value,
 }: React.PropsWithChildren<{ value: true | FutureOptions }>) => {
-  if (typeof value === 'boolean') {
+  if (value === true) {
     value = {
-      themeBridge: value,
+      themeBridge: true,
     };
   }
 

--- a/packages/itwinui-react/src/utils/providers/index.ts
+++ b/packages/itwinui-react/src/utils/providers/index.ts
@@ -2,4 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+export * from './FutureFlagsProvider.js';
 export * from './HydrationProvider.js';


### PR DESCRIPTION
## Changes

This PR removes the `future` object from `ThemeContext` and moves it into a dedicated `FutureFlagsProvider`. Individual `future` flags can be accessed using a new type-safe `useFutureFlag()` hook.

```jsx
const themeBridge = useFutureFlag('themeBridge');
```

The name `useFutureFlag` is bikesheddable (maybe should be `useFutureFlags` or just `useFuture`)

Important points:
- ThemeProvider's `future` prop now accepts a boolean to enable all flags in one go.
- The `future` object is combined between Context and explicitly passed values.

## Testing

Manually tested that theme bridge continues to work in react-workshop.

## Docs

This PR is mostly changing internals, but added a changeset for the new `future={true}` option.