### PR TITLE
remove theme bridge overrides from `Tabs`

### DIFF
--- a/.changeset/orange-cooks-dig.md
+++ b/.changeset/orange-cooks-dig.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Updated theme bridge styling for `Tabs` to use accent colors.

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -359,47 +359,9 @@
   /* Tabs */
 
   .iui-tabs-wrapper {
-    // The old accent stripe is now the regular stripe
-    --_iui-tab-color-stripe-blue: var(--stratakit-color-border-neutral-inverse);
-    // The old positive stripe is now the accent stripe
-    --_iui-tab-color-stripe-green: var(--stratakit-color-border-accent-strong);
-
-    // StrataKit has muted color on its non selected tabs
-    --_iui-tab-color-default: var(--stratakit-color-text-neutral-tertiary);
-    // StrataKit has no accent color on its selected tabs
-    --_iui-tab-color-selected: var(--stratakit-color-text-neutral-primary);
-    // The old positive color is now the accent color
-    --_iui-tab-color-green-selected: var(--stratakit-color-text-accent-strong);
-
-    // Selected tab has stripe on the bottom instead of top
-    &.iui-horizontal .iui-tab::after {
-      inset-inline: 4px;
-      inline-size: calc(100% - 4px * 2);
-      inset-block-start: calc(100% - var(--iui-size-3xs));
-    }
-
-    // Selected tab has stripe on the right instead of left
-    &.iui-vertical .iui-tab::after {
-      inset-block: 4px;
-      block-size: calc(100% - 4px * 2);
-      inset-inline-start: calc(100% - var(--iui-size-3xs));
-    }
-  }
-
-  .iui-tab {
-    // To account for outline-offset
-    border-radius: calc(4px + 6px);
-
-    // StrataKit tab has no border
-    border: none;
-  }
-
-  .iui-tabs-content {
-    // StrataKit tabs content has no background or border
-    background-color: transparent;
-    border: none;
-    // StrataKit border color here is not equal to --iui-color-border's global mapping
-    border-color: var(--stratakit-color-border-neutral-muted);
+    // Remove "positive" green
+    --_iui-tab-color-green-selected: var(--iui-color-text-accent);
+    --_iui-tab-color-stripe-green: var(--iui-color-border-accent);
   }
 
   /* ---------------------------------------------------------------------------- */

--- a/packages/itwinui-css/src/tabs/base.scss
+++ b/packages/itwinui-css/src/tabs/base.scss
@@ -133,10 +133,6 @@ $borderless-horizontal-tab-min-height: calc(
   }
 
   &.iui-green .iui-tab {
-    &:focus {
-      outline-color: var(--iui-color-text-positive);
-    }
-
     &:is([aria-selected='true'], [aria-current]) {
       --_iui-tab-color: var(--_iui-tab-color-green-selected);
 


### PR DESCRIPTION
## Changes

This PR removes all the theme bridge overrides for the `Tabs` component. These overrides were too aggressive, resulting in confusion among product teams and poor affordance for end users.

The global token overrides are enough to reflect the accent color changes, especially after #2541. Beyond that, the only thing necessary is to remove the "green" (positive) variant of Tabs. In the future, we should deprecate `color="green"` altogether.

Note: For simplicity, I decided to remove the focus-outline color change for green tabs in the base CSS.

## Testing

See deploy preview: [CSS](https://itwin.github.io/iTwinUI/2637/css/tabs) | [React](http://itwin.github.io/iTwinUI/2637/react/?arg-future.themeBridge=true&story=tabs--default-tabs&theme=dark).

<img width="301" height="148" alt="Screenshot of tabs with the active tab using green accent color" src="https://github.com/user-attachments/assets/3e8b1f2b-3b05-409c-8db6-e9b00f3aa8e3" />
