### PR TITLE
add headings to `Dialog` and `Tile`

### DIFF
--- a/.changeset/lovely-buses-yell.md
+++ b/.changeset/lovely-buses-yell.md
@@ -1,0 +1,7 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Improved the accessibility of **Dialog** and **Tile** by rendering headings by default.
+
+The default heading level is `<h2>`, which can be customized passing the `as` prop to `Dialog.TitleBar.Title` and `Tile.NameLabel` respectively.

--- a/apps/react-workshop/src/InformationPanel.stories.tsx
+++ b/apps/react-workshop/src/InformationPanel.stories.tsx
@@ -58,7 +58,9 @@ export const Basic = () => {
             console.log('Panel closed');
           }}
         >
-          <Text variant='subheading'>Row {openRowIndex ?? 0}</Text>
+          <Text variant='subheading' as='h2'>
+            Row {openRowIndex ?? 0}
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           <InformationPanelContent displayStyle='inline'>
@@ -139,7 +141,9 @@ export const Horizontal = () => {
             console.log('Panel closed');
           }}
         >
-          <Text variant='subheading'>Row {openRowIndex ?? 0}</Text>
+          <Text variant='subheading' as='h2'>
+            Row {openRowIndex ?? 0}
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           <InformationPanelContent displayStyle='inline'>
@@ -223,7 +227,9 @@ export const CustomActions = () => {
             </IconButton>
           }
         >
-          <Text variant='subheading'>Row details</Text>
+          <Text variant='subheading' as='h2'>
+            Row details
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           {openRowIndex != undefined && (
@@ -298,7 +304,9 @@ export const CustomWidth = () => {
             console.log('Panel closed');
           }}
         >
-          <Text variant='subheading'>Details</Text>
+          <Text variant='subheading' as='h2'>
+            Details
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           <Text>{lorem100}</Text>

--- a/examples/InformationPanel.horizontal.jsx
+++ b/examples/InformationPanel.horizontal.jsx
@@ -42,7 +42,9 @@ export default () => {
             </IconButton>
           }
         >
-          <Text variant='subheading'>Row {openRowIndex ?? 0}</Text>
+          <Text variant='subheading' as='h2'>
+            Row {openRowIndex ?? 0}
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           <InformationPanelContent displayStyle='inline'>

--- a/examples/InformationPanel.main.jsx
+++ b/examples/InformationPanel.main.jsx
@@ -24,7 +24,9 @@ export default () => {
         isOpen={openRowIndex != undefined && openRowIndex !== -1}
       >
         <InformationPanelHeader onClose={() => setOpenRowIndex(-1)}>
-          <Text variant='subheading'>Row {openRowIndex ?? 0}</Text>
+          <Text variant='subheading' as='h2'>
+            Row {openRowIndex ?? 0}
+          </Text>
         </InformationPanelHeader>
         <InformationPanelBody>
           <Text as='p'>Content for row {openRowIndex ?? 0} goes here.</Text>

--- a/packages/itwinui-css/src/dialog/dialog.scss
+++ b/packages/itwinui-css/src/dialog/dialog.scss
@@ -139,6 +139,8 @@ $iui-dialog-min-height: 7.75rem; // 7.75rem = 124px = title bar height + margins
 }
 
 .iui-dialog-title {
+  margin-block: 0;
+  font: inherit;
   margin-inline-end: auto;
   overflow: hidden;
   overflow-wrap: break-word;

--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -241,6 +241,9 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
 }
 
 @mixin iui-tile-name-label {
+  margin-block: 0;
+  font: inherit;
+
   &,
   > .iui-link-action {
     inline-size: 100%;

--- a/packages/itwinui-react/src/core/Dialog/DialogTitleBarTitle.test.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogTitleBarTitle.test.tsx
@@ -10,7 +10,7 @@ it('should render in its most basic state', () => {
   const { container } = render(
     <DialogTitleBarTitle>test-title</DialogTitleBarTitle>,
   );
-  const title = container.querySelector('.iui-dialog-title') as HTMLElement;
+  const title = container.querySelector('h2.iui-dialog-title') as HTMLElement;
   expect(title).toBeTruthy();
   expect(title).toHaveTextContent('test-title');
 });

--- a/packages/itwinui-react/src/core/Dialog/DialogTitleBarTitle.tsx
+++ b/packages/itwinui-react/src/core/Dialog/DialogTitleBarTitle.tsx
@@ -11,7 +11,7 @@ import { polymorphic } from '../../utils/index.js';
  *   <Dialog.TitleBar.Title>My dialog title</Dialog.TitleBar.Title>
  * </Dialog.TitleBar>
  */
-export const DialogTitleBarTitle = polymorphic.div('iui-dialog-title');
+export const DialogTitleBarTitle = polymorphic.h2('iui-dialog-title');
 if (process.env.NODE_ENV === 'development') {
   DialogTitleBarTitle.displayName = 'Dialog.TitleBar.Title';
 }

--- a/packages/itwinui-react/src/core/InformationPanel/InformationPanelHeader.tsx
+++ b/packages/itwinui-react/src/core/InformationPanel/InformationPanelHeader.tsx
@@ -45,7 +45,7 @@ type InformationPanelHeaderProps = {
  *     </>
  *   )}
  * >
- *   <Text variant='subheading'>InfoPanel heading</Text>
+ *   <Text variant='subheading' as='h2'>InfoPanel heading</Text>
  * </InformationPanelHeader>
  */
 export const InformationPanelHeader = React.forwardRef(
@@ -58,9 +58,7 @@ export const InformationPanelHeader = React.forwardRef(
         ref={forwardedRef}
         {...rest}
       >
-        <Box as='span' className='iui-information-header-label'>
-          {children}
-        </Box>
+        <Box className='iui-information-header-label'>{children}</Box>
         <Box className='iui-information-header-actions'>
           {actions}
           {onClose && (

--- a/packages/itwinui-react/src/core/Tile/Tile.test.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.test.tsx
@@ -24,7 +24,7 @@ it('should render in its most basic state', () => {
   expect(container.querySelector('.iui-tile-thumbnail')).toBeFalsy();
   expect(container.querySelector('.iui-tile-content')).toBeTruthy();
 
-  const label = container.querySelector('.iui-tile-name') as HTMLSpanElement;
+  const label = container.querySelector('h2') as HTMLElement;
   expect(label.textContent).toBe('test-name');
 });
 

--- a/packages/itwinui-react/src/core/Tile/Tile.tsx
+++ b/packages/itwinui-react/src/core/Tile/Tile.tsx
@@ -343,7 +343,7 @@ if (process.env.NODE_ENV === 'development') {
 // ----------------------------------------------------------------------------
 // Tile.NameLabel component
 
-const TileNameLabel = polymorphic.span('iui-tile-name-label');
+const TileNameLabel = polymorphic.h2('iui-tile-name-label');
 if (process.env.NODE_ENV === 'development') {
   TileNameLabel.displayName = 'Tile.NameLabel';
 }


### PR DESCRIPTION
## Changes

This PR changes the default element of `Dialog.TitleBar.Title` and `Tile.NameLabel` to **`<h2>`**, and adds some CSS to counteract UA styles.

Additionally, this PR updates the docs/stories/examples of `InformationPanel` to show the use of `<h2>`. (This is unfortunately not easy to handle within the component due to API shape)

## Testing

Manually verified that visual appearance is the same, while semantics are improved.

Updated selectors in unit tests to check for `<h2>` element.