### PR TITLE
Update HSL values in theme bridge

### DIFF
--- a/.changeset/calm-candies-check.md
+++ b/.changeset/calm-candies-check.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-react': patch
+---
+
+Updated values of `--iui-color-background-hsl` and `--iui-color-foreground-hsl` when theme bridge is enabled.

--- a/.changeset/lucky-phones-glow.md
+++ b/.changeset/lucky-phones-glow.md
@@ -1,0 +1,5 @@
+---
+'@itwin/itwinui-css': patch
+---
+
+Updated values of `--iui-color-background-hsl` and `--iui-color-foreground-hsl` when theme bridge is enabled.

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -122,7 +122,7 @@
 
   &:where([data-iui-theme='dark']) {
     --iui-color-background-hsl: 344.44deg 5.7% 12.88%; // --stratakit-color-bg-page-base
-    --iui-color-foreground-hsl: 99.06% 0.002 247.84; // --stratakit-color-text-neutral-primary
+    --iui-color-foreground-hsl: 185.17deg 0.8% 98.77%; // --stratakit-color-text-neutral-primary
     --iui-color-accent-hsl: 166.21deg 96.14% 50.19%; // --stratakit-color-icon-accent-strong
     --iui-color-informational-hsl: 210.52deg 76.91% 71.38%; // --stratakit-color-icon-info-faded
     --iui-color-positive-hsl: 105.91deg 34.34% 61.19%; // --stratakit-color-icon-positive-faded

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -111,8 +111,8 @@
   --iui-color-text-placeholder: var(--stratakit-color-text-neutral-secondary);
 
   &:where([data-iui-theme='light']) {
-    --iui-color-background-hsl: 209.2deg 40.21% 98.84%; // --stratakit-color-bg-page-base
-    --iui-color-foreground-hsl: 222.69deg 6.43% 12.92%; // --stratakit-color-text-neutral-primary
+    --iui-color-background-hsl: 210deg 33.3% 98.8%; // --stratakit-color-bg-page-base
+    --iui-color-foreground-hsl: 225deg 8.5% 18.4%; // --stratakit-color-text-neutral-primary
     --iui-color-accent-hsl: 164.5deg 68.46% 30.05%; // --stratakit-color-icon-accent-strong
     --iui-color-informational-hsl: 210.23deg 96.74% 36.73%; // --stratakit-color-icon-info-faded
     --iui-color-positive-hsl: 105.38deg 97.33% 21.67%; // --stratakit-color-icon-positive-faded
@@ -121,8 +121,8 @@
   }
 
   &:where([data-iui-theme='dark']) {
-    --iui-color-background-hsl: 222.69deg 6.43% 12.92%; // --stratakit-color-bg-page-base
-    --iui-color-foreground-hsl: 209.2deg 40.21% 98.84%; // --stratakit-color-text-neutral-primary
+    --iui-color-background-hsl: 225deg 6.1% 12.9%; // --stratakit-color-bg-page-base
+    --iui-color-foreground-hsl: 210deg 33.3% 98.8%; // --stratakit-color-text-neutral-primary
     --iui-color-accent-hsl: 166.21deg 96.14% 50.19%; // --stratakit-color-icon-accent-strong
     --iui-color-informational-hsl: 210.52deg 76.91% 71.38%; // --stratakit-color-icon-info-faded
     --iui-color-positive-hsl: 105.91deg 34.34% 61.19%; // --stratakit-color-icon-positive-faded

--- a/packages/itwinui-css/src/bridge.scss
+++ b/packages/itwinui-css/src/bridge.scss
@@ -111,8 +111,8 @@
   --iui-color-text-placeholder: var(--stratakit-color-text-neutral-secondary);
 
   &:where([data-iui-theme='light']) {
-    --iui-color-background-hsl: 210deg 33.3% 98.8%; // --stratakit-color-bg-page-base
-    --iui-color-foreground-hsl: 225deg 8.5% 18.4%; // --stratakit-color-text-neutral-primary
+    --iui-color-background-hsl: 185.17deg 0.8% 98.77%; // --stratakit-color-bg-page-base
+    --iui-color-foreground-hsl: 222.82deg 8.68% 18.37%; // --stratakit-color-text-neutral-primary
     --iui-color-accent-hsl: 164.5deg 68.46% 30.05%; // --stratakit-color-icon-accent-strong
     --iui-color-informational-hsl: 210.23deg 96.74% 36.73%; // --stratakit-color-icon-info-faded
     --iui-color-positive-hsl: 105.38deg 97.33% 21.67%; // --stratakit-color-icon-positive-faded
@@ -121,8 +121,8 @@
   }
 
   &:where([data-iui-theme='dark']) {
-    --iui-color-background-hsl: 225deg 6.1% 12.9%; // --stratakit-color-bg-page-base
-    --iui-color-foreground-hsl: 210deg 33.3% 98.8%; // --stratakit-color-text-neutral-primary
+    --iui-color-background-hsl: 344.44deg 5.7% 12.88%; // --stratakit-color-bg-page-base
+    --iui-color-foreground-hsl: 99.06% 0.002 247.84; // --stratakit-color-text-neutral-primary
     --iui-color-accent-hsl: 166.21deg 96.14% 50.19%; // --stratakit-color-icon-accent-strong
     --iui-color-informational-hsl: 210.52deg 76.91% 71.38%; // --stratakit-color-icon-info-faded
     --iui-color-positive-hsl: 105.91deg 34.34% 61.19%; // --stratakit-color-icon-positive-faded


### PR DESCRIPTION
## Changes

Extracted from https://github.com/iTwin/iTwinUI/pull/2697#discussion_r3937238428 to release as patch update.

## Testing

Used the following to confirm HSL values were the same.

```html
<h2>HSL</h2>
<section id='demo-hsl'>
  <div class='flex-box'>
    <div class='color-wrapper'>
      <div class='color-box' style='background-color: hsl(var(--iui-color-background-hsl));'>
      </div>
      <p>iui-color-background-hsl</p>
    </div>
    <div class='color-wrapper'>
      <div class='color-box' style='background-color: hsl(var(--iui-color-foreground-hsl));'>
      </div>
      <p>iui-color-foreground-hsl</p>
    </div>
  </div>

  <div class='flex-box'>
    <div class='color-wrapper'>
      <div class='color-box' style='background-color: var(--stratakit-color-bg-page-base);'></div>
      <p>stratakit-color-bg-page-base</p>
    </div>
    <div class='color-wrapper'>
      <div
        class='color-box'
        style='background-color: var(--stratakit-color-text-neutral-primary);'
      >
      </div>
      <p>stratakit-color-text-neutral-primary</p>
    </div>
  </div>
</section>
```