### PR TITLE
add `color` to `::selection` styles

### DIFF
--- a/.changeset/afraid-groups-yawn.md
+++ b/.changeset/afraid-groups-yawn.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Added `color` to all text `::selection` styles. This fixes a theme bridge issue with text selection color contrast.

--- a/packages/itwinui-css/src/mixins.scss
+++ b/packages/itwinui-css/src/mixins.scss
@@ -19,7 +19,8 @@
 @mixin iui-text-selection($status: accent) {
   &::selection,
   *::selection {
-    background-color: hsl(var(--iui-color-#{$status}-hsl) / var(--iui-opacity-5));
+    background-color: hsl(var(--iui-color-#{$status}-hsl) / var(--iui-opacity-4));
+    color: var(--iui-color-text);
   }
 }
 


### PR DESCRIPTION
## Changes

Setting both `color` and `background-color` ensures sufficient color contrast in all scenarios.

Previously, `::selection` styles were only setting `background-color`. This was causing issues when combined with foreign `::selection` styles that also set `color` (as in the case of theme bridge).

## Testing

Verified that components which override the global text-selection colors appear correctly (especially in light theme).

| [Before](https://itwin.github.io/iTwinUI/react/?arg-future.themeBridge=true&story=alert--informational) | [After](https://itwin.github.io/iTwinUI/2636/react/?arg-future.themeBridge=true&story=alert--informational) |
| --- | --- |
| <img width="258" height="85" alt="Screenshot" src="https://github.com/user-attachments/assets/193b7e2d-367a-49fc-aae0-ff93569be0c3" /> | <img width="259" height="78" alt="Screenshot" src="https://github.com/user-attachments/assets/5b2afa62-252b-4dfc-bf37-3e7f90d1c501" /> |