### PR TITLE
remove internal `LineClamp` component

### DIFF
--- a/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
+++ b/packages/itwinui-react/src/core/Table/ColumnHeader.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import {
   Box,
   ShadowRoot,
-  LineClamp,
+  lineClamp,
   SvgSortDown,
   SvgSortUp,
   useMergedRefs,
@@ -135,10 +135,10 @@ export const ColumnHeader = React.forwardRef((props, forwardedRef) => {
     >
       <>
         {typeof column.Header === 'string' ? (
-          <ShadowRoot>
-            <LineClamp>
+          <ShadowRoot css={lineClamp.css}>
+            <div className={lineClamp.className}>
               <slot />
-            </LineClamp>
+            </div>
             <slot name='actions' />
             <slot name='resizers' />
             <slot name='shadows' />

--- a/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
+++ b/packages/itwinui-react/src/core/Table/cells/DefaultCell.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { defaultColumn } from 'react-table';
 import type { CellRendererProps } from '../../../react-table/react-table.js';
 import cx from 'classnames';
-import { Box, LineClamp, ShadowRoot } from '../../../utils/index.js';
+import { Box, lineClamp, ShadowRoot } from '../../../utils/index.js';
 import { TableInstanceContext } from '../utils.js';
 
 export type DefaultCellProps<T extends Record<string, unknown>> = {
@@ -97,9 +97,9 @@ export const DefaultCell = <T extends Record<string, unknown>>(
 
         <TableCellContent shouldRenderWrapper={isCellRendererChildrenCustom}>
           {clamp ? (
-            <LineClamp>
+            <div className={lineClamp.className}>
               <slot />
-            </LineClamp>
+            </div>
           ) : (
             <slot />
           )}
@@ -178,4 +178,5 @@ const css = /* css */ `
   inset: -6px;
   z-index: -1;
 }
+${lineClamp.css}
 `;

--- a/packages/itwinui-react/src/utils/components/LineClamp.tsx
+++ b/packages/itwinui-react/src/utils/components/LineClamp.tsx
@@ -2,37 +2,20 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as React from 'react';
-import cx from 'classnames';
-import type { PolymorphicForwardRefComponent } from '../props.js';
-import { Box } from './Box.js';
-import { ShadowRoot } from './ShadowRoot.js';
 
-/** @private */
-export const LineClamp = React.forwardRef((props, forwardedRef) => {
-  const { lines, children, ...rest } = props;
-  return (
-    <Box
-      ref={forwardedRef}
-      {...rest}
-      className={cx('iui-line-clamp', props.className)}
-      style={
-        { '--_iui-line-clamp': lines, ...props.style } as React.CSSProperties
-      }
-    >
-      <ShadowRoot css={css} flush={false}>
-        <slot />
-      </ShadowRoot>
-      {children}
-    </Box>
-  );
-}) as PolymorphicForwardRefComponent<'div', { lines?: number }>;
+const className = '_iui-line-clamp';
 
 const css = /* css */ `
-  :host {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: var(--_iui-line-clamp, 3);
-    -webkit-box-orient: vertical;
-  }
+.${className} {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: var(--_iui-line-clamp, 3);
+  -webkit-box-orient: vertical;
+}
 `;
+
+/** @private */
+export const lineClamp = {
+  css,
+  className,
+};


### PR DESCRIPTION
## Changes

This PR converts the `LineClamp` component into an object containing `className` and `css` which can be manually added.

Instead of the line-clamp element creating its own shadow-root just for adding four lines of CSS, we can now reuse the existing shadow-roots (added by `ColumnHeader` and `DefaultCell`).

The main motivation for this change is **performance**. As we've seen in #2462, having every single cell render multiple shadow-roots can cause performance issues. This PR is a small step towards tackling the main performance issue (#2444).

## Testing

N/A. No change in behavior.

## Docs

N/A.