### PR TITLE
Force wrap long text for tile description

### DIFF
--- a/.changeset/sharp-donuts-jam.md
+++ b/.changeset/sharp-donuts-jam.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Force text wrapping for long words. Affected components: 'Tile'

--- a/.changeset/wise-cameras-mate.md
+++ b/.changeset/wise-cameras-mate.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': minor
+---
+
+Force text wrapping for long words. Affected component: 'Tile'

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -259,6 +259,8 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   max-block-size: 3lh;
   @include mixins.iui-line-clamp(3);
   color: var(--_iui-tile-body-text-color);
+  overflow-wrap: anywhere;
+  hyphens: auto;
 }
 
 @mixin iui-tile-metadata {


### PR DESCRIPTION
<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes
Added overflow-wrap: anywhere + hyphens: auto in the iui-tile-description mixin to force the text wrap when the word is too long. 

Affected component: Tile.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
Before:- 
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/f37eacca-7d21-4b71-984e-d4d3bdd5abfb" />
After:-
<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/b13e3a19-5b06-4450-8d41-16b6a41376d3" />

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->
