### PR TITLE
Fix theme bridge background in `react-workshop`

### DIFF
--- a/apps/react-workshop/.ladle/components.tsx
+++ b/apps/react-workshop/.ladle/components.tsx
@@ -31,9 +31,6 @@ export const Provider: GlobalProvider = ({ children }) => {
     });
   }, []);
 
-  // Deferring futureThemeBridge updates to work around Ladle's infinite re-renders when DOM changes upon changing args.
-  const futureThemeBridge = React.useDeferredValue(futureThemeBridgeArg);
-
   // propagate theme to <html> element for page background
   React.useLayoutEffect(() => {
     document.documentElement.dataset.colorScheme = theme;
@@ -41,7 +38,7 @@ export const Provider: GlobalProvider = ({ children }) => {
     document.documentElement.dataset.iuiContrast = highContrast
       ? 'high'
       : 'default';
-  }, [theme, highContrast, futureThemeBridge]);
+  }, [theme, highContrast]);
 
   // redirect old storybook paths to new ones
   React.useEffect(() => {
@@ -54,6 +51,9 @@ export const Provider: GlobalProvider = ({ children }) => {
       }
     }
   }, []);
+
+  // Deferring futureThemeBridge updates to work around Ladle's infinite re-renders when DOM changes upon changing args.
+  const futureThemeBridge = React.useDeferredValue(futureThemeBridgeArg);
 
   const themeProviderProps = {
     theme,


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Partially addresses #2606.

`react-workshop` demos always showed the default background of iTwinUI's backdrop `--iui-color-background-backdrop` regardless of whether the theme bridge was enabled or not. This is because the `ladle-background` element is outside the `ThemeProvider`/`Root` and so doesn't get the theme bridge mapping to the StrataKit equivalent.

<details><summary>Sample DOM</summary>

```html
<html
  lang="en-US"
  data-theme="dark"
  data-mode="full"
  data-storyloaded=""
  data-color-scheme="dark"
  data-iui-theme="dark"
  data-iui-contrast="default"
>
  <head></head>

  <body>
    <div
      class="ladle-background"
      style="background: var(--iui-color-background-backdrop);"
      aria-hidden="true"
    ></div>

    <div
      id="ladle-root"
      class="ladle-wrapper"
      aria-hidden="true"
    >
      <main class="ladle-main">
        <div
          class="🥝-root _iui3191-root"
          data-iui-theme="dark"
          data-iui-contrast="default"
          data-iui-bridge="true"
          data-kiwi-theme="dark"
          data-kiwi-density="dense"
        >
          <!-- App -->
        </div>
      </main>

      <div
        role="separator"
        aria-orientation="vertical"
        class="ladle-resize-handle"
      ></div>
      
      <nav
        role="navigation"
        class="ladle-aside"
        style="min-width: 192px;"
      >
        <!-- Bottom left Ladle controls -->
      </nav>
    </div>
  </body>
</html>
```

</details> 

I tried to add a `<ThemeProvider>` or `<Root>` outside of `ladle-main` but couldn't find a way to do so. Thus, this PR goes with the approach of adding CSS styles to add mappings from `--iui-color-background` and `--iui-color-background-backdrop` to their StrataKit equivalents. These mappings are hardcoded and thus need to be updated if we ever updated the mapping for `--iui-color-background` and `--iui-color-background-backdrop` in `bridge.scss`.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/05da1114-249d-411d-a91e-e3db4f4510a5" />|<video src="https://github.com/user-attachments/assets/7ef12aad-9e76-4be6-ba1c-7103a3a82344" />|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

N/A since change not in user-facing workspace