### PR TITLE
add fallbacks for token renames

### DIFF
--- a/.changeset/small-snails-strive.md
+++ b/.changeset/small-snails-strive.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Updated theme bridge to use latest token values.

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -12,7 +12,7 @@
   --iui-color-background-zebra: color-mix(
     in oklch,
     var(--stratakit-color-bg-page-base),
-    var(--stratakit-color-bg-page-zebra)
+    var(--stratakit-color-bg-control-table-zebra, var(--stratakit-color-bg-page-zebra))
   );
   --iui-color-background-hover: color-mix(
     in oklch,
@@ -76,9 +76,9 @@
   --iui-color-icon-negative: var(--stratakit-color-icon-critical-faded);
 
   --iui-color-icon: var(--stratakit-color-icon-neutral-base);
-  --iui-color-icon-hover: var(--stratakit-color-icon-neutral-hover);
+  --iui-color-icon-hover: var(--stratakit-color-icon-neutral-primary, var(--stratakit-color-icon-neutral-hover));
   --iui-color-icon-muted: var(--stratakit-color-icon-neutral-secondary);
-  --iui-color-icon-muted-hover: var(--stratakit-color-icon-neutral-hover);
+  --iui-color-icon-muted-hover: var(--stratakit-color-icon-neutral-primary, var(--stratakit-color-icon-neutral-hover));
   --iui-color-icon-disabled: var(--stratakit-color-icon-neutral-disabled);
   --iui-color-icon-disabled-hover: var(--iui-color-icon-disabled);
 
@@ -467,6 +467,6 @@
     border-color: var(--stratakit-color-border-elevation-base);
 
     // Use StrataKit's shadow instead of iTwinUI's
-    box-shadow: var(--stratakit-shadow-tooltip-base);
+    box-shadow: var(--stratakit-shadow-control-tooltip-base, var(--stratakit-shadow-tooltip-base));
   }
 }


### PR DESCRIPTION
## Changes

This is in preparation of upcoming renames to some CSS variables. The old variables are used as fallback to support multiple versions.

The fallbacks can be removed in a future minor release, together with a peer dep version bump.

## Testing

Manually checked that the fallback is working where these variables are used.

Since the new version of StrataKit is not yet released, it is not easy to test the happy path.