### PR TITLE
Remove `stretched` prop from `IconButton`

### DIFF
--- a/.changeset/lovely-times-notice.md
+++ b/.changeset/lovely-times-notice.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Removed the accidentally added `stretched` prop from `IconButton`.

--- a/packages/itwinui-react/src/core/Buttons/IconButton.tsx
+++ b/packages/itwinui-react/src/core/Buttons/IconButton.tsx
@@ -46,6 +46,7 @@ export type IconButtonProps = {
   | 'endIconProps'
   | 'labelProps'
   | 'loading'
+  | 'stretched'
 >;
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Noticed that the `stretched` prop was accidentally added to the `IconButton`. This PR removes this no-op prop since we didn't intend the IconButton to be stretched.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Confirmed that `stretched` no longer shows up in the types and autocomplete.

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added `patch` react changeset.