### PR TITLE
fix(Table): correct column drag-and-drop reordering when hidden columns are present

### DIFF
--- a/.changeset/khaki-tables-flash.md
+++ b/.changeset/khaki-tables-flash.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': major
+---
+
+correct column drag-and-drop reordering when hidden columns are present

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -2887,6 +2887,69 @@ it.each([
   },
 );
 
+it('should reorder correctly when hidden columns are present', async () => {
+  const columns: Column<TestDataType>[] = [
+    {
+      id: 'name',
+      Header: 'Name',
+      accessor: 'name',
+    },
+    {
+      id: 'description',
+      Header: 'Description',
+      accessor: 'description',
+    },
+    {
+      id: 'view',
+      Header: 'View',
+      Cell: () => <>View</>,
+    },
+    ActionColumn({ columnManager: true }),
+  ];
+
+  const { container } = render(
+    <Table
+      columns={columns}
+      data={mockedData()}
+      emptyTableContent='Empty table'
+      emptyFilteredTableContent='No results. Clear filter.'
+      enableColumnReordering
+    />,
+  );
+
+  let headerCells = container.querySelectorAll<HTMLDivElement>(
+    '.iui-table-header .iui-table-cell',
+  );
+  const columnManager = headerCells[headerCells.length - 1]
+    .firstElementChild as HTMLElement;
+  await userEvent.click(columnManager);
+
+  const columnManagerColumns = document.querySelectorAll<HTMLElement>('label');
+  await userEvent.click(columnManagerColumns[1]);
+
+  let draggableHeaderCells = container.querySelectorAll<HTMLDivElement>(
+    '.iui-table-header .iui-table-cell[draggable="true"]',
+  );
+  expect(
+    Array.from(draggableHeaderCells).map((cell) => cell.textContent),
+  ).toEqual(['Name', 'View']);
+
+  const srcColumn = draggableHeaderCells[1];
+  const dstColumn = draggableHeaderCells[0];
+
+  fireEvent.dragStart(srcColumn);
+  fireEvent.dragEnter(dstColumn);
+  fireEvent.dragOver(dstColumn);
+  fireEvent.drop(dstColumn);
+
+  draggableHeaderCells = container.querySelectorAll<HTMLDivElement>(
+    '.iui-table-header .iui-table-cell[draggable="true"]',
+  );
+  expect(
+    Array.from(draggableHeaderCells).map((cell) => cell.textContent),
+  ).toEqual(['View', 'Name']);
+});
+
 it('should respect initialState.columnOrder', () => {
   const mockColumns = columns();
   const columnOrder = ['description', 'view', 'name'];

--- a/packages/itwinui-react/src/core/Table/Table.test.tsx
+++ b/packages/itwinui-react/src/core/Table/Table.test.tsx
@@ -2888,48 +2888,26 @@ it.each([
 );
 
 it('should reorder correctly when hidden columns are present', async () => {
-  const columns: Column<TestDataType>[] = [
-    {
-      id: 'name',
-      Header: 'Name',
-      accessor: 'name',
-    },
-    {
-      id: 'description',
-      Header: 'Description',
-      accessor: 'description',
-    },
-    {
-      id: 'view',
-      Header: 'View',
-      Cell: () => <>View</>,
-    },
-    ActionColumn({ columnManager: true }),
-  ];
+  const { container } = renderComponent({
+    columns: [...columns(), ActionColumn({ columnManager: true })],
+    enableColumnReordering: true,
+  });
 
-  const { container } = render(
-    <Table
-      columns={columns}
-      data={mockedData()}
-      emptyTableContent='Empty table'
-      emptyFilteredTableContent='No results. Clear filter.'
-      enableColumnReordering
-    />,
-  );
+  const getDraggableHeaderCells = () =>
+    container.querySelectorAll<HTMLDivElement>(
+      '.iui-table-header .iui-table-cell[draggable="true"]',
+    );
 
-  let headerCells = container.querySelectorAll<HTMLDivElement>(
+  const headerCells = container.querySelectorAll<HTMLDivElement>(
     '.iui-table-header .iui-table-cell',
   );
   const columnManager = headerCells[headerCells.length - 1]
     .firstElementChild as HTMLElement;
   await userEvent.click(columnManager);
 
-  const columnManagerColumns = document.querySelectorAll<HTMLElement>('label');
-  await userEvent.click(columnManagerColumns[1]);
+  await userEvent.click(screen.getByRole('checkbox', { name: 'Description' }));
 
-  let draggableHeaderCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-table-cell[draggable="true"]',
-  );
+  const draggableHeaderCells = getDraggableHeaderCells();
   expect(
     Array.from(draggableHeaderCells).map((cell) => cell.textContent),
   ).toEqual(['Name', 'View']);
@@ -2942,11 +2920,8 @@ it('should reorder correctly when hidden columns are present', async () => {
   fireEvent.dragOver(dstColumn);
   fireEvent.drop(dstColumn);
 
-  draggableHeaderCells = container.querySelectorAll<HTMLDivElement>(
-    '.iui-table-header .iui-table-cell[draggable="true"]',
-  );
   expect(
-    Array.from(draggableHeaderCells).map((cell) => cell.textContent),
+    Array.from(getDraggableHeaderCells()).map((cell) => cell.textContent),
   ).toEqual(['View', 'Name']);
 });
 

--- a/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
+++ b/packages/itwinui-react/src/core/Table/hooks/useColumnDragAndDrop.tsx
@@ -50,7 +50,9 @@ const defaultGetDragAndDropProps =
     const onDragStart = () => {
       instance.dispatch({
         type: REORDER_ACTIONS.columnDragStart,
-        columnIndex: instance.flatHeaders.indexOf(header),
+        columnIndex: instance.allColumns.findIndex(
+          (column) => column.id === header.id,
+        ),
       });
     };
 
@@ -84,7 +86,9 @@ const defaultGetDragAndDropProps =
 
     const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
       event.preventDefault();
-      const headerIndex = instance.flatHeaders.indexOf(header);
+      const headerIndex = instance.allColumns.findIndex(
+        (column) => column.id === header.id,
+      );
       if (instance.state.columnReorderStartIndex !== headerIndex) {
         setOnDragColumnStyle(
           event,


### PR DESCRIPTION
## Changes
- Fixed Table column reordering index calculation to use the canonical allColumns order (matched by column id) for both drag start and drop target.
- This resolves incorrect reorder behavior when hidden columns are present.
- Added unit test coverage for the hidden-column scenario:
  - hide Description via Column Manager
  - drag View before Name
  - verify visible header order becomes View, Name
- No public API changes.
## Testing
- Ran targeted unit test:
`pnpm --filter @itwin/itwinui-react exec vitest run src/core/Table/Table.test.tsx --reporter=dot`
- Result:
  - Test Files: 1 passed (1)
  - Tests: 118 passed (118)
- Visual testing: N/A (no visual/style changes)