### PR TITLE
move `virtualizer` out of `TreeNode`

### DIFF
--- a/.changeset/nice-cars-rhyme.md
+++ b/.changeset/nice-cars-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Small internal change to move `virtualizer` out of `TreeNode`.

--- a/packages/itwinui-react/src/core/Tree/Tree.tsx
+++ b/packages/itwinui-react/src/core/Tree/Tree.tsx
@@ -408,6 +408,9 @@ const VirtualizedTree = React.forwardRef(
   ) => {
     const parentRef = React.useRef<HTMLDivElement | null>(null);
     const virtualizerRootRef = React.useRef<HTMLDivElement | null>(null);
+    const virtualizerRef = React.useRef<
+      Virtualizer<Element, Element> | undefined
+    >(undefined);
 
     const getItemKey = React.useCallback(
       (index: number) => {
@@ -419,7 +422,8 @@ const VirtualizedTree = React.forwardRef(
     /** Sets the virtualizer width to that of the widest element, so that all items are same width. */
     const onVirtualizerChange = React.useMemo(
       () =>
-        debounce((virtualizer?: Virtualizer<Element, Element>) => {
+        debounce(() => {
+          const virtualizer = virtualizerRef.current;
           if (!virtualizer || !virtualizerRootRef.current) {
             return;
           }
@@ -449,6 +453,10 @@ const VirtualizedTree = React.forwardRef(
     });
 
     useLayoutEffect(() => {
+      virtualizerRef.current = virtualizer;
+    }, [virtualizer]);
+
+    useLayoutEffect(() => {
       if (scrollToIndex) {
         virtualizer.scrollToIndex(scrollToIndex);
       }
@@ -468,8 +476,8 @@ const VirtualizedTree = React.forwardRef(
           </ShadowRoot>
           <VirtualizedTreeContext.Provider
             value={React.useMemo(
-              () => ({ virtualizer, onVirtualizerChange }),
-              [virtualizer, onVirtualizerChange],
+              () => ({ onVirtualizerChange }),
+              [onVirtualizerChange],
             )}
           >
             {virtualizer

--- a/packages/itwinui-react/src/core/Tree/TreeContext.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeContext.tsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import * as React from 'react';
-import type { Virtualizer } from '@tanstack/react-virtual';
 
 export type TreeContextProps = {
   /**
@@ -50,10 +49,7 @@ export const useTreeContext = () => {
 
 export const VirtualizedTreeContext = React.createContext<
   | {
-      virtualizer?: Virtualizer<Element, Element>;
-      onVirtualizerChange?: (
-        virtualizer?: Virtualizer<Element, Element>,
-      ) => void;
+      onVirtualizerChange?: () => void;
     }
   | undefined
 >(undefined);

--- a/packages/itwinui-react/src/core/Tree/TreeNode.tsx
+++ b/packages/itwinui-react/src/core/Tree/TreeNode.tsx
@@ -179,7 +179,7 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
     indexInGroup,
   } = useTreeContext();
 
-  const { virtualizer, onVirtualizerChange } =
+  const { onVirtualizerChange } =
     React.useContext(VirtualizedTreeContext) ?? {};
 
   const [isFocused, setIsFocused] = React.useState(false);
@@ -197,7 +197,7 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
         if (isNodeFocused) {
           if (isExpanded) {
             onExpanded(nodeId, false);
-            onVirtualizerChange?.(virtualizer);
+            onVirtualizerChange?.();
             break;
           }
           if (parentNodeId) {
@@ -225,7 +225,7 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
         if (isNodeFocused) {
           if (!isExpanded && hasSubNodes) {
             onExpanded(nodeId, true);
-            onVirtualizerChange?.(virtualizer);
+            onVirtualizerChange?.();
             break;
           }
           (focusableElements[0] as HTMLElement)?.focus();
@@ -262,10 +262,10 @@ export const TreeNode = React.forwardRef((props, forwardedRef) => {
   const onExpanderClick = React.useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       onExpanded(nodeId, !isExpanded);
-      onVirtualizerChange?.(virtualizer);
+      onVirtualizerChange?.();
       event.stopPropagation();
     },
-    [isExpanded, nodeId, onExpanded, onVirtualizerChange, virtualizer],
+    [isExpanded, nodeId, onExpanded, onVirtualizerChange],
   );
 
   return (


### PR DESCRIPTION
## Changes

This is a follow-up optimization from #2633.

Instead of storing the `virtualizer` object in Context and reading it in `TreeNode` (of which there can be hundreds of thousands, constantly unmounting and remounting during scroll), we will now store it in a `ref` in `Tree`. The `TreeNode` has no real use for `virtualizer`; it simply needs to notify the parent `Tree`.

## Testing

Existing behavior of "virtualized tree + horizontal scrolling" confirmed unchanged.