### PR TITLE
Add justifyContent prop to ButtonGroup

### DIFF
--- a/apps/react-workshop/src/ButtonGroup.stories.tsx
+++ b/apps/react-workshop/src/ButtonGroup.stories.tsx
@@ -111,67 +111,6 @@ Overflow.decorators = [
   ),
 ];
 
-export const OverflowJustifyEnd = () => {
-  const items = Array.from({ length: 10 }, (_, index) => (
-    <IconButton key={index} label={`Item #${index}`}>
-      <SvgPlaceholder />
-    </IconButton>
-  ));
-
-  return (
-    <ButtonGroup
-      orientation='horizontal'
-      justifyContent='flex-end'
-      overflowButton={(overflowStart) => (
-        <DropdownMenu
-          menuItems={(close) =>
-            Array(items.length - overflowStart)
-              .fill(null)
-              .map((_, _index) => {
-                const index = overflowStart + _index;
-                return (
-                  <MenuItem
-                    key={index}
-                    onClick={close}
-                    startIcon={<SvgPlaceholder />}
-                  >
-                    Item #{index}
-                  </MenuItem>
-                );
-              })
-          }
-        >
-          <IconButton label='More'>
-            <SvgMore />
-          </IconButton>
-        </DropdownMenu>
-      )}
-    >
-      {items}
-    </ButtonGroup>
-  );
-};
-OverflowJustifyEnd.decorators = [
-  (Story: () => React.ReactNode) => (
-    <>
-      <Text variant='small' as='small' isMuted>
-        Resize the container to see overflow behavior.
-      </Text>
-      <div
-        style={{
-          width: 'min(30rem, 100%)',
-          border: '1px solid hotpink',
-          padding: 8,
-          overflow: 'hidden',
-          resize: 'inline',
-        }}
-      >
-        <Story />
-      </div>
-    </>
-  ),
-];
-
 export const InputButtonCombo = () => {
   return (
     <ButtonGroup>
@@ -232,7 +171,6 @@ export const VerticalOverflow = () => {
   return (
     <ButtonGroup
       orientation='vertical'
-      justifyContent='center'
       style={{ blockSize: '100%' }}
       overflowButton={(overflowStart) => (
         <DropdownMenu


### PR DESCRIPTION

![2025-11-27 14 36 14](https://github.com/user-attachments/assets/bcc8894f-e05c-42eb-ad86-7337f0024e1b)


<!--
Thank you for your contribution to iTwinUI.

If you are only making changes to the docs site using the "Edit page on GitHub" link,
then you can ignore most of this template.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Added justify-content to the ButtonGroup to enable the user to decide where the button group should be aligned.
## Testing

<!--
How did you test your changes?
If your PR has visual changes, then make sure they are demonstrated in css-workshop and react-workshop, then approve visual test images for both (`pnpm approve:css` and `pnpm approve:react`).

If not applicable, you can write "N/A".
-->
I created a story and tested it in react-workshop