### PR TITLE
MenuItem: deprecate `value` prop and expose `onClick` event

### DIFF
--- a/.changeset/clever-cycles-care.md
+++ b/.changeset/clever-cycles-care.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+`MenuItem`'s `value` prop has been deprecated. When the `value` is not passed, the `onClick` prop will now be called with the `event` instead of `value`.

--- a/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBoxMenuItem.tsx
@@ -21,7 +21,7 @@ export const ComboBoxMenuItem = React.memo(
       children,
       isSelected,
       disabled,
-      value,
+      value, // eslint-disable-line -- Unused.
       onClick,
       sublabel,
       size = !!sublabel ? 'large' : 'default',
@@ -52,7 +52,7 @@ export const ComboBoxMenuItem = React.memo(
         disabled={disabled}
         focused={focusedIndex === index}
         ref={refs}
-        onClick={() => onClick?.(value)}
+        onClick={() => onClick?.()}
         role={role}
         tabIndex={role === 'presentation' ? undefined : -1}
         aria-selected={isSelected}

--- a/packages/itwinui-react/src/core/Menu/MenuItem.test.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.test.tsx
@@ -315,3 +315,15 @@ it('should portal submenu to same place as parent menu', async () => {
   expect(portaledParentMenuItem).toBeTruthy();
   expect(portaledSubmenuItem).toBeTruthy();
 });
+
+it('should call onClick with event argument', async () => {
+  const onClick = vi.fn();
+  render(<MenuItem onClick={onClick}>Test</MenuItem>);
+
+  const menuItem = screen.getByRole('menuitem');
+  await userEvent.click(menuItem);
+
+  expect(onClick).toHaveBeenCalledWith(
+    expect.objectContaining({ target: menuItem }), // event-like object
+  );
+});

--- a/packages/itwinui-react/src/core/Menu/MenuItem.tsx
+++ b/packages/itwinui-react/src/core/Menu/MenuItem.tsx
@@ -28,57 +28,66 @@ export type MenuItemProps = {
    * Item is disabled.
    */
   disabled?: boolean;
-  /**
-   * Value of the item.
-   */
-  value?: unknown;
-  /**
-   * Callback function that handles click and keyboard submit actions.
-   */
-  onClick?: (value?: unknown) => void;
-  /**
-   * Modify height of the item.
-   * Use 'large' when any of the sibling items have `sublabel`.
-   *
-   * Defaults to 'large' if `sublabel` provided, otherwise 'default'.
-   */
-  size?: 'default' | 'large';
-  /**
-   * Sub label shown below the main content of the item.
-   */
-  sublabel?: React.ReactNode;
-  /**
-   * SVG icon component shown on the left.
-   */
-  startIcon?: React.JSX.Element;
-  /**
-   * @deprecated Use startIcon.
-   * SVG icon component shown on the left.
-   */
-  icon?: React.JSX.Element;
-  /**
-   * SVG icon component shown on the right.
-   */
-  endIcon?: React.JSX.Element;
-  /**
-   * @deprecated Use endIcon.
-   * SVG icon component shown on the right.
-   */
-  badge?: React.JSX.Element;
-  /**
-   * ARIA role. For menu item use 'menuitem', for select item use 'option'.
-   * @default 'menuitem'
-   */
-  role?: string;
-  /**
-   * Items to be shown in the submenu when hovered over the item.
-   */
-  subMenuItems?: React.JSX.Element[];
-  /**
-   * Content of the menu item.
-   */
-  children?: React.ReactNode;
-} & Pick<ListItemOwnProps, 'focused'>;
+} & (
+  | {
+      /**
+       * Value of the item.
+       * @deprecated
+       */
+      value: unknown;
+      /**
+       * Callback function that handles click and keyboard submit actions.
+       */
+      onClick?: (value?: unknown) => void;
+    }
+  | {
+      /** @deprecated */ value?: never;
+      onClick?: (event?: React.MouseEvent) => void;
+    }
+) & {
+    /**
+     * Modify height of the item.
+     * Use 'large' when any of the sibling items have `sublabel`.
+     *
+     * Defaults to 'large' if `sublabel` provided, otherwise 'default'.
+     */
+    size?: 'default' | 'large';
+    /**
+     * Sub label shown below the main content of the item.
+     */
+    sublabel?: React.ReactNode;
+    /**
+     * SVG icon component shown on the left.
+     */
+    startIcon?: React.JSX.Element;
+    /**
+     * @deprecated Use startIcon.
+     * SVG icon component shown on the left.
+     */
+    icon?: React.JSX.Element;
+    /**
+     * SVG icon component shown on the right.
+     */
+    endIcon?: React.JSX.Element;
+    /**
+     * @deprecated Use endIcon.
+     * SVG icon component shown on the right.
+     */
+    badge?: React.JSX.Element;
+    /**
+     * ARIA role. For menu item use 'menuitem', for select item use 'option'.
+     * @default 'menuitem'
+     */
+    role?: string;
+    /**
+     * Items to be shown in the submenu when hovered over the item.
+     */
+    subMenuItems?: React.JSX.Element[];
+    /**
+     * Content of the menu item.
+     */
+    children?: React.ReactNode;
+  } & Pick<ListItemOwnProps, 'focused'>;
 
 /**
  * Basic menu item component. Should be used inside `Menu` component for each item.
@@ -144,7 +153,7 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
     } satisfies Parameters<typeof Menu>[0]['popoverProps'];
   }, [hasSubMenu]);
 
-  const onClick = () => {
+  const onClick = (event: React.MouseEvent) => {
     if (disabled) {
       return;
     }
@@ -153,10 +162,8 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
       dropdownMenu?.close();
     }
 
-    onClickProp?.(value);
+    onClickProp?.((value ?? event) as any);
   };
-
-  const handlers: React.DOMAttributes<HTMLButtonElement> = { onClick };
 
   /** Index of this item out of all the focusable items in the parent `Menu` */
   const focusableItemIndex = parentMenu?.focusableElements.findIndex(
@@ -182,9 +189,9 @@ export const MenuItem = React.forwardRef((props, forwardedRef) => {
       {...(parentMenu?.popoverGetItemProps != null
         ? parentMenu.popoverGetItemProps({
             focusableItemIndex,
-            userProps: handlers,
+            userProps: { onClick },
           })
-        : handlers)}
+        : { onClick })}
       {...(rest as React.DOMAttributes<HTMLButtonElement>)}
     >
       {startIcon && (

--- a/packages/itwinui-react/src/core/Select/Select.tsx
+++ b/packages/itwinui-react/src/core/Select/Select.tsx
@@ -369,7 +369,13 @@ const CustomSelect = React.forwardRef((props, forwardedRef) => {
         <MenuItem>{option.label}</MenuItem>
       );
 
-      const { label, icon, startIcon: startIconProp, ...restOption } = option;
+      const {
+        label,
+        icon,
+        startIcon: startIconProp,
+        value: _, // eslint-disable-line -- Unused. We do not want to pass `value` to `MenuItem`.
+        ...restOption
+      } = option;
 
       const startIcon = startIconProp ?? icon;
 


### PR DESCRIPTION
## Changes

Two (and half) changes to `MenuItem` component:
1. Deprecated `value` prop.
2. Made `onClick` be called with the `event` arg when `value` is not passed.
   2.5. Removed intermediate `handlers` object which only contains `onClick`.

There were also some very small changes in `ComboBox` and `Select`, both of which internally use `MenuItem`. These components no longer pass `value` to `MenuItem`. The `onClick` is not affected because we weren't really using the arg. There should be no changes needed on consuming side.

### Types

The prop types now use a discriminated union to determine the correct type of `onClick` based on `value`. This doesn't work perfectly, but is still acceptable.
- When `value` is passed, `onClick` is called with `value?: unknown` (same as before).
- When `value` is not passed, `onClick` is called with `any`.
  - **`event` needs explicit typing**, i.e. `onClick={(event: React.MouseEvent) => {}}`

To infer the `event` type automatically, we would probably need to use a generic type. However this would complicate how the entire component is typed, so I chose not to do this.

<details>
<summary>Example</summary>

```ts
type ValueAndOnClick<T> =
  | {
      /**
       * Value of the item.
       * @deprecated
       */
      value: T;
      /**
       * Callback function that handles click and keyboard submit actions.
       */
      onClick?: (value?: T) => void;
    }
  | {
      /** @deprecated */ value?: never;
      onClick?: (event: React.MouseEvent<HTMLElement>) => void;
    };
```

</details>


## Testing

Added a simple unit test verifying the behavior of `<MenuItem onClick={…}>`.

Also manually tested `DropdownMenu`, `ComboBox` and `Select` for extra surety.

## Docs

Added a `minor` changeset.

I was looking into whether any docs need to be updated, but it seems like `MenuItem` is not explicitly documented anywhere (not even in `dropdownmenu.mdx`).
