### PR TITLE
Fix theme bridge fonts

### DIFF
--- a/.changeset/khaki-women-sin.md
+++ b/.changeset/khaki-women-sin.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed theme bridge to use StrataKit fonts.

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -2,6 +2,9 @@
 // See LICENSE.md in the project root for license terms and full copyright notice.
 
 .iui-root:where([data-iui-bridge='true']) {
+  --iui-font-sans: var(--stratakit-font-family-sans);
+  --iui-font-mono: var(--stratakit-font-family-mono);
+
   --iui-color-white: var(--stratakit-color-static-white);
 
   --iui-color-background: var(--stratakit-color-bg-page-base);


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Addresses the issue mentioned in https://github.com/iTwin/iTwinUI/issues/2606#issuecomment-3104899344. In this issue, a `<ThemeProvider>` without `as={Root}` sets the `font-family` as iTwinUI's `--iui-font-sans` instead of StrataKit's `--stratakit-font-family-sans` for its descendants.

To fix it, the theme bridge maps iTwinUI's font variables with those of StrataKit.

## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->

Tested using the code mentioned in https://github.com/iTwin/iTwinUI/issues/2606#issuecomment-3104899344:

<details><summary>Code</summary>

```tsx
<ThemeProvider
  as={Root}
  future={{ themeBridge: true }}
  colorScheme={theme}
  synchronizeColorScheme
  density='dense'
>
  <ThemeProvider theme={theme}>
    <Button>Hello world</Button>
  </ThemeProvider>
</ThemeProvider>
```

</details> 

|Before|After|
|-|-|
|<img width="121" height="49" alt="Before; shows the iTwinUI font family used when theme bridge is enabled" src="https://github.com/user-attachments/assets/6401d6d9-35d0-4ade-bf41-25d8f1a9fe7d" />|<img width="121" height="49" alt="After; shows the correct StrataKit font family used when theme bridge is enabled" src="https://github.com/user-attachments/assets/0415bbe4-ffc0-49f6-b070-e7f1985c6846" />|

## Docs

<!--
If your PR includes user-facing changes, then update docs in all places (JSDoc, website, stories, etc).
Make sure to include a changeset (`pnpm changeset`).

If not applicable, you can write "N/A".
-->

Added patch react changeset.