### PR TITLE
make virtual tree nodes equally wide

### DIFF
--- a/.changeset/tricky-days-flash.md
+++ b/.changeset/tricky-days-flash.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Fixed horizontal scroll in `Tree` with `enableVirtualization` so that all nodes are equally wide instead of using their intrinsic width.

--- a/packages/itwinui-react/src/core/Tree/TreeContext.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeContext.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
+import type { Virtualizer } from '@tanstack/react-virtual';
 
 export type TreeContextProps = {
   /**
@@ -46,3 +47,13 @@ export const useTreeContext = () => {
   }
   return context;
 };
+
+export const VirtualizedTreeContext = React.createContext<
+  | {
+      virtualizer?: Virtualizer<Element, Element>;
+      onVirtualizerChange?: (
+        virtualizer?: Virtualizer<Element, Element>,
+      ) => void;
+    }
+  | undefined
+>(undefined);

--- a/packages/itwinui-react/src/core/Tree/TreeNode.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.tsx
@@ -12,7 +12,7 @@ import {
 import type { PolymorphicForwardRefComponent } from '../../utils/index.js';
 import cx from 'classnames';
 import { TreeNodeExpander } from './TreeNodeExpander.js';
-import { useTreeContext } from './TreeContext.js';
+import { useTreeContext, VirtualizedTreeContext } from './TreeContext.js';
 
 type TreeNodeProps = {
   /**
@@ -179,6 +179,9 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
     indexInGroup,
   } = useTreeContext();
 
+  const { virtualizer, onVirtualizerChange } =
+    React.useContext(VirtualizedTreeContext) ?? {};
+
   const [isFocused, setIsFocused] = React.useState(false);
   const nodeRef = React.useRef<HTMLDivElement>(null);
 
@@ -194,6 +197,7 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
         if (isNodeFocused) {
           if (isExpanded) {
             onExpanded(nodeId, false);
+            onVirtualizerChange?.(virtualizer);
             break;
           }
           if (parentNodeId) {
@@ -221,6 +225,7 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
         if (isNodeFocused) {
           if (!isExpanded && hasSubNodes) {
             onExpanded(nodeId, true);
+            onVirtualizerChange?.(virtualizer);
             break;
           }
           (focusableElements[0] as HTMLElement)?.focus();
@@ -257,9 +262,10 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
   const onExpanderClick = React.useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       onExpanded(nodeId, !isExpanded);
+      onVirtualizerChange?.(virtualizer);
       event.stopPropagation();
     },
-    [isExpanded, nodeId, onExpanded],
+    [isExpanded, nodeId, onExpanded, onVirtualizerChange, virtualizer],
   );
 
   return (


### PR DESCRIPTION
## Changes

Fixes #2330 by setting an explicit width on the virtualizer root. This width is periodically calculated as the maximum width of all _mounted_ elements inside the virtualizer.

This is done inside the virtualizer's [`onChange`](https://tanstack.com/virtual/latest/docs/api/virtualizer#onchange) callback, which I had to debounce because otherwise it executes several times when scrolling. Layout reads/writes are expensive operations so we should try to minimize them. I'm also updating the style imperatively instead of using React state (which would require additional re-render each time).

## Testing

Manually tested that the linked issue is fixed. Verified also that the Tree returns to its original width after a wider node is collapsed.

[Preview](https://itwin.github.io/iTwinUI/2633/react/?story=tree--virtualized-with-horizontal-scroll&theme=dark) (try expanding one of the deeply nested nodes and compare the behavior with [`main` branch](https://itwin.github.io/iTwinUI/react/?story=tree--virtualized-with-horizontal-scroll&theme=dark))

| Before | After |
| --- | --- |
| <img width="404" height="390" alt="Screenshot showing tree nodes that don't stretch to fill the available width" src="https://github.com/user-attachments/assets/ac10f1a4-151e-42e0-9619-cd2c10806f90" /> | <img width="411" height="392" alt="Screenshot showing tree nodes that stretch to fill the available width" src="https://github.com/user-attachments/assets/300dd1e2-bc47-4533-a80d-7cea4d95bd58" /> |


## Docs

Added changeset.
