### PR TITLE
Close `ComboBox` dropdown menu after `onChange` callback when option is chosen

### DIFF
--- a/.changeset/sparkly-squids-mix.md
+++ b/.changeset/sparkly-squids-mix.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': minor
+---
+
+Close ComboBox dropdown menu after onChange callback when option is chosen

--- a/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
+++ b/packages/itwinui-react/src/core/ComboBox/ComboBox.tsx
@@ -510,8 +510,8 @@ export const ComboBox = React.forwardRef(
           }
         } else {
           setSelectedIndexes(__originalIndex);
-          hide();
           onChangeHandler(__originalIndex);
+          hide();
         }
       },
       [


### PR DESCRIPTION
## Changes

Will make it so choosing an option from `ComboBox`'s dropdown menu will first fire the `onChange` calback before hiding the dropdown, thus having the `onHide` callback be fired after `onChange` and allowing to know whether the dropdown was closed because of an option being selected.

## Testing

Tested the change within a local Electron-based application that uses iTwinUI, and `onChange` is fired before `onHide`, as expected by the change.

Although, since the order in which the callbacks are fired changes, and the order appears to have been this way for at least 3 years, this may be a bigger breaking change than it's worth.