### PR TITLE
update `Tile` thumbnail radius

### DIFF
--- a/packages/itwinui-css/src/tile/tile.scss
+++ b/packages/itwinui-css/src/tile/tile.scss
@@ -27,11 +27,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
   }
 
   &:where(:not(.iui-folder)) {
-    > :where(.iui-tile-thumbnail) {
-      border-start-start-radius: inherit;
-      border-start-end-radius: inherit;
-    }
-
     > :where(:last-child) {
       border-end-start-radius: inherit;
       border-end-end-radius: inherit;
@@ -160,11 +155,6 @@ $thumbnail-selector: ':is(.iui-thumbnail-icon, .iui-tile-thumbnail-picture)';
     'thumbnail content';
   grid-template-columns: 1fr 2fr;
   grid-template-rows: auto 1fr;
-
-  > :where(:first-child) {
-    border-start-start-radius: inherit;
-    border-end-start-radius: inherit;
-  }
 
   > :where(:last-child) {
     border-start-end-radius: inherit;


### PR DESCRIPTION
## Changes

Fixes https://github.com/iTwin/iTwinUI/issues/2669.

Tile thumbnail now sets its corner radius value to `outer border-radius MINUS border-width`.

## Testing

**Screenshots:**

| Before | After |
| --- | --- |
| <img width="225" height="164" alt="screenshot" src="https://github.com/user-attachments/assets/2a1a314e-f1dc-4448-8111-4daf438d8cc2" /> | <img width="226" height="164" alt="screenshot" src="https://github.com/user-attachments/assets/e94f1635-ed5d-42cd-88fa-159502ceba9c" /> |

Visual test snapshots are mostly unaffected because this is a subpixel change that might not meet the minimum threshold.